### PR TITLE
Amélioration des perfomances de la sauvegarde

### DIFF
--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/utils/Serializer.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/utils/Serializer.java
@@ -5,31 +5,52 @@ import com.ignfab.minalac.generator.outputs.minetest.Block;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.BufferedOutputStream;
 import java.util.Map;
 import java.util.zip.DeflaterOutputStream;
+import java.util.zip.Deflater;
 
 public class Serializer {
 
+    // We use a static buffer to convert int32 and int64 to bytes.
+    // This avoid usage of OutputBuffer.write(int) which performs something similar
+    // but with a byte array instantiation for each call.
+    private final byte[] buffer;
+
+    // Using a static deflater avoids many useless instantiations.
+    private final Deflater deflater;
+
+    public Serializer() {
+        buffer = new byte[8192];
+        deflater = new Deflater(Deflater.BEST_COMPRESSION);
+    }
+
     private void write8Bits(OutputStream stream, int value) throws IOException {
-        stream.write((byte) (value & 0xFF));
+        buffer[0] = (byte) (value & 0xFF);
+        stream.write(buffer, 0, 1);
     }
 
     private void write16Bits(OutputStream stream, int value) throws IOException {
-        stream.write((byte) ((value >> 8) & 0xFF));
-        stream.write((byte) (value & 0xFF));
+        buffer[0] = (byte) ((value >> 8) & 0xFF);
+        buffer[1] = (byte) (value & 0xFF);
+        stream.write(buffer, 0, 2);
     }
 
     private void write32Bits(OutputStream stream, int value) throws IOException {
-        stream.write((byte) ((value >> 24) & 0xFF));
-        stream.write((byte) ((value >> 16) & 0xFF));
-        stream.write((byte) ((value >> 8) & 0xFF));
-        stream.write((byte) (value & 0xFF));
+        buffer[0] = (byte) ((value >> 24) & 0xFF);
+        buffer[1] = (byte) ((value >> 16) & 0xFF);
+        buffer[2] = (byte) ((value >> 8) & 0xFF);
+        buffer[3] = (byte) (value & 0xFF);
+        stream.write(buffer, 0, 4);
     }
 
     private void writeParam0IntoStream(OutputStream stream, Block block) throws IOException {
-        for (short param0 : block.getParam0()) {
-            write16Bits(stream, param0);
+        int i = 0;
+        for (short value : block.getParam0()) {
+            buffer[i++] = (byte) ((value >> 8) & 0xFF);
+            buffer[i++] = (byte) (value & 0xFF);
         }
+        stream.write(buffer);
     }
 
     //See World Format Documentation for more information about block serialization
@@ -57,7 +78,7 @@ public class Serializer {
     //See World Format Documentation for version 28
     //https://github.com/minetest/minetest/blob/master/doc/world_format.md
     public byte[] serialize(Block block) throws IOException {
-        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        ByteArrayOutputStream stream = new ByteArrayOutputStream(16384);
 
         //u8 : map version number
         write8Bits(stream, 28);
@@ -75,20 +96,25 @@ public class Serializer {
         write8Bits(stream, 2);
 
         //Zlib Node data
-        DeflaterOutputStream nodeDataStream = new DeflaterOutputStream(stream);
+        DeflaterOutputStream nodeDataStream = new DeflaterOutputStream(stream, deflater);
+
         writeParam0IntoStream(nodeDataStream, block);
         nodeDataStream.write(block.getParam1());
         nodeDataStream.write(block.getParam2());
+
         nodeDataStream.flush();
         nodeDataStream.finish();
+        deflater.reset();
 
         //Zlib Node metadata
-        DeflaterOutputStream nodeMetadataStream = new DeflaterOutputStream(stream);
+        DeflaterOutputStream nodeMetadataStream = new DeflaterOutputStream(stream, deflater);
+
         //u8 : version
         write16Bits(nodeMetadataStream, 2);
         write16Bits(nodeMetadataStream, 0);
         nodeMetadataStream.flush();
         nodeMetadataStream.finish();
+        deflater.reset();
 
         //u8 : static object version
         write8Bits(stream, 0);

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/utils/SqlLiteMapWriter.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/utils/SqlLiteMapWriter.java
@@ -9,33 +9,31 @@ import java.nio.file.Paths;
 import java.sql.*;
 
 public class SqlLiteMapWriter {
-    private Connection sqlFileConnector;
+    private Connection connection;
     private Serializer serializer;
 
     public SqlLiteMapWriter(String directoryFullPath) throws MapWriteException {
         if (!Files.exists(Paths.get(directoryFullPath)))
             throw new MapWriteException("The directory can not be accessed");
-        this.sqlFileConnector = createAndConnectToFileDB(directoryFullPath);
+        createAndConnectToFileDB(directoryFullPath);
         this.serializer = new Serializer();
     }
 
-    private Connection createAndConnectToFileDB(String directoryFullPath) throws MapWriteException {
-        Connection connection;
+    private void createAndConnectToFileDB(String directoryFullPath) throws MapWriteException {
         try {
             String pathDBFile = "jdbc:sqlite:" + directoryFullPath + "map.sqlite";
-            String statementTableBlock = "CREATE TABLE `blocks` (`pos` INT NOT NULL PRIMARY KEY,`data` BLOB);";
             connection = DriverManager.getConnection(pathDBFile);
-            Statement createTable = connection.createStatement();
-            createTable.execute(statementTableBlock);
+            Statement statement = connection.createStatement();
+            statement.execute("PRAGMA synchronous=OFF");
+            statement.execute("CREATE TABLE `blocks` (`pos` INT NOT NULL PRIMARY KEY,`data` BLOB)");
         } catch (SQLException e) {
             throw new MapWriteException(e.getMessage());
         }
-        return connection;
     }
 
     public void insertBlock(int pos, Block block) throws MapWriteException {
         try {
-            PreparedStatement statement = sqlFileConnector.prepareStatement("INSERT INTO blocks VALUES (?,?)");
+            PreparedStatement statement = connection.prepareStatement("INSERT INTO blocks VALUES (?,?)");
             statement.setInt(1, pos);
             statement.setBytes(2, this.serializer.serialize(block));
             statement.execute();


### PR DESCRIPTION
Cela fonctionne en demandant à la base sqlite de ne pas se synchroniser à chaque requête SQL.
Le seul inconvéniant est que la base risque d'être corrompue si le systeme de fichiers tombe. Dans ce cas, cela importe peu, plus rien ne fonctionnera et il faudra recommencer la génération.

Pour tester: lancer la même commande avec ou sans le commit et mesurer le temps de traitement.