### PR TITLE
feat(world2d): Add world2d utility classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.xerial/sqlite-jdbc -->

--- a/src/doc/QuickStart.md
+++ b/src/doc/QuickStart.md
@@ -62,9 +62,8 @@ Same perspective but during sunset. (In Minetest, the sun's path aligns with the
 ## Complete Code
 
 ```java
-import com.ignfab.minalac.generator.*;
-import com.ignfab.minalac.generator.VoxelTypeFactory;
-import com.ignfab.minalac.generator.minetest.MTVoxelWorld;
+import com.ignfab.minalac.generator.world.VoxelTypeFactory;
+import com.ignfab.minalac.generator.outputs.minetest.MTVoxelWorld;
 import com.ignfab.minalac.generator.MapCreationException;
 
 public class SampleCode {

--- a/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
+++ b/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
@@ -1,13 +1,16 @@
 package com.ignfab.minalac.generator;
 
-import com.ignfab.minalac.generator.minetest.MTVoxelWorld;
-
 import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.nio.FloatBuffer;
+
+import com.ignfab.minalac.generator.world.*;
+import com.ignfab.minalac.generator.outputs.minetest.MTVoxelWorld;
+import com.ignfab.minalac.generator.utils.world2d.*;
+import com.ignfab.minalac.generator.utils.world2d.chunk.*;
+import com.ignfab.minalac.generator.utils.world2d.iterator.*;
 
 /**
  * This is a temporary class to have an idea of how the program works.
@@ -15,85 +18,111 @@ import java.nio.FloatBuffer;
  */
 public class SampleImplementation {
     public static void main(String[] args) throws IOException, OutOfWorldException, MapWriteException {
-        if (args.length != 2) {
-            System.out.println("There must be two arguments : directoryPath and url");
+        if (args.length != 5) {
+            System.out.println("There must be five arguments : directoryPath, baseURL, width, height, verticalScale");
         } else {
-            System.out.println("Creation of the map ...");
-            System.out.println(args[0]);
-            System.out.println(args[1]);
-
-            //Parent directory must exist
             //Example : "/home/john/.minetest/worlds/map/"
-            String directoryFullPath = args[0];
+            String directoryPath = args[0];
 
-            //The function createWorldFromUrl doesn't, for now, handle the parameters.
-            //BBOX has to be a square.
-            //Width and height have to be one-tenth of the side of the side length of the BBOX's square
+            //Example : https://data.geopf.fr/wms-r/wms?LAYERS=RGEALTI-MNT_PYR-ZIP_FXX_LAMB93_WMS&FORMAT=image/x-bil;bits=32&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&STYLES=&CRS=EPSG:2154&BBOX=595000,6335000,605000,6345000
+            String partialURL = args[1];
 
-            //Example "https://data.geopf.fr/wms-r/wms?LAYERS=RGEALTI-MNT_PYR-ZIP_FXX_LAMB93_WMS&FORMAT=image/x-bil;bits=32&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&STYLES=&CRS=EPSG:2154&BBOX=595000,6335000,605000,6345000&WIDTH=1000&HEIGHT=1000"
-            String dataUrl = args[1];
+            //Example : 1000
+            int width = Integer.parseInt(args[2]);
 
-            float[] mntArray = getHeightMap(dataUrl);
+            //Example : 1000
+            int height = Integer.parseInt(args[3]);
 
-            VoxelWorld worldMnt = new MTVoxelWorld();
-            createWorldFromMnt(mntArray, worldMnt);
-            worldMnt.save(directoryFullPath);
+            //Example : 10 (in meter per voxel)
+            float verticalScale = Float.parseFloat(args[4]);
 
-            int midPoint = (int) (mntArray.length + Math.sqrt(mntArray.length)) / 2;
-            setStaticSpawnPoint(directoryFullPath, 0, (int) mntArray[midPoint] / 10 + 1, 0);
+            System.out.println("Creation of the map ..." +
+                    "\ndirectoryPath: " + directoryPath +
+                    "\npartialURL: " + partialURL +
+                    "\nwidth: " + width +
+                    "\nheight: " + height +
+                    "\nverticalScale: " + verticalScale);
+
+            HeightMap heightMap = createGroundHeightMap(partialURL, width, height, verticalScale);
+
+            VoxelWorld world = new MTVoxelWorld();
+            placeVoxelFromHeightMap(heightMap, world);
+            save(directoryPath, world);
+
+            setStaticSpawnPoint(directoryPath, 0, heightMap.get(0, 0) + 1, 0);
         }
     }
 
-    private static void createWorldFromMnt(float[] mntArray, VoxelWorld world) throws OutOfWorldException {
-        int worldLength = (int) Math.sqrt(mntArray.length);
-
-        int x, y, z;
-
+    private static void placeVoxelFromHeightMap(HeightMap map, VoxelWorld world) throws OutOfWorldException {
         VoxelType grassVT = world.getFactory().createVoxelType(SemanticType.Grass);
         VoxelType stoneVT = world.getFactory().createVoxelType(SemanticType.Stone);
         VoxelType dirtVT = world.getFactory().createVoxelType(SemanticType.Dirt);
 
-        for (int i = 0; i < mntArray.length; i++) {
-            //Temporary translation so the player spawn at the center of the generated map (player info isn't generated yet on this version)
-            x = i % worldLength - worldLength / 2;
-            //Ratio between the side length of the BBOX and width/heigth length
-            //In this example, we assume that the ratio given by the URL is always 10
-            y = (int) mntArray[i] / 10;
-            z = i / worldLength - worldLength / 2;
-
+        for (Chunk2dElement element : map) {
+            int x = element.getX();
+            int y = element.getY();
+            int z = element.getValue();
             grassVT.place(x, y, z);
-            dirtVT.place(x, (y - 1), z);
-            dirtVT.place(x, (y - 2), z);
+            dirtVT.place(x, y, (z - 1));
+            dirtVT.place(x, y, (z - 2));
 
-            for (int y_stone = y - 3; y_stone > y - (3 + 10); y_stone--) {
-                stoneVT.place(x, y_stone, z);
+            for (int z_stone = z - 3; z_stone > z - (3 + 10); z_stone--) {
+                stoneVT.place(x, y, z_stone);
             }
         }
     }
 
-    private static float[] getHeightMap(String urlString) throws MalformedURLException {
+    private static HeightMap createGroundHeightMap(String partialUrl, int width, int height, float verticalScale) throws MalformedURLException {
         float[] mntArray;
-        URL url = new URL(urlString);
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        byte[] data;
+        URL url = new URL(partialUrl + "&WIDTH=" + width + "&HEIGHT=" + height);
 
         try (InputStream inputStream = url.openStream()) {
-            int n;
-            byte[] buffer = new byte[1];
-            while (-1 != (n = inputStream.read(buffer))) {
-                outputStream.write(buffer, 0, n);
-            }
+            int total, read;
+            total = 0;
+            data = new byte[width * height * 4];
+            while (0 < (read = inputStream.read(data, total, data.length - total)))
+                total = total + read;
+            if (total != data.length)
+                throw new RuntimeException("Incomplete data read from response stream");
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
 
-        byte[] byteArray = outputStream.toByteArray();
-        ByteBuffer byteBuffer = ByteBuffer.wrap(byteArray).order(ByteOrder.LITTLE_ENDIAN);
+        mntArray = byteArrayToFloatArray(data);
 
-        FloatBuffer floatBuffer = byteBuffer.asFloatBuffer();
-        mntArray = new float[floatBuffer.capacity()];
-        floatBuffer.get(mntArray);
+        int xMinHeightMap = -width / 2, yMinHeightMap = -height / 2;
+        HeightMap heightMap = new HeightMap(xMinHeightMap, yMinHeightMap, width, height, 0);
 
-        return mntArray;
+        int x_arr, y_arr, x_world, y_world;
+        for (int i = 0; i < mntArray.length; i++) {
+            x_arr = i % width;
+            y_arr = i / width;
+            x_world = x_arr + xMinHeightMap;
+            y_world = -(y_arr + yMinHeightMap) - 1; //-1 so min y_world matches yMinHeightMap (There is an offset due to y-axis inversion),
+            heightMap.set(x_world, y_world, (int) (mntArray[i] / verticalScale));
+        }
+        return heightMap;
+    }
+
+    private static float[] byteArrayToFloatArray(byte[] byteData) {
+        float[] floatData = new float[byteData.length / 4];
+        ByteBuffer.wrap(byteData).order(ByteOrder.LITTLE_ENDIAN).asFloatBuffer().get(floatData);
+        return floatData;
+    }
+
+    private static void save(String directory, VoxelWorld world) throws MapWriteException {
+        deleteDirectory(new File(directory));
+        world.save(directory);
+    }
+
+    private static boolean deleteDirectory(File directoryToBeDeleted) {
+        File[] allContents = directoryToBeDeleted.listFiles();
+        if (allContents != null) {
+            for (File file : allContents)
+                deleteDirectory(file);
+        }
+        return directoryToBeDeleted.delete();
     }
 
     private static void setStaticSpawnPoint(String directoryFullPath, int x, int y, int z) throws IOException {
@@ -108,6 +137,26 @@ public class SampleImplementation {
             PrintWriter printWriter = new PrintWriter(fileWriter);
             printWriter.println("minetest.setting_set(\"static_spawnpoint\", \"" + x + ", " + y + ", " + z + "\")");
             printWriter.close();
+        }
+    }
+
+    //This class will probably be added on an upcoming pull-request (since it doesn't belong to the package utils.world2d.chunk)
+    private static class HeightMap extends ArrayChunk2d implements IterableChunk2d {
+        public HeightMap(int originX, int originY, int sizeX, int sizeY, int defaultValue) {
+            super(originX, originY, sizeX, sizeY, defaultValue);
+        }
+
+        public HeightMap(WorldBBox2d box, int defaultValue) {
+            super(box, defaultValue);
+        }
+
+        public HeightMap(WorldCoords2d coords, WorldSize2d size, int defaultValue) {
+            super(coords, size, defaultValue);
+        }
+
+        @Override
+        public Chunk2dIterator iterator() {
+            return new Chunk2dIteratorAll(this);
         }
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/VoxelType.java
+++ b/src/main/java/com/ignfab/minalac/generator/VoxelType.java
@@ -1,6 +1,0 @@
-package com.ignfab.minalac.generator;
-
-public interface VoxelType {
-    //TODO find a convention to explicitly define the coordinates
-    void place(int x, int y, int z) throws OutOfWorldException;
-}

--- a/src/main/java/com/ignfab/minalac/generator/minetest/voxelType/MTSimpleVoxelType.java
+++ b/src/main/java/com/ignfab/minalac/generator/minetest/voxelType/MTSimpleVoxelType.java
@@ -1,9 +1,0 @@
-package com.ignfab.minalac.generator.minetest.voxelType;
-
-import com.ignfab.minalac.generator.minetest.MTVoxelWorld;
-
-public class MTSimpleVoxelType extends MTVoxelType {
-    public MTSimpleVoxelType(MTVoxelWorld world, String type) {
-        super(world, type, (byte) 0, (byte) 0);
-    }
-}

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/Block.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/Block.java
@@ -1,6 +1,4 @@
-package com.ignfab.minalac.generator.minetest;
-
-import com.ignfab.minalac.generator.minetest.voxelType.MTVoxelType;
+package com.ignfab.minalac.generator.outputs.minetest;
 
 import java.util.HashMap;
 

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelType.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelType.java
@@ -1,8 +1,7 @@
-package com.ignfab.minalac.generator.minetest.voxelType;
+package com.ignfab.minalac.generator.outputs.minetest;
 
-import com.ignfab.minalac.generator.OutOfWorldException;
-import com.ignfab.minalac.generator.VoxelType;
-import com.ignfab.minalac.generator.minetest.MTVoxelWorld;
+import com.ignfab.minalac.generator.world.OutOfWorldException;
+import com.ignfab.minalac.generator.world.VoxelType;
 
 public abstract class MTVoxelType implements VoxelType {
     protected MTVoxelWorld world;
@@ -19,7 +18,8 @@ public abstract class MTVoxelType implements VoxelType {
 
     @Override
     public void place(int x, int y, int z) throws OutOfWorldException {
-        this.world.set(x, y, z, this);
+        //The y-axis in Minetest corresponds, in our chosen coordinate system, to the z-axis, hence the inversion
+        this.world.set(x, z, y, this);
     }
 
     public String getType() {

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelTypeFactory.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelTypeFactory.java
@@ -1,9 +1,9 @@
-package com.ignfab.minalac.generator.minetest;
+package com.ignfab.minalac.generator.outputs.minetest;
 
-import com.ignfab.minalac.generator.SemanticType;
-import com.ignfab.minalac.generator.VoxelTypeFactory;
-import com.ignfab.minalac.generator.VoxelType;
-import com.ignfab.minalac.generator.minetest.voxelType.MTSimpleVoxelType;
+import com.ignfab.minalac.generator.world.SemanticType;
+import com.ignfab.minalac.generator.world.VoxelTypeFactory;
+import com.ignfab.minalac.generator.world.VoxelType;
+import com.ignfab.minalac.generator.outputs.minetest.voxelType.MTSimpleVoxelType;
 
 public class MTVoxelTypeFactory implements VoxelTypeFactory {
     private MTVoxelWorld world;

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelWorld.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelWorld.java
@@ -1,11 +1,10 @@
-package com.ignfab.minalac.generator.minetest;
+package com.ignfab.minalac.generator.outputs.minetest;
 
-import com.ignfab.minalac.generator.MapWriteException;
-import com.ignfab.minalac.generator.OutOfWorldException;
-import com.ignfab.minalac.generator.VoxelTypeFactory;
-import com.ignfab.minalac.generator.VoxelWorld;
-import com.ignfab.minalac.generator.minetest.utils.SqlLiteMapWriter;
-import com.ignfab.minalac.generator.minetest.voxelType.MTVoxelType;
+import com.ignfab.minalac.generator.world.MapWriteException;
+import com.ignfab.minalac.generator.world.OutOfWorldException;
+import com.ignfab.minalac.generator.world.VoxelTypeFactory;
+import com.ignfab.minalac.generator.world.VoxelWorld;
+import com.ignfab.minalac.generator.outputs.minetest.utils.SqlLiteMapWriter;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -31,7 +30,7 @@ public class MTVoxelWorld implements VoxelWorld {
         return this.factory;
     }
 
-    public void set(int x, int y, int z, MTVoxelType voxel) throws OutOfWorldException {
+    protected void set(int x, int y, int z, MTVoxelType voxel) throws OutOfWorldException {
         if (-limitPosition > x || x > limitPosition ||
                 -limitPosition > y || y > limitPosition ||
                 -limitPosition > z || z > limitPosition

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/utils/Serializer.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/utils/Serializer.java
@@ -1,6 +1,6 @@
-package com.ignfab.minalac.generator.minetest.utils;
+package com.ignfab.minalac.generator.outputs.minetest.utils;
 
-import com.ignfab.minalac.generator.minetest.Block;
+import com.ignfab.minalac.generator.outputs.minetest.Block;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/utils/SqlLiteMapWriter.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/utils/SqlLiteMapWriter.java
@@ -1,7 +1,7 @@
-package com.ignfab.minalac.generator.minetest.utils;
+package com.ignfab.minalac.generator.outputs.minetest.utils;
 
-import com.ignfab.minalac.generator.MapWriteException;
-import com.ignfab.minalac.generator.minetest.Block;
+import com.ignfab.minalac.generator.outputs.minetest.Block;
+import com.ignfab.minalac.generator.world.MapWriteException;
 
 import java.io.*;
 import java.nio.file.Files;

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/voxelType/MTSimpleVoxelType.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/voxelType/MTSimpleVoxelType.java
@@ -1,0 +1,10 @@
+package com.ignfab.minalac.generator.outputs.minetest.voxelType;
+
+import com.ignfab.minalac.generator.outputs.minetest.MTVoxelType;
+import com.ignfab.minalac.generator.outputs.minetest.MTVoxelWorld;
+
+public class MTSimpleVoxelType extends MTVoxelType {
+    public MTSimpleVoxelType(MTVoxelWorld world, String type) {
+        super(world, type, (byte) 0, (byte) 0);
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/utils/world2d/WorldBBox2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world2d/WorldBBox2d.java
@@ -1,0 +1,114 @@
+package com.ignfab.minalac.generator.utils.world2d;
+
+import com.ignfab.minalac.generator.utils.world2d.iterator.WorldBBox2dIterator;
+
+/**
+ * The {@code WorldBBox2d} class represents a two-dimensional bounding box that surrounds an area on the surface of (xy-plane) of the voxel world.
+ * This BBOX is defined by a minimum point and a maximum point. These points are included in the bounding box.
+ * An explanation of the voxel world coordinates system can be found on {@link com.ignfab.minalac.generator.utils.world2d.WorldCoords2d}.
+ *
+ * @see WorldCoords2d
+ */
+public class WorldBBox2d {
+    private WorldCoords2d min, max;
+    private WorldSize2d size;
+
+    /**
+     * Constructs a new {@code WorldBBox2d} by providing a starting position and the desired size of the bounding box.
+     *
+     * @param origin the starting position's coordinates (minimum point).
+     * @param size   the bounding box size.
+     */
+    public WorldBBox2d(WorldCoords2d origin, WorldSize2d size) {
+        this.size = size;
+        min = origin;
+        max = new WorldCoords2d(
+                min.getX() + size.getX() - 1,
+                min.getY() + size.getY() - 1
+        );
+    }
+
+    /**
+     * Constructs a new {@code WorldBBox2d} by providing a starting position and the desired size of the bounding box.
+     *
+     * @param originX the x-coordinate of the starting position.
+     * @param originY the y-coordinate of the starting position.
+     * @param sizeX   the size along the x-axis of the bounding box.
+     * @param sizeY   the size along the y-axis of the bounding box.
+     */
+    public WorldBBox2d(int originX, int originY, int sizeX, int sizeY) {
+        this(new WorldCoords2d(originX, originY), new WorldSize2d(sizeX, sizeY));
+    }
+
+    /**
+     * Constructs a new {@code WorldBBox2d} by providing the minimum and maximum points of the bounding box.
+     *
+     * @param min the minimum point's coordinates.
+     * @param max the maximum point's coordinates.
+     * @throws IllegalArgumentException if any coordinates of the maximum point is less than its counterpart in the minimum point.
+     */
+    public WorldBBox2d(WorldCoords2d min, WorldCoords2d max) {
+        if (min.getX() > max.getX() || min.getY() > max.getY())
+            throw new IllegalArgumentException("Minimum point must be less than or equal to maximum point");
+        this.min = min;
+        this.max = max;
+        size = new WorldSize2d(max.getX() - min.getX() + 1, max.getY() - min.getY() + 1);
+    }
+
+    /**
+     * Returns {@code true} if the given coordinates are in the bounding box.
+     *
+     * @param x the x-coordinate value.
+     * @param y the y-coordinate value.
+     * @return {@code true} if coordinates are in the bounding box.
+     */
+    public boolean contains(int x, int y) {
+        return min.getX() <= x && x <= max.getX() && min.getY() <= y && y <= max.getY();
+    }
+
+    /**
+     * Returns {@code true} if the given coordinates are in the bounding box.
+     *
+     * @param coords the coordinates to be checked.
+     * @return {@code true} if coordinates are in the bounding box.
+     */
+    public boolean contains(WorldCoords2d coords) {
+        return contains(coords.getX(), coords.getY());
+    }
+
+    /**
+     * Returns the size of the bounding box.
+     *
+     * @return the size of the bounding box as a {@code WorldSize2d}.
+     */
+    public WorldSize2d getSize() {
+        return size;
+    }
+
+    /**
+     * Returns the minimum point.
+     *
+     * @return the {@code WorldCoords2d} of the minimum point.
+     */
+    public WorldCoords2d getMin() {
+        return min;
+    }
+
+    /**
+     * Returns the maximum point.
+     *
+     * @return the {@code WorldCoords2d} of the maximum point.
+     */
+    public WorldCoords2d getMax() {
+        return max;
+    }
+
+    /**
+     * Returns an iterator.
+     *
+     * @return a {@code WorldBBox2dIterator} to iterate over all the points contained in the bounding box.
+     */
+    public WorldBBox2dIterator iterator() {
+        return new WorldBBox2dIterator(this);
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/utils/world2d/WorldCoords2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world2d/WorldCoords2d.java
@@ -1,0 +1,46 @@
+package com.ignfab.minalac.generator.utils.world2d;
+
+/**
+ * The {@code WorldCoords2d} class represents a component on the surface (xy-plane) in the voxel world.
+ * In the voxel world, coordinates are defined by three axes (x, y, z) where the z-axis represents the altitude, and increments correspond to the size of a voxel.
+ * This class is read-only.
+ */
+public class WorldCoords2d {
+    /**
+     * The x-component value.
+     */
+    protected int x;
+    /**
+     * The y-component value.
+     */
+    protected int y;
+
+    /**
+     * Constructs a new {@code WorldCoords2d}.
+     *
+     * @param x the x-component value.
+     * @param y the y-component value.
+     */
+    public WorldCoords2d(int x, int y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    /**
+     * Returns the x-component value.
+     *
+     * @return the x-component value.
+     */
+    public int getX() {
+        return x;
+    }
+
+    /**
+     * Returns the y-component value.
+     *
+     * @return the y-component value.
+     */
+    public int getY() {
+        return y;
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/utils/world2d/WorldSize2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world2d/WorldSize2d.java
@@ -1,0 +1,33 @@
+package com.ignfab.minalac.generator.utils.world2d;
+
+/**
+ * The {@code WorldSize2d} subclass represents the size along the x-axis and the y-axis in the voxel world.
+ * The x-component represents the size along the x-axis, while the y-component represents the size along the y-axis.
+ * Size is always greater than zero.
+ *
+ * @see com.ignfab.minalac.generator.utils.world2d.WorldCoords2d
+ */
+public class WorldSize2d extends WorldCoords2d {
+    /**
+     * Constructs a new {@code WorldSize2d}.
+     * Sizes must be greater than 0.
+     *
+     * @param sizeX the size along the x-axis.
+     * @param sizeY the size along the y-axis.
+     * @throws IllegalArgumentException if either {@code sizeX} or {@code sizeY} is less than or equal to 0.
+     */
+    public WorldSize2d(int sizeX, int sizeY) {
+        super(sizeX, sizeY);
+        if (sizeX <= 0 || sizeY <= 0)
+            throw new IllegalArgumentException("Invalid dimensions : sizeX and sizeY must be greater than 0");
+    }
+
+    /**
+     * Calculates and returns the area.
+     *
+     * @return the calculated area.
+     */
+    public int area() {
+        return x * y;
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/utils/world2d/chunk/ArrayChunk2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world2d/chunk/ArrayChunk2d.java
@@ -1,0 +1,110 @@
+package com.ignfab.minalac.generator.utils.world2d.chunk;
+
+import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
+import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
+import com.ignfab.minalac.generator.utils.world2d.WorldSize2d;
+
+import java.util.Arrays;
+
+/**
+ * The {@code ArrayChunk2d} class represents a readable and writable two-dimensional chunk of the voxel world based on an array.
+ * It implements {@link WritableChunk2d} and {@link ReadableChunk2d} interfaces.
+ */
+public class ArrayChunk2d implements ReadableChunk2d, WritableChunk2d {
+    /**
+     * The bounding box of the chunk.
+     */
+    protected WorldBBox2d bbox;
+    /**
+     * The array used to store the values.
+     */
+    protected int[] values;
+
+    /**
+     * Constructs a new {@code ArrayChunk2d}.
+     *
+     * @param bbox         the bounding box of the chunk.
+     * @param defaultValue the defaultValue associated with all the points.
+     */
+    public ArrayChunk2d(WorldBBox2d bbox, int defaultValue) {
+        this.bbox = bbox;
+        values = new int[bbox.getSize().getX() * bbox.getSize().getY()];
+        Arrays.fill(values, defaultValue);
+    }
+
+    /**
+     * Constructs a new {@code ArrayChunk2d}.
+     *
+     * @param originX      the x-coordinate of the starting position.
+     * @param originY      the y-coordinate of the starting position.
+     * @param sizeX        the size along the x-axis of the {@code ArrayChunk2d}.
+     * @param sizeY        the size along the y-axis of the {@code ArrayChunk2d}.
+     * @param defaultValue the defaultValue associated with all the points.
+     * @throws IllegalArgumentException if either {@code sizeX} or {@code sizeY} is less than or equal to 0.
+     */
+    public ArrayChunk2d(int originX, int originY, int sizeX, int sizeY, int defaultValue) {
+        this(new WorldBBox2d(originX, originY, sizeX, sizeY), defaultValue);
+    }
+
+    /**
+     * Constructs a new {@code ArrayChunk2d}.
+     *
+     * @param coords       the coordinate of the starting position.
+     * @param size         the size of the {@code ArrayChunk2d}.
+     * @param defaultValue the defaultValue associated with all the points.
+     */
+    public ArrayChunk2d(WorldCoords2d coords, WorldSize2d size, int defaultValue) {
+        this(new WorldBBox2d(coords, size), defaultValue);
+    }
+
+    private int index(int x, int y) {
+        if (!bbox.contains(x, y))
+            throw new IndexOutOfBoundsException(String.format("%s: Index out of range at (x=%d, y=%d)", getClass().getSimpleName(), x, y));
+        return (x - bbox.getMin().getX()) * bbox.getSize().getY() + (y - bbox.getMin().getY());
+    }
+
+    @Override
+    public WorldBBox2d bbox() {
+        return bbox;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IndexOutOfBoundsException if provided coordinates are outside the chunk.
+     */
+    @Override
+    public void set(int x, int y, int value) {
+        values[index(x, y)] = value;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IndexOutOfBoundsException if provided coordinates are outside the chunk.
+     */
+    @Override
+    public void set(WorldCoords2d coords, int value) {
+        values[index(coords.getX(), coords.getY())] = value;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IndexOutOfBoundsException if provided coordinates are outside the chunk.
+     */
+    @Override
+    public int get(int x, int y) {
+        return values[index(x, y)];
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IndexOutOfBoundsException if provided coordinates are outside the chunk.
+     */
+    @Override
+    public int get(WorldCoords2d coords) {
+        return values[index(coords.getX(), coords.getY())];
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/utils/world2d/chunk/IterableChunk2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world2d/chunk/IterableChunk2d.java
@@ -1,0 +1,16 @@
+package com.ignfab.minalac.generator.utils.world2d.chunk;
+
+import com.ignfab.minalac.generator.utils.world2d.iterator.Chunk2dElement;
+import com.ignfab.minalac.generator.utils.world2d.iterator.Chunk2dIterator;
+
+/**
+ * The {@code IterableChunk2d} interface represents an iterable {@link ReadableChunk2d}.
+ */
+public interface IterableChunk2d extends ReadableChunk2d, Iterable<Chunk2dElement> {
+    /**
+     * Returns an iterator.
+     *
+     * @return a {@link com.ignfab.minalac.generator.utils.world2d.iterator.Chunk2dIterator} to iterate over the elements.
+     */
+    Chunk2dIterator iterator();
+}

--- a/src/main/java/com/ignfab/minalac/generator/utils/world2d/chunk/ReadableChunk2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world2d/chunk/ReadableChunk2d.java
@@ -1,0 +1,38 @@
+package com.ignfab.minalac.generator.utils.world2d.chunk;
+
+import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
+import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
+
+/**
+ * The {@code ReadableChunk2d} interface represents a readable two-dimensional chunk.
+ * A two-dimensional chunk is an area of the surface of the voxel world where each point (x, y) is associated with a {@code int} value.
+ * Coordinates in {@code ReadableChunk2d} methods are relative to the voxel world, not to the chunk.
+ * An explanation of the voxel world coordinates system can be found on {@link com.ignfab.minalac.generator.utils.world2d.WorldCoords2d}.
+ *
+ * @see WorldCoords2d
+ */
+public interface ReadableChunk2d {
+    /**
+     * Returns the bounding box of the chunk.
+     *
+     * @return the {@link com.ignfab.minalac.generator.utils.world2d.WorldBBox2d} associated to the chunk.
+     */
+    WorldBBox2d bbox();
+
+    /**
+     * Returns the value at coordinates.
+     *
+     * @param x the x-coordinate value.
+     * @param y the y-coordinate value.
+     * @return the {@code int} value at the coordinate (x, y).
+     */
+    int get(int x, int y);
+
+    /**
+     * Returns the value at coordinates.
+     *
+     * @param coords the coordinates.
+     * @return the {@code int} value at the provided coordinates.
+     */
+    int get(WorldCoords2d coords);
+}

--- a/src/main/java/com/ignfab/minalac/generator/utils/world2d/chunk/WritableChunk2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world2d/chunk/WritableChunk2d.java
@@ -1,0 +1,38 @@
+package com.ignfab.minalac.generator.utils.world2d.chunk;
+
+import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
+import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
+
+/**
+ * The {@code WritableChunk2d} interface represents a writable two-dimensional chunk.
+ * A two-dimensional chunk is an area of the surface of the voxel world where each point (x, y) is associated with a {@code int} value.
+ * Coordinates in {@code WritableChunk2d} methods are relative to the voxel world, not to the chunk.
+ * An explanation of the voxel world coordinates system can be found on {@link com.ignfab.minalac.generator.utils.world2d.WorldCoords2d}.
+ *
+ * @see WorldCoords2d
+ */
+public interface WritableChunk2d {
+    /**
+     * Returns the bounding box of the chunk.
+     *
+     * @return the {@link com.ignfab.minalac.generator.utils.world2d.WorldBBox2d} associated to the chunk.
+     */
+    WorldBBox2d bbox();
+
+    /**
+     * Set the value at the specified coordinates.
+     *
+     * @param x     the x-coordinate value.
+     * @param y     the y-coordinate value.
+     * @param value the value to set.
+     */
+    void set(int x, int y, int value);
+
+    /**
+     * Set the value at the specified coordinates.
+     *
+     * @param coords the coordinates.
+     * @param value  the value to set.
+     */
+    void set(WorldCoords2d coords, int value);
+}

--- a/src/main/java/com/ignfab/minalac/generator/utils/world2d/iterator/Chunk2dElement.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world2d/iterator/Chunk2dElement.java
@@ -1,0 +1,61 @@
+package com.ignfab.minalac.generator.utils.world2d.iterator;
+
+import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
+
+/**
+ * {@code Chunk2dElement} is returned by {@code Chunk2dIterator}.
+ * It encapsulates coordinates (x, y) and associated {@code int} value.
+ *
+ * @see WorldCoords2d
+ */
+public class Chunk2dElement {
+    private WorldCoords2d coords;
+    private int value;
+
+    /**
+     * Constructs a new {Chunk2dElement}.
+     *
+     * @param coords the {@code WorldCoords2d}.
+     * @param value  the value at coordinates.
+     */
+    protected Chunk2dElement(WorldCoords2d coords, int value) {
+        this.coords = coords;
+        this.value = value;
+    }
+
+    /**
+     * Returns the value at coordinates.
+     *
+     * @return the value at coordinates.
+     */
+    public int getValue() {
+        return value;
+    }
+
+    /**
+     * Returns the coordinates.
+     *
+     * @return the {@code WorldCoords2d}.
+     */
+    public WorldCoords2d getCoords() {
+        return coords;
+    }
+
+    /**
+     * Returns the x-coordinate.
+     *
+     * @return the x-coordinate value.
+     */
+    public int getX() {
+        return coords.getX();
+    }
+
+    /**
+     * Returns the y-coordinate.
+     *
+     * @return the y-coordinate value.
+     */
+    public int getY() {
+        return coords.getY();
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/utils/world2d/iterator/Chunk2dIterator.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world2d/iterator/Chunk2dIterator.java
@@ -1,0 +1,9 @@
+package com.ignfab.minalac.generator.utils.world2d.iterator;
+
+import java.util.Iterator;
+
+/**
+ * An iterator over the elements of a {@code ReadableChunk2d}.
+ */
+public interface Chunk2dIterator extends Iterator<Chunk2dElement> {
+}

--- a/src/main/java/com/ignfab/minalac/generator/utils/world2d/iterator/Chunk2dIteratorAll.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world2d/iterator/Chunk2dIteratorAll.java
@@ -1,0 +1,47 @@
+package com.ignfab.minalac.generator.utils.world2d.iterator;
+
+import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
+import com.ignfab.minalac.generator.utils.world2d.chunk.ReadableChunk2d;
+
+import java.util.NoSuchElementException;
+
+/**
+ * An iterator over all the elements of a {@code ReadableChunk2d}.
+ */
+public class Chunk2dIteratorAll implements Chunk2dIterator {
+
+    private ReadableChunk2d chunk;
+    private WorldBBox2dIterator bboxIterator;
+
+    /**
+     * Constructs a new {@code Chunk2dIteratorAll}.
+     *
+     * @param chunk the {@code ReadableChunk2d} to iterate over.
+     */
+    public Chunk2dIteratorAll(ReadableChunk2d chunk) {
+        this.chunk = chunk;
+        bboxIterator = chunk.bbox().iterator();
+    }
+
+    /**
+     * Indicates if there are more elements.
+     *
+     * @return {@code true} if the iteration has more elements.
+     */
+    @Override
+    public boolean hasNext() {
+        return bboxIterator.hasNext();
+    }
+
+    /**
+     * Returns the next element.
+     *
+     * @return the next {@code Chunk2dElement} in the iteration.
+     * @throws NoSuchElementException if the iteration has no more elements.
+     */
+    @Override
+    public Chunk2dElement next() {
+        WorldCoords2d current = bboxIterator.next();
+        return new Chunk2dElement(current, chunk.get(current));
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/utils/world2d/iterator/Chunk2dIteratorSkip.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world2d/iterator/Chunk2dIteratorSkip.java
@@ -1,0 +1,72 @@
+package com.ignfab.minalac.generator.utils.world2d.iterator;
+
+import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
+import com.ignfab.minalac.generator.utils.world2d.chunk.ReadableChunk2d;
+
+import java.util.NoSuchElementException;
+
+/**
+ * An iterator over the elements of a {@code ReadableChunk2d}.
+ * This iterator skips the elements that have a value equals to a certain {@code skipValue}.
+ */
+public class Chunk2dIteratorSkip implements Chunk2dIterator {
+    private ReadableChunk2d chunk;
+    private WorldBBox2dIterator bboxIterator;
+    private Chunk2dElement current;
+    private int skipValue;
+
+    /**
+     * Constructs a new {@code Chunk2dIteratorSkip}.
+     *
+     * @param chunk     the {@code ReadableChunk2d} to iterate over.
+     * @param skipValue the value to skip.
+     */
+    public Chunk2dIteratorSkip(ReadableChunk2d chunk, int skipValue) {
+        this.chunk = chunk;
+        bboxIterator = chunk.bbox().iterator();
+        this.skipValue = skipValue;
+        moveOn();
+    }
+
+    private void moveOn() {
+        WorldCoords2d coords;
+        int value;
+
+        try {
+            do {
+                coords = bboxIterator.next();
+                value = chunk.get(coords);
+            } while (value == skipValue);
+
+            current = new Chunk2dElement(coords, value);
+        } catch (NoSuchElementException e) {
+            current = null;
+        }
+    }
+
+    /**
+     * Indicates if there are more elements.
+     *
+     * @return {@code true} if the iteration has more elements.
+     */
+    @Override
+    public boolean hasNext() {
+        return current != null;
+    }
+
+    /**
+     * Returns the next element.
+     *
+     * @return the next {@code Chunk2dElement} in the iteration.
+     * @throws NoSuchElementException if the iteration has no more elements.
+     */
+    @Override
+    public Chunk2dElement next() throws NoSuchElementException {
+        if (!hasNext())
+            throw new NoSuchElementException();
+
+        Chunk2dElement result = current;
+        moveOn();
+        return result;
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/utils/world2d/iterator/WorldBBox2dIterator.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world2d/iterator/WorldBBox2dIterator.java
@@ -1,0 +1,63 @@
+package com.ignfab.minalac.generator.utils.world2d.iterator;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
+import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
+
+/**
+ * An iterator over all coordinates in a {@code WorldBBox2d}.
+ */
+public class WorldBBox2dIterator implements Iterator<WorldCoords2d> {
+    private WorldBBox2d bbox;
+    private int x, y;
+    private boolean hasNext;
+
+    /**
+     * Constructs a new {@code WorldBBox2dIterator}.
+     *
+     * @param bbox the {@code WorldBBox2d} to iterate over.
+     */
+    public WorldBBox2dIterator(WorldBBox2d bbox) {
+        this.bbox = bbox;
+        x = bbox.getMin().getX();
+        y = bbox.getMin().getY();
+
+        if (bbox.getSize().area() > 0)
+            hasNext = true;
+    }
+
+    private void moveOn() {
+        x++;
+        if (x > bbox.getMax().getX()) {
+            x = bbox.getMin().getX();
+            y++;
+            if (y > bbox.getMax().getY())
+                hasNext = false;
+        }
+    }
+
+    /**
+     * Indicates if there are more elements.
+     *
+     * @return {@code true} if the iteration has more elements.
+     */
+    public boolean hasNext() {
+        return hasNext;
+    }
+
+    /**
+     * Returns the next element.
+     *
+     * @return the next {@code WorldCoords2d} in the iteration.
+     * @throws NoSuchElementException if the iteration has no more elements.
+     */
+    public WorldCoords2d next() throws NoSuchElementException {
+        if (!hasNext)
+            throw new NoSuchElementException();
+        WorldCoords2d result = new WorldCoords2d(x, y);
+        moveOn();
+        return result;
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/world/MapWriteException.java
+++ b/src/main/java/com/ignfab/minalac/generator/world/MapWriteException.java
@@ -1,4 +1,4 @@
-package com.ignfab.minalac.generator;
+package com.ignfab.minalac.generator.world;
 
 public class MapWriteException extends Exception {
 

--- a/src/main/java/com/ignfab/minalac/generator/world/OutOfWorldException.java
+++ b/src/main/java/com/ignfab/minalac/generator/world/OutOfWorldException.java
@@ -1,4 +1,4 @@
-package com.ignfab.minalac.generator;
+package com.ignfab.minalac.generator.world;
 
 public class OutOfWorldException extends Exception {
 }

--- a/src/main/java/com/ignfab/minalac/generator/world/SemanticType.java
+++ b/src/main/java/com/ignfab/minalac/generator/world/SemanticType.java
@@ -1,4 +1,4 @@
-package com.ignfab.minalac.generator;
+package com.ignfab.minalac.generator.world;
 
 public enum SemanticType {
     Grass, Stone, Air, Water, Dirt

--- a/src/main/java/com/ignfab/minalac/generator/world/VoxelType.java
+++ b/src/main/java/com/ignfab/minalac/generator/world/VoxelType.java
@@ -1,0 +1,6 @@
+package com.ignfab.minalac.generator.world;
+
+public interface VoxelType {
+    //TODO : add the javadoc that explicitly define the coordinate system used + change the QuickStart.md accordingly
+    void place(int x, int y, int z) throws OutOfWorldException;
+}

--- a/src/main/java/com/ignfab/minalac/generator/world/VoxelTypeFactory.java
+++ b/src/main/java/com/ignfab/minalac/generator/world/VoxelTypeFactory.java
@@ -1,4 +1,4 @@
-package com.ignfab.minalac.generator;
+package com.ignfab.minalac.generator.world;
 
 public interface VoxelTypeFactory {
     VoxelType createVoxelType(SemanticType semanticType);

--- a/src/main/java/com/ignfab/minalac/generator/world/VoxelWorld.java
+++ b/src/main/java/com/ignfab/minalac/generator/world/VoxelWorld.java
@@ -1,4 +1,4 @@
-package com.ignfab.minalac.generator;
+package com.ignfab.minalac.generator.world;
 
 public interface VoxelWorld {
     VoxelTypeFactory getFactory();

--- a/src/test/java/com/ignfab/minalac/generator/outputs/minetest/TestMTVoxelWorld.java
+++ b/src/test/java/com/ignfab/minalac/generator/outputs/minetest/TestMTVoxelWorld.java
@@ -1,4 +1,4 @@
-package com.ignfab.minalac.generator.minetest;
+package com.ignfab.minalac.generator.outputs.minetest;
 
 import org.junit.Test;
 

--- a/src/test/java/com/ignfab/minalac/generator/utils/world2d/TestWorldBBox2d.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/world2d/TestWorldBBox2d.java
@@ -1,0 +1,72 @@
+package com.ignfab.minalac.generator.utils.world2d;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class TestWorldBBox2d {
+    @Test
+    public void testConstructor() {
+        // Instanciating a new voxel box
+        new WorldBBox2d(0, 0, 10, 10);
+
+        // Instanciating a 0 sized voxel box
+        try {
+            new WorldBBox2d(0, 0, 0, 0);
+            fail("IllegalArgumentException expected!");
+        } catch (IllegalArgumentException e) {
+        } catch (Exception e) {
+            fail("Wrong exception thrown");
+        }
+
+        try {
+            new WorldBBox2d(0, 0, -1, -1);
+            fail("IllegalArgumentException expected!");
+        } catch (IllegalArgumentException e) {
+        } catch (Exception e) {
+            fail("Wrong exception thrown");
+        }
+    }
+
+    @Test
+    public void testContains() {
+        WorldBBox2d box = new WorldBBox2d(-1, -2, 3, 4);
+
+        //four points bounding the box
+        assertTrue(box.contains(-1, -2));
+        assertTrue(box.contains(1, -2));
+        assertTrue(box.contains(1, 1));
+        assertTrue(box.contains(-1, 1));
+
+        //Point inside
+        assertTrue(box.contains(0, -1));
+
+        //Four points outside the box bounding it
+        assertFalse(box.contains(-2, -2));
+        assertFalse(box.contains(2, -2));
+        assertFalse(box.contains(1, 2));
+        assertFalse(box.contains(-1, 2));
+
+        //Point outside
+        assertFalse(box.contains(20, 10));
+
+        //Same with other version
+
+        assertTrue(box.contains(new WorldCoords2d(-1, -2)));
+        assertTrue(box.contains(new WorldCoords2d(1, -2)));
+        assertTrue(box.contains(new WorldCoords2d(1, 1)));
+        assertTrue(box.contains(new WorldCoords2d(-1, 1)));
+
+        //Point inside
+        assertTrue(box.contains(new WorldCoords2d(0, -1)));
+
+        //Four points outside the box bounding it
+        assertFalse(box.contains(new WorldCoords2d(-2, -2)));
+        assertFalse(box.contains(new WorldCoords2d(2, -2)));
+        assertFalse(box.contains(new WorldCoords2d(1, 2)));
+        assertFalse(box.contains(new WorldCoords2d(-1, 2)));
+
+        //Point outside
+        assertFalse(box.contains(new WorldCoords2d(20, 10)));
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/utils/world2d/chunk/TestArrayChunk2d.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/world2d/chunk/TestArrayChunk2d.java
@@ -1,0 +1,97 @@
+package com.ignfab.minalac.generator.utils.world2d.chunk;
+
+import java.lang.reflect.Field;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestArrayChunk2d {
+    private int[] getData(ArrayChunk2d chunk) throws NoSuchFieldException, IllegalAccessException {
+        Field data = ArrayChunk2d.class.getDeclaredField("values");
+        data.setAccessible(true);
+        return (int[]) data.get(chunk);
+    }
+
+    private void replaceValuesField(ArrayChunk2d chunk, int[] tab) throws NoSuchFieldException, IllegalAccessException {
+        Field data = ArrayChunk2d.class.getDeclaredField("values");
+        data.setAccessible(true);
+        data.set(chunk, tab);
+    }
+
+    @Test
+    public void testGet() throws NoSuchFieldException, IllegalAccessException {
+        ArrayChunk2d chunk_1 = new ArrayChunk2d(0, 0, 3, 2, 0);
+        int[] newValues = {1, 2, 3, 4, 5, 6};
+        /*
+        | - - y ->
+        | 1 2
+        | 3 4
+        | 5 6
+        x
+        |
+        v
+        */
+        replaceValuesField(chunk_1, newValues);
+
+        assertEquals(2, chunk_1.get(0, 1));
+        assertEquals(3, chunk_1.get(1, 0));
+        assertEquals(6, chunk_1.get(2, 1));
+
+        ArrayChunk2d chunk_2 = new ArrayChunk2d(-5, -2, 3, 2, 0);
+        replaceValuesField(chunk_2, newValues);
+
+        /*
+        |  -  -   y ->
+        |  1  2  -5
+        |  3  4  -4
+        |  5  6  -3
+        x -2 -1
+        |
+        v
+        */
+
+        assertEquals(1, chunk_2.get(-5, -2));
+        assertEquals(2, chunk_2.get(-5, -1));
+        assertEquals(5, chunk_2.get(-3, -2));
+        assertEquals(6, chunk_2.get(-3, -1));
+        assertEquals(4, chunk_2.get(-4, -1));
+    }
+
+    @Test
+    public void testSet() throws NoSuchFieldException, IllegalAccessException {
+        ArrayChunk2d chunk = new ArrayChunk2d(0, 0, 3, 2, 0);
+        int[] newValues = {1, 2, 3, 4, 5, 6};
+        /*
+        | - - y ->
+        | 1 2
+        | 3 4
+        | 5 6
+        x
+        |
+        v
+        */
+
+        replaceValuesField(chunk, newValues);
+
+        chunk.set(0, 1, 7);
+        chunk.set(1, 1, 8);
+        chunk.set(2, 0, 9);
+
+        assertEquals(7, getData(chunk)[1]);
+        assertEquals(8, getData(chunk)[3]);
+        assertEquals(9, getData(chunk)[4]);
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testSetOut() {
+        ArrayChunk2d chunk = new ArrayChunk2d(0, 0, 3, 2, 0);
+        chunk.set(25, 25, 0);
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testGetOut() {
+        ArrayChunk2d chunk = new ArrayChunk2d(0, 0, 3, 2, 0);
+        chunk.get(25, 25);
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/utils/world2d/iterator/TestChunk2DIteratorAll.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/world2d/iterator/TestChunk2DIteratorAll.java
@@ -1,0 +1,37 @@
+package com.ignfab.minalac.generator.utils.world2d.iterator;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.ignfab.minalac.generator.utils.world2d.chunk.ArrayChunk2d;
+
+public class TestChunk2DIteratorAll {
+    @Test
+    public void testFullyFilledMapIterator() {
+        ArrayChunk2d chunk = new ArrayChunk2d(1, 2, 3, 4, 1);
+        //Fill chunk with unique values
+        for (int x = 1; x <= 3; x++)
+            for (int y = 2; y <= 5; y++)
+                chunk.set(x, y, x + y * 3);
+
+        Chunk2dIteratorAll iterator = new Chunk2dIteratorAll(chunk);
+        boolean[][] done = {{false, false, false, false}, {false, false, false, false}, {false, false, false, false}};
+        int count = 0;
+
+        // Check if iterator gives the right value
+        while (iterator.hasNext()) {
+            Chunk2dElement element = iterator.next();
+            assertEquals(String.format("Wrong chunk value at (x = %d, y = %d)", element.getX(), element.getY()), element.getX() + element.getY() * 3, element.getValue());
+            done[element.getX() - 1][element.getY() - 2] = true;
+            count++;
+        }
+
+        // Check if the iterator has visited every place exactly once.
+        assertEquals("Unexpected number of iterated element", 12, count);
+        for (int x = 0; x < 3; x++)
+            for (int y = 0; y < 4; y++)
+                assertTrue(String.format("Chunk element at (x = %d, y = %d) skipped !", x + 1, y + 2), done[x][y]);
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/utils/world2d/iterator/TestChunk2DIteratorSkip.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/world2d/iterator/TestChunk2DIteratorSkip.java
@@ -1,0 +1,67 @@
+package com.ignfab.minalac.generator.utils.world2d.iterator;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.ignfab.minalac.generator.utils.world2d.chunk.ArrayChunk2d;
+
+public class TestChunk2DIteratorSkip {
+    @Test
+    public void testFullyFilledMapIterator() {
+        ArrayChunk2d chunk = new ArrayChunk2d(1, 2, 3, 4, 1);
+        // Fill chunk with unique values
+        for (int x = 1; x <= 3; x++)
+            for (int y = 2; y <= 5; y++)
+                chunk.set(x, y, x + y * 3);
+
+        Chunk2dIteratorSkip iterator = new Chunk2dIteratorSkip(chunk, -1);
+        boolean[][] done = {{false, false, false, false}, {false, false, false, false}, {false, false, false, false}};
+        int count = 0;
+
+        // Check if iterator gives the right value.
+        while (iterator.hasNext()) {
+            Chunk2dElement element = iterator.next();
+            assertEquals(String.format("Wrong chunk value at (x = %d, y = %d)", element.getX(), element.getY()), element.getX() + element.getY() * 3, element.getValue());
+            done[element.getX() - 1][element.getY() - 2] = true;
+            count++;
+        }
+
+        // Check if the iterator has visited every place exactly once.
+        assertEquals("Unexpected number of iterated element", 12, count);
+        for (int x = 0; x < 3; x++)
+            for (int y = 0; y < 4; y++)
+                assertTrue(String.format("Chunk element at (x = %d, y = %d) skipped !", x + 1, y + 2), done[x][y]);
+    }
+
+    @Test
+    public void testPartiallyFilledChunkIterator() {
+        ArrayChunk2d chunk = new ArrayChunk2d(2, 3, 4, 5, 0);
+        // Fill a 2*3 rectangle in the middle of the chunk
+        for (int x = 3; x <= 4; x++)
+            for (int y = 4; y <= 6; y++)
+                chunk.set(x, y, 1);
+
+        Chunk2dIteratorSkip iterator = new Chunk2dIteratorSkip(chunk, 0);
+        boolean[][] done = {{false, false, false}, {false, false, false}};
+        int count = 0;
+
+        // Check we only iterate over the filled rectangle
+        while (iterator.hasNext()) {
+            Chunk2dElement element = iterator.next();
+            assertTrue(String.format("Iterated outside set chunk at (x = %d, y = %d)", element.getX(), element.getY()),
+                    3 <= element.getX() && element.getX() <= 4 &&
+                            4 <= element.getY() && element.getY() <= 6);
+            assertEquals("Wrong value", 1, element.getValue());
+            done[element.getX() - 3][element.getY() - 4] = true;
+            count++;
+        }
+
+        // Check if the iterator has visited every place exactly once.
+        assertEquals("Unexpected number of iterated element", 6, count);
+        for (int x = 0; x < 2; x++)
+            for (int y = 0; y < 3; y++)
+                assertTrue(String.format("Chunk element at (x = %d, y = %d) skipped !", x + 2 + 1, y + 3 + 1), done[x][y]);
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/utils/world2d/iterator/TestWorldBBox2dIterator.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/world2d/iterator/TestWorldBBox2dIterator.java
@@ -1,0 +1,35 @@
+package com.ignfab.minalac.generator.utils.world2d.iterator;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
+import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
+
+public class TestWorldBBox2dIterator {
+    @Test
+    public void testIterator() {
+        WorldBBox2d bbox = new WorldBBox2d(1, 2, 3, 4);
+
+        WorldBBox2dIterator iterator = new WorldBBox2dIterator(bbox);
+        boolean[][] done = {{false, false, false, false}, {false, false, false, false}, {false, false, false, false}};
+        int count = 0;
+
+        // Check if iterator gives the right values.
+        while (iterator.hasNext()) {
+            WorldCoords2d coord = iterator.next();
+            assertTrue(String.format("x = %d is out of box", coord.getX()), 1 <= coord.getX() && coord.getX() <= 3);
+            assertTrue(String.format("y = %d is out of box", coord.getY()), 2 <= coord.getY() && coord.getY() <= 5);
+            done[coord.getX() - 1][coord.getY() - 2] = true;
+            count++;
+        }
+
+        // Check if the iterator has visited every place exactly once.
+        assertEquals("Unexpected number of iterated element", 12, count);
+        for (int x = 0; x < 3; x++)
+            for (int y = 0; y < 4; y++)
+                assertTrue(String.format("Coordinates (x = %d, y = %d) skipped !", x + 1, y + 2), done[x][y]);
+    }
+}


### PR DESCRIPTION

Cette PR n'est pas tout à fait terminée.

Elle vise à créer des classes pour manipuler des morceaux de cartes 2d en voxels.

Deux interfaces importantes:
`ReadableVoxel2dMap` : objet contenant des données 2d voxelisées que l'on peut lire.
`WritableVoxel2dMap` : objet contenant des données 2d voxelisées que l'on peut écrire.

`Voxel2dMap` implémente ces deux interfaces et pourra nous servir au moins à jouer avec et à tester.

Au final, on aura d'autres objets qui implémentent `ReadableVoxel2dMap`. Par exemple, on pourrait encapsuer `Graphics2d` dans un `ReadableVoxel2dMap` pour le rendu des features (Selon le GML on écrit dans un `Graphics2d` et on l'expose via `ReadableVoxel2dMap` au renderers qui vont pouvoir modifier le VoxelWorld).

Les `ReadableVoxel2dMap` ont une valeur par défaut qui est la valeur à laquelle elles sont initialisées. Cette valeur peut aussi signifier que la cellule n'est pas concernée par la carte (en dehors de la feature par exemple).

Exemple de `ReadableVoxel2dMap` :
```
0 0 1 0 0
0 1 0 1 0
1 0 0 0 1
1 1 1 1 1
1 0 0 0 1
1 0 0 0 1
```
Si sa valeur par défaut est 0, on va pouvoir utiliser un iterateur pour ne dessiner que le "A" que forment les 1.

Ainsi, le code pour écrire la `ReadableVoxel2dMap` dans le monde peut être très simple:
```java
map.iter().forEachRemaining(
      (coord) -> {
          stoneVoxel.place(coord.x(), coord.y(), 0);
      }
);
```
`map` est un `ReadableVoxel2dMap` et `stoneVoxel` un `voxelType`.
L'itérateur va se cantonner aux 1.

Il reste à créer des `ReadableVoxel2dMap` qui contiennent nos données. On peut déjà facilement, avec `VoxelMap2d`, créer des petites images pour tester.

`VoxelMap2d` devrait aussi pouvoir être dérivée pour stocker les différentes HeightMap (ou, du moins, les HeightMaps pourraient implémenter les interfaces `ReadableVoxel2dMap`  et `WritableVoxel2dMap`)