### PR TITLE
Add BufferedImageChunk and GeometryModel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# Compile
+
+```
+cd minalac-generator
+mvn compile
+```
+
+# Test
+
+```
+cd minalac-generator
+mvn test
+```
+
+# Execute
+```
+cd minalac-generator
+mvn compile && mvn exec:java -Dexec.mainClass="com.ignfab.minalac.generator.SampleImplementation" -Dexec.args="$HOME/.minetest/worlds/minalac EPSG:2154 600000 6340000 1000 1000 1.0 10.0"
+```
+
+If behind a proxy, don't forget to:
+```
+export MAVEN_OPTS="-Dhttp.proxyHost=proxy.ign.fr -Dhttp.proxyPort=3128 -Dhttps.proxyHost=proxy.ign.fr -Dhttps.proxyPort=3128"
+```

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,12 @@
             <artifactId>slf4j-simple</artifactId>
             <version>2.0.9</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.apache.poi/poi -->
+        <dependency>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>poi</artifactId>
+            <version>5.2.5</version>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/org.locationtech.jts/jts-core -->
         <dependency>
             <groupId>org.locationtech.jts</groupId>
@@ -65,13 +71,23 @@
             <version>${geotools.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.geotools</groupId>
-            <artifactId>gt-epsg-hsql</artifactId>
+            <groupId>org.geotools.xsd</groupId>
+            <artifactId>gt-xsd-wfs</artifactId>
             <version>${geotools.version}</version>
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>
             <artifactId>gt-referencing</artifactId>
+            <version>${geotools.version}</version>
+        </dependency>
+        <!--
+            Important because without it won't be able to identify coordinates system
+            Example : No code "EPSG:4326" from authority "EPSG"
+            https://blog.csdn.net/jfqqqqq/article/details/124681727
+        -->
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-epsg-hsql</artifactId>
             <version>${geotools.version}</version>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <geotools.version>31.0</geotools.version>
     </properties>
 
     <dependencies>
@@ -51,7 +52,39 @@
             <artifactId>slf4j-simple</artifactId>
             <version>2.0.9</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.locationtech.jts/jts-core -->
+        <dependency>
+            <groupId>org.locationtech.jts</groupId>
+            <artifactId>jts-core</artifactId>
+            <version>1.19.0</version>
+        </dependency>
+        <!-- Geotools -->
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-main</artifactId>
+            <version>${geotools.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-epsg-hsql</artifactId>
+            <version>${geotools.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-referencing</artifactId>
+            <version>${geotools.version}</version>
+        </dependency>
     </dependencies>
+
+    <repositories>
+        <repository>
+            <id>osgeo</id>
+            <name>OSGeo Release Repository</name>
+            <url>https://repo.osgeo.org/repository/release/</url>
+            <snapshots><enabled>false</enabled></snapshots>
+            <releases><enabled>true</enabled></releases>
+        </repository>
+    </repositories>
 
     <build>
         <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->

--- a/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
+++ b/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
@@ -6,50 +6,167 @@ import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.xml.sax.SAXException;
+
+import org.geotools.referencing.CRS;
+import org.geotools.api.feature.simple.SimpleFeature;
+import org.geotools.api.referencing.NoSuchAuthorityCodeException;
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.operation.TransformException;
+import org.geotools.data.simple.SimpleFeatureIterator;
+import org.geotools.data.simple.SimpleFeatureCollection;
+
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.util.AffineTransformation;
+
 import com.ignfab.minalac.generator.world.*;
 import com.ignfab.minalac.generator.outputs.minetest.MTVoxelWorld;
 import com.ignfab.minalac.generator.utils.world2d.*;
 import com.ignfab.minalac.generator.utils.world2d.chunk.*;
 import com.ignfab.minalac.generator.utils.world2d.iterator.*;
 
+import com.ignfab.minalac.generator.generation.CoordsConverter;
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.inputs.WFS2DataProvider;
+import com.ignfab.minalac.generator.models.GeometryModel;
+import com.ignfab.minalac.generator.models.BufferedImageChunk;
+
 /**
  * This is a temporary class to have an idea of how the program works.
  * It generates a Minetest map which is a 3D rendering from a heightmap
  */
 public class SampleImplementation {
-    public static void main(String[] args) throws IOException, OutOfWorldException, MapWriteException {
-        if (args.length != 5) {
-            System.out.println("There must be five arguments : directoryPath, baseURL, width, height, verticalScale");
+    public static void main(String[] args)
+    throws IOException, OutOfWorldException, MapWriteException, SAXException,
+           NoSuchAuthorityCodeException, FactoryException,
+           ParserConfigurationException, TransformException {
+        if (args.length != 8) {
+            System.out.println("There must be eight arguments : directoryPath, crs, centerX, centerY, extendX, extendY, horizontalScale, verticalScale");
         } else {
             //Example : "/home/john/.minetest/worlds/map/"
             String directoryPath = args[0];
 
-            //Example : https://data.geopf.fr/wms-r/wms?LAYERS=RGEALTI-MNT_PYR-ZIP_FXX_LAMB93_WMS&FORMAT=image/x-bil;bits=32&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&STYLES=&CRS=EPSG:2154&BBOX=595000,6335000,605000,6345000
-            String partialURL = args[1];
+            //Example : "EPSG:2154"
+            String crs = args[1];
 
-            //Example : 1000
-            int width = Integer.parseInt(args[2]);
+            // Center coordinates (in CRS), example : 600000 6340000
+            // TODO: Center should be in Lon/lat in WGS84
+            float centerX = Float.parseFloat(args[2]);
+            float centerY = Float.parseFloat(args[3]);
 
-            //Example : 1000
-            int height = Integer.parseInt(args[3]);
+            // Extends in voxel, example: 1000 1000, must be >0
+            int extendX = Integer.parseInt(args[4]);
+            int extendY = Integer.parseInt(args[5]);
 
-            //Example : 10 (in meter per voxel)
-            float verticalScale = Float.parseFloat(args[4]);
+            // Horizontal scale (horizontal size of voxel in meters), example: 1.0, must be >0
+            float horizontalScale = Float.parseFloat(args[6]);
 
-            System.out.println("Creation of the map ..." +
-                    "\ndirectoryPath: " + directoryPath +
-                    "\npartialURL: " + partialURL +
-                    "\nwidth: " + width +
-                    "\nheight: " + height +
-                    "\nverticalScale: " + verticalScale);
+            // Vertical scale (vertical size of voxel in meters), example: 10.0, must be >0
+            float verticalScale = Float.parseFloat(args[7]);
 
-            HeightMap heightMap = createGroundHeightMap(partialURL, width, height, verticalScale);
+            System.out.println("Creation of the map.");
 
+            // For now:
+            // - We use same CRS for all layers
+            // - Center is already in this CRS
+
+            // Affine tranformation:
+            // - Translation : center to 0,0
+            // - Rotation : not yet implemented
+            // - Scale : horizontal scale
+
+            AffineTransformation crsToVoxel = new AffineTransformation();
+            crsToVoxel.translate(-centerX, -centerY);
+            // crsToVoxel.rotate(rotate * pi / 180.0, 0.0, 0.0);
+            crsToVoxel.scale(1.0 / horizontalScale, 1.0 / horizontalScale);
+
+            AffineTransformation voxelToCrs = new AffineTransformation();
+            voxelToCrs.scale(horizontalScale, horizontalScale);
+            // VoxelToCrs.rotate(- rotate * pi / 180.0, 0.0, 0.0);
+            voxelToCrs.translate(centerX, centerY);
+
+            // Map BBox
+            Coordinate corners[] = {
+                new Coordinate((float) extendX / 2, (float) extendY / 2),
+                new Coordinate((float) extendX / 2, - (float) extendY / 2),
+                new Coordinate(- (float) extendX / 2, (float) extendY / 2),
+                new Coordinate(- (float) extendX / 2, - (float) extendY / 2),
+                new Coordinate((float) extendX / 2, (float) extendY / 2)
+            };
+
+            Geometry box = new GeometryFactory().createLinearRing(corners);
+            Envelope envelope = voxelToCrs.transform(box).getEnvelopeInternal();
+
+            String bboxURL = "BBOX=" + envelope.getMinX() + "," + envelope.getMinY() + "," + envelope.getMaxX() + "," + envelope.getMaxY();
+
+            // Creation of heightmap
+
+            System.out.println("Downloading height map");
+            HeightMap heightMap = createGroundHeightMap("https://data.geopf.fr/wms-r/wms?LAYERS=RGEALTI-MNT_PYR-ZIP_FXX_LAMB93_WMS&FORMAT=image/x-bil;bits=32&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&STYLES=&CRS=" + crs + "&" + bboxURL, extendX, extendY, verticalScale);
+
+            // TODO: A lot of above code should end up in Generation class
+            Generation generation = new Generation(CRS.decode(crs), crsToVoxel); // This is supposed to be the target CRS
+
+            System.out.println("World creation");
             VoxelWorld world = new MTVoxelWorld();
+            System.out.println("Placing ground");
             placeVoxelFromHeightMap(heightMap, world);
+
+            // Add a vector layer
+            System.out.println("Add vector layer");
+            WFS2DataProvider provider = new WFS2DataProvider("https://data.geopf.fr/wfs/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=BDTOPO_V3:batiment&STARTINDEX=0&COUNT=1000&SRSNAME=urn:ogc:def:crs:EPSG::2154&" + bboxURL +",urn:ogc:def:crs:EPSG::2154");
+            placeVectorFeatures(provider.getFeatures(),
+                generation.makeCoordsConverter(CRS.decode(crs)), // This is supposed to be the layer CRS (actually the same for this demo)
+                world, heightMap);
+
+            System.out.println("Saving");
             save(directoryPath, world);
 
+            System.out.println("Done");
             setStaticSpawnPoint(directoryPath, 0, heightMap.get(0, 0) + 1, 0);
+
+            // TODO: That's not working. It's an attempt to avoid InterruptExecption thrown by threads started by CRS.decode
+            CRS.cleanupThreadLocals();
+        }
+    }
+
+    private static void placeVectorFeatures(SimpleFeatureCollection features, CoordsConverter converter, VoxelWorld world, HeightMap heightMap)
+        throws TransformException, OutOfWorldException {
+        VoxelType insideVT = world.getFactory().createVoxelType(SemanticType.Cobble);
+        VoxelType wallVT = world.getFactory().createVoxelType(SemanticType.Brick);
+        try (
+            SimpleFeatureIterator iterator = features.features();
+        ) {
+            while( iterator.hasNext() ){
+                SimpleFeature feature = iterator.next();
+
+                // Create a model out of feature geometry
+                GeometryModel model = new GeometryModel((Geometry)feature.getDefaultGeometry(), converter);
+
+                // Rasterize that model into a chunk
+                BufferedImageChunk chunk = model.getChunk();
+
+                // Iterate over chunk and draw shape on map at heightMap altitude
+                for (Chunk2dElement element : chunk) {
+                    WorldCoords2d c = element.getCoords();
+                    // TODO: Make Iterator able to intersect with another box
+                    // TODO: Have a world bbox rather
+                    if (heightMap.bbox().contains(c))
+                        switch(element.getValue()) {
+                            case GeometryModel.INSIDE:
+                                insideVT.place(c.getX(), c.getY(), heightMap.get(c) + 1);
+                                break;
+                            case GeometryModel.BORDER:
+                                wallVT.place(c.getX(), c.getY(), heightMap.get(c) + 1);
+                                break;
+                        }
+                }
+            }
         }
     }
 
@@ -91,17 +208,19 @@ public class SampleImplementation {
 
         mntArray = byteArrayToFloatArray(data);
 
-        int xMinHeightMap = -width / 2, yMinHeightMap = -height / 2;
-        HeightMap heightMap = new HeightMap(xMinHeightMap, yMinHeightMap, width, height, 0);
+        int xMin = -width / 2;
+        int yMin = -height / 2;
 
-        int x_arr, y_arr, x_world, y_world;
-        for (int i = 0; i < mntArray.length; i++) {
-            x_arr = i % width;
-            y_arr = i / width;
-            x_world = x_arr + xMinHeightMap;
-            y_world = -(y_arr + yMinHeightMap) - 1; //-1 so min y_world matches yMinHeightMap (There is an offset due to y-axis inversion),
-            heightMap.set(x_world, y_world, (int) (mntArray[i] / verticalScale));
-        }
+        HeightMap heightMap = new HeightMap(xMin, yMin, width, height, 0);
+
+        int index = 0;
+
+        for (int y = height - 1 ; y >= 0 ; y--) // In raster, Y axis is downwards
+            for (int x = 0 ; x < width ; x++) {
+                heightMap.set(x + xMin, y + yMin, (int) (mntArray[index] / verticalScale));
+                index++;
+            }
+
         return heightMap;
     }
 

--- a/src/main/java/com/ignfab/minalac/generator/generation/CoordsConverter.java
+++ b/src/main/java/com/ignfab/minalac/generator/generation/CoordsConverter.java
@@ -1,0 +1,44 @@
+package com.ignfab.minalac.generator.generation;
+
+import org.geotools.api.referencing.operation.MathTransform;
+import org.geotools.api.referencing.operation.TransformException;
+import org.geotools.geometry.jts.JTS;
+
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.util.AffineTransformation;
+
+/**
+ * Converts coordinates from a CRS to world coordinates.
+ */
+public class CoordsConverter {
+    private MathTransform crsTransform;
+    private AffineTransformation postTransform;
+
+    /**
+     * Constructs a new {@code CoordsConverter}.
+     *
+     * This is up to the caller to give proper transformations:
+     * @param crsTransform Transformation from source CRS to world CRS.
+     * @param postTransform Affine transformation applied for scale and rotation after CRS transformation.
+     * @throws IllegalArgumentException if crsTransformation is not two dimensional.
+     */
+
+    public CoordsConverter(MathTransform crsTransform, AffineTransformation postTransform) {
+        if (crsTransform.getSourceDimensions() != 2 || crsTransform.getTargetDimensions() != 2)
+            throw new IllegalArgumentException("crsTransform must be from two dimensions to two dimensions");
+
+        this.crsTransform = crsTransform;
+        this.postTransform = postTransform;
+    }
+
+    /**
+     * Converts a geometry into world coordinates.
+     *
+     * @param geom Geometry to transform.
+     * @return Transformed geometry (into world coordinates).
+     * @throws TransformException if unable to perform transformation.
+     */
+    public Geometry convert(Geometry geom) throws TransformException {
+        return postTransform.transform(JTS.transform(geom, crsTransform));
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/generation/Generation.java
+++ b/src/main/java/com/ignfab/minalac/generator/generation/Generation.java
@@ -1,0 +1,41 @@
+package com.ignfab.minalac.generator.generation;
+
+import org.geotools.referencing.CRS;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.operation.MathTransform;
+
+import org.locationtech.jts.geom.util.AffineTransformation;
+
+/**
+ * Generation context class.
+ *
+ * Contains stuff about ongoing generation and its context.
+ */
+public class Generation {
+    private CoordinateReferenceSystem crs;
+    private AffineTransformation transformation;
+
+    /**
+     * Constructs a new generation context.
+     *
+     * @param crs Coordinate reference system used for generated world.
+     * @param transformation Two dimensions affine transformation applied to world (usually rotation + scale).
+     */
+    public Generation(CoordinateReferenceSystem crs, AffineTransformation transformation) {
+        this.crs = crs;
+        this.transformation = transformation;
+    }
+
+    /**
+     * Creates a converter for a given CRS.
+     *
+     * @param sourceCrs CRS from which convert map coordinates.
+     * @return A converter to be used to convert any map coordinates into generated world coordinates.
+     * @throws FactoryException If not suitable transformation found for conversion.
+     */
+    public CoordsConverter makeCoordsConverter(CoordinateReferenceSystem sourceCrs) throws FactoryException {
+        MathTransform crsTransform = CRS.findMathTransform(sourceCrs, crs);
+        return new CoordsConverter(crsTransform, transformation);
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/inputs/WFS2DataProvider.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/WFS2DataProvider.java
@@ -1,0 +1,39 @@
+package com.ignfab.minalac.generator.inputs;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.apache.poi.util.ReplacingInputStream;
+
+import org.geotools.data.simple.SimpleFeatureCollection;
+import org.geotools.wfs.GML;
+
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.ParserConfigurationException;
+
+public class WFS2DataProvider {
+    private String baseURL;
+
+    public WFS2DataProvider(String baseURL) {
+        this.baseURL = baseURL;
+    }
+
+    public SimpleFeatureCollection getFeatures() throws MalformedURLException, IOException, ParserConfigurationException, SAXException {
+        GML gml = new GML(GML.Version.GML3);
+
+        URL url = new URL(baseURL);
+
+        InputStream stream = url.openStream();
+
+        InputStream replacedStream =  new ReplacingInputStream( new ReplacingInputStream( new ReplacingInputStream( new ReplacingInputStream( stream,
+                "</wfs:member>\n<wfs:member>", ""),
+                "wfs:member", "gml:featureMembers"),
+                "http://BDTOPO_V3", "http://BDTOPOV3"),
+                "xmlns:gml=\"http://www.opengis.net/gml/3.2\"", "xmlns:gml=\"http://www.opengis.net/gml\"");
+
+        return gml.decodeFeatureCollection(replacedStream);
+   }
+}

--- a/src/main/java/com/ignfab/minalac/generator/models/BufferedImageChunk.java
+++ b/src/main/java/com/ignfab/minalac/generator/models/BufferedImageChunk.java
@@ -1,0 +1,116 @@
+package com.ignfab.minalac.generator.models;
+
+import java.awt.image.BufferedImage;
+import java.awt.image.DataBufferByte;
+import java.awt.Graphics2D;
+import java.awt.Color;
+import java.util.Arrays;
+
+import com.ignfab.minalac.generator.utils.world2d.chunk.IterableChunk2d;
+import com.ignfab.minalac.generator.utils.world2d.chunk.WritableChunk2d;
+import com.ignfab.minalac.generator.utils.world2d.iterator.Chunk2dIteratorSkip;
+import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
+import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
+
+/**
+ * A readable and writable 2d chunk of world map based on {@code BufferedImage}.
+ *
+ * Values are stored as bytes so their range is 0 to 255.
+ */
+public class BufferedImageChunk implements IterableChunk2d, WritableChunk2d {
+    private BufferedImage image;
+    private WorldBBox2d bbox;
+
+    /**
+     * Construct a new {@code BufferedImageChunk}
+     *
+     * @param bbox Bounding box of that chunk
+     *
+     * Chunk is initalized with 0 values.
+     */
+    BufferedImageChunk(WorldBBox2d bbox) {
+        this.bbox = bbox;
+
+        // This is a bit hacky. We use a 256 level grey image.
+        // TYPE_BYTE_GRAY color model is the closest to what we need for now (store a few different values).
+        // To get rid of this hack, we should have a look on how to develop a specific
+        // color model to store integers (I guess this could be lot of useless work).
+        image = new BufferedImage(bbox.getSize().getX(), bbox.getSize().getY(), BufferedImage.TYPE_BYTE_GRAY);
+        Arrays.fill(((DataBufferByte) image.getRaster().getDataBuffer()).getData(), (byte)0);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public WorldBBox2d bbox() {
+        return bbox;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int get(int x, int y) {
+        if (!bbox.contains(x, y)) throw new IndexOutOfBoundsException();
+        return image.getRaster().getSample(x - bbox.getMin().getX(), y - bbox.getMin().getY(), 0);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int get(WorldCoords2d coords) {
+        return get(coords.getX(), coords.getY());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void set(int x, int y, int value) {
+        if (!bbox.contains(x, y)) throw new IndexOutOfBoundsException();
+        image.getRaster().setSample(x - bbox.getMin().getX(), y - bbox.getMin().getY(), 0, value);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void set(WorldCoords2d coords, int value) {
+        set(coords.getX(), coords.getY(), value);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Chunk2dIteratorSkip iterator() {
+        return new Chunk2dIteratorSkip(this, 0);
+    }
+
+    /**
+     * Creates a {@code Graphics2D} able to draw on this chunk.
+     *
+     * Coordinates in that {@code Graphics2D} are bounding box relative (starting at 0,0 and up to size).
+     *
+     * @return A {@code Graphics2D} instance linked to embedded {@code BufferedImage}.
+     */
+    public Graphics2D createGraphics() {
+        return image.createGraphics();
+    }
+
+    // This method is very handy to definitely hide the TYPE_BYTE_GRAY hack:
+    /**
+     * Returns a {@code Color} for drawing a given integer value.
+     *
+     * @param value Value to be represented as color
+     * @return A {@code Color} to be used to draw given value.
+     */
+    public static Color colorFor(int value) {
+        if (value < 0 || value > 255)
+            throw new IndexOutOfBoundsException();
+
+        return new Color(value, value, value);
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/models/GeometryModel.java
+++ b/src/main/java/com/ignfab/minalac/generator/models/GeometryModel.java
@@ -1,0 +1,167 @@
+package com.ignfab.minalac.generator.models;
+
+import java.awt.Graphics2D;
+import java.awt.Color;
+
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryCollection;
+import org.locationtech.jts.geom.Polygon;
+import org.locationtech.jts.geom.util.AffineTransformation;
+
+import org.geotools.api.referencing.operation.TransformException;
+
+import com.ignfab.minalac.generator.generation.CoordsConverter;
+import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
+import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
+
+// This class converts float coord array into two integer arrays ready for Graphics2D
+class ConvertedCoords {
+    public int[] x;
+    public int[] y;
+    public int length;
+
+    ConvertedCoords(Coordinate[] coords) {
+        length = coords.length;
+        x = new int[length];
+        y = new int[length];
+
+        for (int n = 0; n < length; n++) {
+            x[n] = (int)Math.floor(coords[n].x);
+            y[n] = (int)Math.floor(coords[n].y);
+        }
+    }
+}
+
+/**
+ * Model represented by a JTS Geometry
+ *
+ * It is rasterizable. Rasterized chunk will include three values:
+ * 0: Not in geometry, 1: On its edge, 2: Inside it (polygons only).
+ */
+public class GeometryModel implements Rasterizable {
+    private Geometry geom;
+    private BufferedImageChunk chunk;
+
+    public static final int OUTSIDE = 0;
+    public static final int BORDER = 1;
+    public static final int INSIDE = 2;
+
+    private static final Color outsideColor = BufferedImageChunk.colorFor(OUTSIDE); // Not in shape color
+    private static final Color borderColor = BufferedImageChunk.colorFor(BORDER); // Shape border color
+    private static final Color insideColor = BufferedImageChunk.colorFor(INSIDE); // Inside shape (fill) color
+
+
+
+    /**
+     * Constructs a new {@code GeometryModel}
+     *
+     * @param geom A JTS Geometry
+     * @param converter Converter from geometry CRS to world coordinates
+     */
+    public GeometryModel(Geometry geom, CoordsConverter converter) throws TransformException{
+        // Until there is no need of it we don't keep original geometry.
+        // Geometry is stored transformed into world coordinates
+        this.geom = converter.convert(geom);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public BufferedImageChunk getChunk() {
+
+        if (chunk == null) {
+            makeChunk();
+        }
+
+        return chunk;
+    };
+
+    /**
+     * Creates chunk, performing rasterization.
+     *
+     * This could be made public if really needed.
+     */
+    private void makeChunk() {
+        // Compute bounding box
+        Envelope envelope = geom.getEnvelopeInternal();
+
+        WorldBBox2d bbox = new WorldBBox2d(
+            new WorldCoords2d((int)Math.floor(envelope.getMinX()), (int)Math.floor(envelope.getMinY())),
+            new WorldCoords2d((int)Math.floor(envelope.getMaxX()), (int)Math.floor(envelope.getMaxY())));
+
+        // Create chunk
+        chunk = new BufferedImageChunk(bbox);
+        Graphics2D graphics = chunk.createGraphics();
+
+        // Draw geometry translated into bounding box relative coordinates (i.e. BufferedImage coordinates))
+        Geometry geom = AffineTransformation.translationInstance(-Math.floor(envelope.getMinX()), -Math.floor(envelope.getMinY())).transform(this.geom);
+        draw(graphics, geom);
+
+        graphics.dispose();
+    }
+
+    /**
+     * Recursively draw geometry on buffered image
+     */
+    private void draw(Graphics2D graphics, Geometry geometry) {
+        ConvertedCoords coords;
+
+        switch (geometry.getGeometryType()) {
+
+            // Simple geometries
+            case Geometry.TYPENAME_POINT:
+            case Geometry.TYPENAME_LINESTRING:
+            case Geometry.TYPENAME_LINEARRING:
+                coords = new ConvertedCoords(geometry.getCoordinates());
+                graphics.setColor(borderColor);
+                switch (geometry.getGeometryType()) {
+                    case Geometry.TYPENAME_POINT:
+                        graphics.drawRect(coords.x[0], coords.y[0], 1, 1);
+                        break;
+                    case Geometry.TYPENAME_LINESTRING:
+                        graphics.drawPolyline(coords.x, coords.y, coords.length);
+                        break;
+                    case Geometry.TYPENAME_LINEARRING:
+                        graphics.drawPolygon(coords.x, coords.y, coords.length);
+                        break;
+                }
+                break;
+
+            // Geometry collections
+            case Geometry.TYPENAME_GEOMETRYCOLLECTION:
+            case Geometry.TYPENAME_MULTILINESTRING:
+            case Geometry.TYPENAME_MULTIPOINT:
+            case Geometry.TYPENAME_MULTIPOLYGON:
+                GeometryCollection collection = (GeometryCollection)geometry;
+                for (int n = 0; n < collection.getNumGeometries(); n++)
+                    draw(graphics, collection.getGeometryN(n));
+                break;
+
+            // Polygons (with holes)
+            case Geometry.TYPENAME_POLYGON:
+                Polygon polygon = (Polygon)geometry;
+                coords = new ConvertedCoords(polygon.getExteriorRing().getCoordinates());
+
+                graphics.setColor(insideColor);
+                graphics.fillPolygon(coords.x, coords.y, coords.length);
+                graphics.setColor(borderColor);
+                graphics.drawPolygon(coords.x, coords.y, coords.length);
+
+                if (polygon.getNumInteriorRing() > 0) {
+                    for (int n = 0; n < polygon.getNumInteriorRing(); n++) {
+                        coords = new ConvertedCoords(polygon.getInteriorRingN(n).getCoordinates());
+
+                        graphics.setColor(outsideColor); // Wipe inside hole
+                        graphics.fillPolygon(coords.x, coords.y, coords.length);
+                        graphics.setColor(borderColor);
+                        graphics.drawPolygon(coords.x, coords.y, coords.length);
+                    }
+                }
+                break;
+        }
+    }
+}
+

--- a/src/main/java/com/ignfab/minalac/generator/models/Rasterizable.java
+++ b/src/main/java/com/ignfab/minalac/generator/models/Rasterizable.java
@@ -1,0 +1,15 @@
+package com.ignfab.minalac.generator.models;
+
+import com.ignfab.minalac.generator.utils.world2d.chunk.ReadableChunk2d;
+
+/**
+ * Objects that can be rasterized into {@code ReadableChunk2d}.
+ */
+public interface Rasterizable {
+    /**
+     * Returns rasterized {@code ReadableChunk2d}.
+     *
+     * @return Rasterized chunk
+     */
+    ReadableChunk2d getChunk();
+}

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelTypeFactory.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelTypeFactory.java
@@ -22,6 +22,10 @@ public class MTVoxelTypeFactory implements VoxelTypeFactory {
                 return new MTSimpleVoxelType(this.world, "default:stone");
             case Dirt:
                 return new MTSimpleVoxelType(this.world, "default:dirt");
+            case Cobble:
+                return new MTSimpleVoxelType(this.world, "default:cobble");
+            case Brick:
+                return new MTSimpleVoxelType(this.world, "default:stonebrick");
             case Water:
                 return new MTSimpleVoxelType(this.world, "default:water_source");
             default:

--- a/src/main/java/com/ignfab/minalac/generator/world/SemanticType.java
+++ b/src/main/java/com/ignfab/minalac/generator/world/SemanticType.java
@@ -1,5 +1,5 @@
 package com.ignfab.minalac.generator.world;
 
 public enum SemanticType {
-    Grass, Stone, Air, Water, Dirt
+    Grass, Stone, Air, Water, Dirt, Cobble, Brick
 }

--- a/src/test/java/com/ignfab/minalac/generator/generation/TestCoordsConverter.java
+++ b/src/test/java/com/ignfab/minalac/generator/generation/TestCoordsConverter.java
@@ -1,0 +1,108 @@
+package com.ignfab.minalac.generator.generation;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.geotools.api.referencing.NoSuchAuthorityCodeException;
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.operation.MathTransform;
+import org.geotools.api.referencing.operation.TransformException;
+import org.geotools.referencing.CRS;
+import org.geotools.referencing.operation.transform.IdentityTransform;
+
+import org.locationtech.jts.geom.util.AffineTransformation;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Coordinate;
+
+import com.ignfab.minalac.generator.generation.CoordsConverter;
+
+public class TestCoordsConverter {
+
+    private static GeometryFactory factory = new GeometryFactory();
+
+    // Tests right usage of affine transformation
+    @Test
+    public void testPointAffineTransform() throws TransformException {
+        Geometry result;
+
+        // Verify identity transformation
+        result = new CoordsConverter(IdentityTransform.create(2), new AffineTransformation())
+            .convert(factory.createPoint(new Coordinate(1.0, -2.0)));
+
+        assertEquals(result.getCoordinate().getX(),  1.0, 0.0001);
+        assertEquals(result.getCoordinate().getY(), -2.0, 0.0001);
+
+        // Verify 180° rotation transformation
+        result = new CoordsConverter(IdentityTransform.create(2), AffineTransformation.rotationInstance(Math.PI))
+            .convert(factory.createPoint(new Coordinate(1.0, -2.0)));
+
+        assertEquals(result.getCoordinate().getX(), -1.0, 0.0001);
+        assertEquals(result.getCoordinate().getY(),  2.0, 0.0001);
+
+        // Verify 90° rotation transformation
+        result = new CoordsConverter(IdentityTransform.create(2), AffineTransformation.rotationInstance(Math.PI / 2))
+            .convert(factory.createPoint(new Coordinate(1.0, -2.0)));
+
+        assertEquals(result.getCoordinate().getX(), 2.0, 0.0001);
+        assertEquals(result.getCoordinate().getY(), 1.0, 0.0001);
+
+        // Verify translation transformation
+        result = new CoordsConverter(IdentityTransform.create(2), AffineTransformation.translationInstance(-2.0, 1.0))
+            .convert(factory.createPoint(new Coordinate(1.0, -2.0)));
+
+        assertEquals(result.getCoordinate().getX(), -1.0, 0.0001);
+        assertEquals(result.getCoordinate().getY(), -1.0, 0.0001);
+    }
+
+    // Tests transformation works as expected on multipoint shapes
+    @Test
+    public void testShapeAffineTransformation() throws TransformException {
+        Geometry result;
+
+        Coordinate[] coords = {new Coordinate(-2.0, -2.0), new Coordinate(-1.0, 2.0), new Coordinate(2.0, 0.0)};
+
+        result = new CoordsConverter(IdentityTransform.create(2), AffineTransformation.rotationInstance(Math.PI / 2))
+            .convert(factory.createLineString(coords));
+
+        coords = result.getCoordinates();
+
+        // We assume that coords order has not changed but this is not sure at all.
+        assertEquals(coords[0].getX(),  2.0, 0.0001);
+        assertEquals(coords[0].getY(), -2.0, 0.0001);
+        assertEquals(coords[1].getX(), -2.0, 0.0001);
+        assertEquals(coords[1].getY(), -1.0, 0.0001);
+        assertEquals(coords[2].getX(),  0.0, 0.0001);
+        assertEquals(coords[2].getY(),  2.0, 0.0001);
+    }
+
+    // Tests projection works as expected, combined or not with affine transformations
+    @Test
+    public void testProjection() throws TransformException, NoSuchAuthorityCodeException, FactoryException {
+        Geometry result;
+
+        // Check simple geographic conversion from WSG 84 to LAMBERT 93
+        // IGN leveling mark https://geodesie.ign.fr/fiches/pdf/P.C.K3L3-20b_534424.pdf
+        MathTransform crsTransform = CRS.findMathTransform(CRS.decode("EPSG:4326"), CRS.decode("EPSG:2154"));
+        result = new CoordsConverter(crsTransform, new AffineTransformation())
+            .convert(factory.createPoint(new Coordinate(48.8452222, 2.4247222)));
+
+        assertEquals(result.getCoordinate().getX(),  657780.0, 2);
+        assertEquals(result.getCoordinate().getY(), 6860730.0, 2);
+
+        // Combine it with a translation
+        result = new CoordsConverter(crsTransform, AffineTransformation.translationInstance(-657780.0, -6860730.0))
+            .convert(factory.createPoint(new Coordinate(48.8452222, 2.4247222)));
+
+        assertEquals(result.getCoordinate().getX(), 0.0, 2);
+        assertEquals(result.getCoordinate().getY(), 0.0, 2);
+
+        // Combine with translation & rotation (rotation center should be given point)
+        result = new CoordsConverter(crsTransform, AffineTransformation.translationInstance(-657780.0, -6860730.0).rotate(1.0))
+            .convert(factory.createPoint(new Coordinate(48.8452222, 2.4247222)));
+
+        assertEquals(result.getCoordinate().getX(), 0.0, 2);
+        assertEquals(result.getCoordinate().getY(), 0.0, 2);
+    }
+}
+

--- a/src/test/java/com/ignfab/minalac/generator/models/TestBufferedImageChunk.java
+++ b/src/test/java/com/ignfab/minalac/generator/models/TestBufferedImageChunk.java
@@ -1,0 +1,85 @@
+package com.ignfab.minalac.generator.models;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.awt.Graphics2D;
+
+import com.ignfab.minalac.generator.models.BufferedImageChunk;
+import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
+import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
+
+public class TestBufferedImageChunk {
+
+    @Test
+    public void testGetAndSetOutOfBounds() {
+        WorldBBox2d bbox = new WorldBBox2d(-2, -1, 4, 3);
+        BufferedImageChunk chunk = new BufferedImageChunk(bbox);
+
+        assertThrows(IndexOutOfBoundsException.class,
+            () -> chunk.set(3, 0, 0),
+            "Wrong exception thrown when setting out of X bounds");
+
+        assertThrows(IndexOutOfBoundsException.class,
+            () -> chunk.set(-2, -2, 0),
+            "Wrong exception thrown when setting out of Y bounds");
+    }
+
+    @Test
+    public void testGetAndSetEveryWhere() {
+        WorldBBox2d bbox = new WorldBBox2d(-5, -2, 4, 3);
+        BufferedImageChunk chunk = new BufferedImageChunk(bbox);
+        int v;
+
+        // Set a different value on each chunk cell
+        v = 0;
+        for (int y = bbox.getMin().getY(); y <= bbox.getMax().getY(); y++)
+            for (int x = bbox.getMin().getX(); x <= bbox.getMax().getX(); x++)
+                chunk.set(x, y, v++);
+
+        v = 0;
+        for (int y = bbox.getMin().getY(); y <= bbox.getMax().getY(); y++)
+            for (int x = bbox.getMin().getX(); x <= bbox.getMax().getX(); x++)
+                assertEquals(chunk.get(x, y), v++, "("+x+", "+y+")");
+    }
+
+    @Test
+    public void testGraphics2D() {
+        WorldBBox2d bbox = new WorldBBox2d(2, 3, 4, 5);
+        BufferedImageChunk chunk = new BufferedImageChunk(bbox);
+
+        // Testing colors drawing two rectangles in a chunk:
+        //
+        //   X: 2 3 4 5
+        // Y:  ---------
+        // 3  | A A     |
+        // 4  | A A     |
+        // 5  | A B B B |
+        // 6  |   B B B |
+        // 7  |   B B B |
+        //     ---------
+        // Rectangle A has value 123
+        // Rectangle B has value 234
+
+        Graphics2D graphics = chunk.createGraphics();
+        // Fill rectangle A
+        graphics.setColor(chunk.colorFor(123));
+        graphics.fillRect(0, 0, 2, 3);
+        // Fill rectangle B
+        graphics.setColor(chunk.colorFor(234));
+        graphics.fillRect(1, 2, 3, 3);
+
+        for (int x = 2; x < 6; x++)
+            for (int y = 3; y < 8; y++)
+                // Check rectangle B
+                if (x >= 3 && y >= 5)
+                    assertEquals(chunk.get(x, y), 234, "("+x+", "+y+")");
+                // Check rectangle A
+                else if (x <= 3 && y <= 5)
+                    assertEquals(chunk.get(x, y), 123, "("+x+", "+y+")");
+                // Check outside both rectangles
+                else
+                    assertEquals(chunk.get(x, y), 0, "("+x+", "+y+")");
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/models/TestGeometryModel.java
+++ b/src/test/java/com/ignfab/minalac/generator/models/TestGeometryModel.java
@@ -1,0 +1,189 @@
+package com.ignfab.minalac.generator.models;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.geotools.api.referencing.operation.TransformException;
+import org.geotools.referencing.operation.transform.IdentityTransform;
+
+import org.locationtech.jts.geom.util.AffineTransformation;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.LinearRing;
+
+import com.ignfab.minalac.generator.generation.CoordsConverter;
+import com.ignfab.minalac.generator.models.GeometryModel;
+import com.ignfab.minalac.generator.utils.world2d.chunk.ReadableChunk2d;
+
+public class TestGeometryModel {
+    private static CoordsConverter converter = new CoordsConverter(IdentityTransform.create(2), new AffineTransformation());
+    private static GeometryFactory factory = new GeometryFactory();
+
+    @Test
+    public void testPointRasterization() throws TransformException {
+        System.out.println("testPointRasterization");
+        GeometryModel model = new GeometryModel(factory.createPoint(new Coordinate(10.0, -20.0)), converter);
+        ReadableChunk2d chunk = model.getChunk();
+
+        assertEquals(chunk.bbox().getSize().getX(),  1, "x-size");
+        assertEquals(chunk.bbox().getSize().getY(),  1, "y-size");
+        assertEquals(chunk.bbox().getMin().getX(),  10, "x-min");
+        assertEquals(chunk.bbox().getMin().getY(), -20, "y-min");
+    }
+
+    @Test
+    public void testLineStringRasterization() throws TransformException {
+        Coordinate[] coords = {
+            new Coordinate(-1.0, -1.0),
+            new Coordinate(-1.0,  1.0),
+            new Coordinate( 2.0,  1.0)};
+        GeometryModel model = new GeometryModel(factory.createLineString(coords), converter);
+        ReadableChunk2d chunk = model.getChunk();
+
+        // Expected :
+        // B O O O
+        // B O O O
+        // B B B B
+
+        // Bbox check
+        assertEquals(chunk.bbox().getSize().getX(), 4, "x-size");
+        assertEquals(chunk.bbox().getSize().getY(), 3, "y-size");
+        assertEquals(chunk.bbox().getMin().getX(), -1, "x-min");
+        assertEquals(chunk.bbox().getMin().getY(), -1, "y-min");
+
+        // Pixel check
+        assertEquals(chunk.get(-1, -1), GeometryModel.BORDER,  "(-1, -1)");
+        assertEquals(chunk.get( 0, -1), GeometryModel.OUTSIDE, "(0, -1)");
+        assertEquals(chunk.get( 1, -1), GeometryModel.OUTSIDE, "(1, -1)");
+        assertEquals(chunk.get( 2, -1), GeometryModel.OUTSIDE, "(2, -1)");
+        assertEquals(chunk.get(-1,  0), GeometryModel.BORDER,  "(-1, 0)");
+        assertEquals(chunk.get( 0,  0), GeometryModel.OUTSIDE, "(0, 0)");
+        assertEquals(chunk.get( 1,  0), GeometryModel.OUTSIDE, "(1, 0)");
+        assertEquals(chunk.get( 2,  0), GeometryModel.OUTSIDE, "(2, 0)");
+        assertEquals(chunk.get(-1,  1), GeometryModel.BORDER,  "(-1, 1)");
+        assertEquals(chunk.get( 0,  1), GeometryModel.BORDER,  "(0, 1)");
+        assertEquals(chunk.get( 1,  1), GeometryModel.BORDER,  "(1, 1)");
+        assertEquals(chunk.get( 2,  1), GeometryModel.BORDER,  "(2, 1)");
+    }
+
+    @Test
+    public void testPolygonRasterization() throws TransformException {
+        Coordinate[] coords = {
+            new Coordinate(-2.0, -2.0),
+            new Coordinate( 2.0,  2.0),
+            new Coordinate( 2.0, -2.0),
+            new Coordinate(-2.0, -2.0)};
+        GeometryModel model = new GeometryModel(factory.createPolygon(coords), converter);
+        ReadableChunk2d chunk = model.getChunk();
+
+        // Expected :
+        // 1 1 1 1 1
+        // 0 1 2 2 1
+        // 0 0 1 2 1
+        // 0 0 0 1 1
+        // 0 0 0 0 1
+
+        // Bbox check
+        assertEquals(chunk.bbox().getSize().getX(), 5, "x-size");
+        assertEquals(chunk.bbox().getSize().getY(), 5, "y-size");
+        assertEquals(chunk.bbox().getMin().getX(), -2, "x-min");
+        assertEquals(chunk.bbox().getMin().getY(), -2, "y-min");
+
+        // Pixel check
+        assertEquals(chunk.get(-2, -2), GeometryModel.BORDER,  "(-2,-2)");
+        assertEquals(chunk.get(-1, -2), GeometryModel.BORDER,  "(-1, -2)");
+        assertEquals(chunk.get( 0, -2), GeometryModel.BORDER,  "(0, -2)");
+        assertEquals(chunk.get( 1, -2), GeometryModel.BORDER,  "(1, -2)");
+        assertEquals(chunk.get( 2, -2), GeometryModel.BORDER,  "(2, -2)");
+
+        assertEquals(chunk.get(-2, -1), GeometryModel.OUTSIDE, "(-2, -1)");
+        assertEquals(chunk.get(-1, -1), GeometryModel.BORDER,  "(-1, -1)");
+        assertEquals(chunk.get( 0, -1), GeometryModel.INSIDE,  "(0, -1)");
+        assertEquals(chunk.get( 1, -1), GeometryModel.INSIDE,  "(1, -1)");
+        assertEquals(chunk.get( 2, -1), GeometryModel.BORDER,  "(2, -1)");
+
+        assertEquals(chunk.get(-2,  0), GeometryModel.OUTSIDE, "(-2, 0)");
+        assertEquals(chunk.get(-1,  0), GeometryModel.OUTSIDE, "(-1, 0)");
+        assertEquals(chunk.get( 0,  0), GeometryModel.BORDER,  "(0, 0)");
+        assertEquals(chunk.get( 1,  0), GeometryModel.INSIDE,  "(1, 0)");
+        assertEquals(chunk.get( 2,  0), GeometryModel.BORDER,  "(2, 0)");
+
+        assertEquals(chunk.get(-2,  1), GeometryModel.OUTSIDE, "(-2, 1)");
+        assertEquals(chunk.get(-1,  1), GeometryModel.OUTSIDE, "(-1, 1)");
+        assertEquals(chunk.get( 0,  1), GeometryModel.OUTSIDE, "(0, 1)");
+        assertEquals(chunk.get( 1,  1), GeometryModel.BORDER,  "(1, 1)");
+        assertEquals(chunk.get( 2,  1), GeometryModel.BORDER,  "(2, 1)");
+
+        assertEquals(chunk.get(-2,  2), GeometryModel.OUTSIDE, "(-2, 2)");
+        assertEquals(chunk.get(-1,  2), GeometryModel.OUTSIDE, "(-1, 2)");
+        assertEquals(chunk.get( 0,  2), GeometryModel.OUTSIDE, "(0, 2)");
+        assertEquals(chunk.get( 1,  2), GeometryModel.OUTSIDE, "(1, 2)");
+        assertEquals(chunk.get( 2,  2), GeometryModel.BORDER,  "(2, 2)");
+    }
+
+    @Test
+    public void testPolygonWithHoleRasterization() throws TransformException {
+        Coordinate[] shapecoords = {
+            new Coordinate(-2.0, -2.0),
+            new Coordinate(-2.0,  2.0),
+            new Coordinate( 2.0,  2.0),
+            new Coordinate( 2.0, -2.0),
+            new Coordinate(-2.0, -2.0)};
+        Coordinate[] holecoords = {
+            new Coordinate(-2.0, -2.0),
+            new Coordinate( 2.0,  2.0),
+            new Coordinate( 2.0, -2.0),
+            new Coordinate(-2.0, -2.0)};
+
+        LinearRing[] holes = { (LinearRing)factory.createLinearRing(holecoords) };
+        LinearRing shape = (LinearRing)factory.createLinearRing(shapecoords);
+
+        GeometryModel model = new GeometryModel(factory.createPolygon(shape, holes), converter);
+        ReadableChunk2d chunk = model.getChunk();
+
+        // Expected :
+        // 1 1 1 1 1
+        // 1 1 0 0 1
+        // 1 2 1 0 1
+        // 1 2 2 1 1
+        // 1 1 1 1 1
+
+        // Bbox check
+        assertEquals(chunk.bbox().getSize().getX(), 5, "x-size");
+        assertEquals(chunk.bbox().getSize().getY(), 5, "y-size");
+        assertEquals(chunk.bbox().getMin().getX(), -2, "x-min");
+        assertEquals(chunk.bbox().getMin().getY(), -2, "y-min");
+
+        // Pixel check
+        assertEquals(chunk.get(-2, -2), GeometryModel.BORDER,  "(-2,-2)");
+        assertEquals(chunk.get(-1, -2), GeometryModel.BORDER,  "(-1, -2)");
+        assertEquals(chunk.get( 0, -2), GeometryModel.BORDER,  "(0, -2)");
+        assertEquals(chunk.get( 1, -2), GeometryModel.BORDER,  "(1, -2)");
+        assertEquals(chunk.get( 2, -2), GeometryModel.BORDER,  "(2, -2)");
+
+        assertEquals(chunk.get(-2, -1), GeometryModel.BORDER,  "(-2, -1)");
+        assertEquals(chunk.get(-1, -1), GeometryModel.BORDER,  "(-1, -1)");
+        assertEquals(chunk.get( 0, -1), GeometryModel.OUTSIDE, "(0, -1)");
+        assertEquals(chunk.get( 1, -1), GeometryModel.OUTSIDE, "(1, -1)");
+        assertEquals(chunk.get( 2, -1), GeometryModel.BORDER,  "(2, -1)");
+
+        assertEquals(chunk.get(-2,  0), GeometryModel.BORDER,  "(-2, 0)");
+        assertEquals(chunk.get(-1,  0), GeometryModel.INSIDE,  "(-1, 0)");
+        assertEquals(chunk.get( 0,  0), GeometryModel.BORDER,  "(0, 0)");
+        assertEquals(chunk.get( 1,  0), GeometryModel.OUTSIDE, "(1, 0)");
+        assertEquals(chunk.get( 2,  0), GeometryModel.BORDER,  "(2, 0)");
+
+        assertEquals(chunk.get(-2,  1), GeometryModel.BORDER,  "(-2, 1)");
+        assertEquals(chunk.get(-1,  1), GeometryModel.INSIDE,  "(-1, 1)");
+        assertEquals(chunk.get( 0,  1), GeometryModel.INSIDE,  "(0, 1)");
+        assertEquals(chunk.get( 1,  1), GeometryModel.BORDER,  "(1, 1)");
+        assertEquals(chunk.get( 2,  1), GeometryModel.BORDER,  "(2, 1)");
+
+        assertEquals(chunk.get(-2,  2), GeometryModel.BORDER,  "(-2, 2)");
+        assertEquals(chunk.get(-1,  2), GeometryModel.BORDER,  "(-1, 2)");
+        assertEquals(chunk.get( 0,  2), GeometryModel.BORDER,  "(0, 2)" );
+        assertEquals(chunk.get( 1,  2), GeometryModel.BORDER,  "(1, 2)");
+        assertEquals(chunk.get( 2,  2), GeometryModel.BORDER,  "(2, 2)" );
+    }
+}


### PR DESCRIPTION
Cette PR ajoute les classes nécessaires à la rasterisation des données vectorielles.

Une petite demo ajoutant des batiments sur la carte a été ajoutée au main. Elle peut se lancer ainsi:

```
cd minalac-generator
mvn compile && mvn exec:java -Dexec.mainClass="com.ignfab.minalac.generator.SampleImplementation" -Dexec.args="$HOME/.minetest/worlds/minalac EPSG:2154 600000 6340000 1000 1000 1.0 10.0"
```
