### PR TITLE
feat(generation): Move projection & conversion stuff to Generation class

### DIFF
--- a/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
+++ b/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
@@ -12,17 +12,15 @@ import org.xml.sax.SAXException;
 
 import org.geotools.referencing.CRS;
 import org.geotools.api.feature.simple.SimpleFeature;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.api.referencing.NoSuchAuthorityCodeException;
 import org.geotools.api.referencing.FactoryException;
 import org.geotools.api.referencing.operation.TransformException;
 import org.geotools.data.simple.SimpleFeatureIterator;
 import org.geotools.data.simple.SimpleFeatureCollection;
 
-import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
-import org.locationtech.jts.geom.GeometryFactory;
-import org.locationtech.jts.geom.util.AffineTransformation;
 
 import com.ignfab.minalac.generator.world.*;
 import com.ignfab.minalac.generator.outputs.minetest.MTVoxelWorld;
@@ -52,7 +50,8 @@ public class SampleImplementation {
             String directoryPath = args[0];
 
             //Example : "EPSG:2154"
-            String crs = args[1];
+            String crsName = args[1];
+            CoordinateReferenceSystem crs = CRS.decode(crsName);
 
             // Center coordinates (in CRS), example : 600000 6340000
             // TODO: Center should be in Lon/lat in WGS84
@@ -71,46 +70,20 @@ public class SampleImplementation {
 
             System.out.println("Creation of the map.");
 
-            // For now:
-            // - We use same CRS for all layers
-            // - Center is already in this CRS
+            Generation generation = new Generation(
+                crs,
+                centerX, centerY,
+                extendX, extendY,
+                horizontalScale, verticalScale
+            );
 
-            // Affine tranformation:
-            // - Translation : center to 0,0
-            // - Rotation : not yet implemented
-            // - Scale : horizontal scale
-
-            AffineTransformation crsToVoxel = new AffineTransformation();
-            crsToVoxel.translate(-centerX, -centerY);
-            // crsToVoxel.rotate(rotate * pi / 180.0, 0.0, 0.0);
-            crsToVoxel.scale(1.0 / horizontalScale, 1.0 / horizontalScale);
-
-            AffineTransformation voxelToCrs = new AffineTransformation();
-            voxelToCrs.scale(horizontalScale, horizontalScale);
-            // VoxelToCrs.rotate(- rotate * pi / 180.0, 0.0, 0.0);
-            voxelToCrs.translate(centerX, centerY);
-
-            // Map BBox
-            Coordinate corners[] = {
-                new Coordinate((float) extendX / 2, (float) extendY / 2),
-                new Coordinate((float) extendX / 2, - (float) extendY / 2),
-                new Coordinate(- (float) extendX / 2, (float) extendY / 2),
-                new Coordinate(- (float) extendX / 2, - (float) extendY / 2),
-                new Coordinate((float) extendX / 2, (float) extendY / 2)
-            };
-
-            Geometry box = new GeometryFactory().createLinearRing(corners);
-            Envelope envelope = voxelToCrs.transform(box).getEnvelopeInternal();
-
+            Envelope envelope = generation.getEnvelopeForCRS(crs);
             String bboxURL = "BBOX=" + envelope.getMinX() + "," + envelope.getMinY() + "," + envelope.getMaxX() + "," + envelope.getMaxY();
 
             // Creation of heightmap
 
             System.out.println("Downloading height map");
-            HeightMap heightMap = createGroundHeightMap("https://data.geopf.fr/wms-r/wms?LAYERS=RGEALTI-MNT_PYR-ZIP_FXX_LAMB93_WMS&FORMAT=image/x-bil;bits=32&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&STYLES=&CRS=" + crs + "&" + bboxURL, extendX, extendY, verticalScale);
-
-            // TODO: A lot of above code should end up in Generation class
-            Generation generation = new Generation(CRS.decode(crs), crsToVoxel); // This is supposed to be the target CRS
+            HeightMap heightMap = createGroundHeightMap("https://data.geopf.fr/wms-r/wms?LAYERS=RGEALTI-MNT_PYR-ZIP_FXX_LAMB93_WMS&FORMAT=image/x-bil;bits=32&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&STYLES=&CRS=" + crsName + "&" + bboxURL, extendX, extendY, verticalScale);
 
             System.out.println("World creation");
             VoxelWorld world = new MTVoxelWorld();
@@ -121,7 +94,7 @@ public class SampleImplementation {
             System.out.println("Add vector layer");
             WFS2DataProvider provider = new WFS2DataProvider("https://data.geopf.fr/wfs/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=BDTOPO_V3:batiment&STARTINDEX=0&COUNT=1000&SRSNAME=urn:ogc:def:crs:EPSG::2154&" + bboxURL +",urn:ogc:def:crs:EPSG::2154");
             placeVectorFeatures(provider.getFeatures(),
-                generation.makeCoordsConverter(CRS.decode(crs)), // This is supposed to be the layer CRS (actually the same for this demo)
+                generation.makeCoordsConverter(crs), // This is supposed to be the layer CRS (actually the same for this demo)
                 world, heightMap);
 
             System.out.println("Saving");

--- a/src/main/java/com/ignfab/minalac/generator/generation/Generation.java
+++ b/src/main/java/com/ignfab/minalac/generator/generation/Generation.java
@@ -1,10 +1,18 @@
 package com.ignfab.minalac.generator.generation;
 
-import org.geotools.referencing.CRS;
-import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
-import org.geotools.api.referencing.FactoryException;
-import org.geotools.api.referencing.operation.MathTransform;
+import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
 
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.api.referencing.operation.MathTransform;
+import org.geotools.api.referencing.operation.TransformException;
+import org.geotools.geometry.jts.JTS;
+import org.geotools.referencing.CRS;
+
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.util.AffineTransformation;
 
 /**
@@ -13,18 +21,92 @@ import org.locationtech.jts.geom.util.AffineTransformation;
  * Contains stuff about ongoing generation and its context.
  */
 public class Generation {
+    // Target coordinate reference system (CRS used for voxel world rendering)
     private CoordinateReferenceSystem crs;
-    private AffineTransformation transformation;
+
+    // Vertical size of voxel in target CRS units
+    private double verticalScale;
+
+    // Transformations from and to target CRS
+    private AffineTransformation crsToVoxel, voxelToCrs;
+
+    // TODO: use a 3d bbox when its implemented:
+    private WorldBBox2d worldBBox;
 
     /**
      * Constructs a new generation context.
      *
-     * @param crs Coordinate reference system used for generated world.
-     * @param transformation Two dimensions affine transformation applied to world (usually rotation + scale).
+     * @param crs Coordinate reference system used for generated world
+     * @param centerX Generation center x-coordinate (in generated world CRS)
+     * @param centerY Generation center y-coordinate (in generated world CRS)
+     * @param extendX Generated world size (in voxels) along x-coordinates
+     * @param extendY Generated world size (in voxels) along y-coordinates
+     * @param horizontalScale Horizontal size of voxel in CRS units
+     * @param verticalScale Vertical size of voxel in CRS units
      */
-    public Generation(CoordinateReferenceSystem crs, AffineTransformation transformation) {
+    public Generation(
+        CoordinateReferenceSystem crs,
+        double centerX,
+        double centerY,
+        int extendX,
+        int extendY,
+        double horizontalScale,
+        double verticalScale) {
+
+        // For now:
+        // - Center is in target CRS (should be lon/lat).
+        // - Rotation is not yet implemented (should be).
+
         this.crs = crs;
-        this.transformation = transformation;
+        this.verticalScale = verticalScale;
+
+        // Voxel BBox
+        worldBBox = new WorldBBox2d(-extendX / 2, -extendY / 2, extendX, extendY);
+
+        // CRS to Voxel transformation (basically, translates, rotates and scale)
+        crsToVoxel = new AffineTransformation();
+        crsToVoxel.translate(-centerX, -centerY);
+        // crsToVoxel.rotate(rotate * pi / 180.0, 0.0, 0.0);
+        crsToVoxel.scale(1.0 / horizontalScale, 1.0 / horizontalScale);
+
+        // Voxel to CRS transformation (reverse of crsToVoxel transformation)
+        voxelToCrs = new AffineTransformation();
+        voxelToCrs.scale(horizontalScale, horizontalScale);
+        // VoxelToCrs.rotate(- rotate * pi / 180.0, 0.0, 0.0);
+        voxelToCrs.translate(centerX, centerY);
+    }
+
+    /**
+     * Returns geographic envelope (bounding box equivalent) of generated world
+     * in a given CRS.
+     *
+     * @param crs Coordinate reference system to get envelope for.
+     *
+     * @return Envelope covering generated world in CRS.
+     */
+    public Envelope getEnvelopeForCRS(CoordinateReferenceSystem crs) throws FactoryException, TransformException {
+        MathTransform crsTransform = CRS.findMathTransform(this.crs, crs);
+
+        Coordinate[] corners = {
+            new Coordinate(worldBBox.getMinX(), worldBBox.getMinY()),
+            new Coordinate(worldBBox.getMaxX(), worldBBox.getMinY()),
+            new Coordinate(worldBBox.getMaxX(), worldBBox.getMaxY()),
+            new Coordinate(worldBBox.getMinX(), worldBBox.getMaxY()),
+            new Coordinate(worldBBox.getMinX(), worldBBox.getMinY())
+        };
+
+        Geometry geom = voxelToCrs.transform(new GeometryFactory().createLinearRing(corners));
+
+        return JTS.transform(geom, crsTransform).getEnvelopeInternal();
+    }
+
+    /**
+     * Returns World 2d box in voxels
+     *
+     * @return a WorldBBox2d representing horizontal world size
+     */
+    public WorldBBox2d getWorldBBox2d() {
+        return worldBBox;
     }
 
     /**
@@ -35,7 +117,6 @@ public class Generation {
      * @throws FactoryException If not suitable transformation found for conversion.
      */
     public CoordsConverter makeCoordsConverter(CoordinateReferenceSystem sourceCrs) throws FactoryException {
-        MathTransform crsTransform = CRS.findMathTransform(sourceCrs, crs);
-        return new CoordsConverter(crsTransform, transformation);
+        return new CoordsConverter(CRS.findMathTransform(sourceCrs, crs), crsToVoxel);
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/utils/world2d/WorldBBox2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world2d/WorldBBox2d.java
@@ -86,6 +86,24 @@ public class WorldBBox2d {
     }
 
     /**
+     * Returns the bounding box size along the x-axis.
+     *
+     * @return the bounding box size along the x-axis.
+     */
+    public int getSizeX() {
+        return size.getX();
+    }
+
+    /**
+     * Returns the bounding box size along the y-axis.
+     *
+     * @return the bounding box size along the y-axis.
+     */
+    public int getSizeY() {
+        return size.getY();
+    }
+
+    /**
      * Returns the minimum point.
      *
      * @return the {@code WorldCoords2d} of the minimum point.
@@ -95,12 +113,48 @@ public class WorldBBox2d {
     }
 
     /**
+     * Returns the minimum point x-coordinate.
+     *
+     * @return the x-coordinate of the minimum point.
+     */
+    public int getMinX() {
+        return min.getX();
+    }
+
+    /**
+     * Returns the minimum point y-coordinate.
+     *
+     * @return the y-coordinate of the minimum point.
+     */
+    public int getMinY() {
+        return min.getY();
+    }
+
+    /**
      * Returns the maximum point.
      *
      * @return the {@code WorldCoords2d} of the maximum point.
      */
     public WorldCoords2d getMax() {
         return max;
+    }
+
+    /**
+     * Returns the maximum point x-coordinate.
+     *
+     * @return the x-coordinate of the maximum point.
+     */
+    public int getMaxX() {
+        return max.getX();
+    }
+
+    /**
+     * Returns the maximum point y-coordinate.
+     *
+     * @return the y-coordinate of the maximum point.
+     */
+    public int getMaxY() {
+        return max.getY();
     }
 
     /**

--- a/src/test/java/com/ignfab/minalac/generator/generation/TestGeneration.java
+++ b/src/test/java/com/ignfab/minalac/generator/generation/TestGeneration.java
@@ -1,0 +1,49 @@
+package com.ignfab.minalac.generator.generation;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.operation.TransformException;
+import org.geotools.referencing.CRS;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+
+import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
+
+public class TestGeneration {
+    @Test
+    public void testGeneration() throws FactoryException, TransformException {
+        CoordinateReferenceSystem crs = CRS.decode("EPSG:2154");
+        Generation generation = new Generation(crs, 601000.0, 6341000.0, 501, 501, 2.0, 3.0);
+
+        WorldBBox2d box = generation.getWorldBBox2d();
+        assertEquals(-250, box.getMinX());
+        assertEquals(-250, box.getMinY());
+        assertEquals(250, box.getMaxX());
+        assertEquals(250, box.getMaxY());
+
+        // We should have an envelope +/- 500 around center (250 voxel * 2.0 meters/voxels = 500m)
+        Envelope envelope = generation.getEnvelopeForCRS(crs);
+        assertEquals(600500.0, envelope.getMinX(), 0.01);
+        assertEquals(6340500.0, envelope.getMinY(), 0.01);
+        assertEquals(601500.0, envelope.getMaxX(), 0.01);
+        assertEquals(6341500.0, envelope.getMaxY(), 0.01);
+
+        // Try another CRS
+        envelope = generation.getEnvelopeForCRS(CRS.decode("EPSG:4326"));
+        assertEquals(44.1564, envelope.getMinX(), 0.0002);
+        assertEquals(1.7559, envelope.getMinY(), 0.0002);
+
+        // Coords converter from WSG84
+        CoordsConverter converter = generation.makeCoordsConverter(CRS.decode("EPSG:4326"));
+        // 44.1655934, 1.7682873 is WSG84 for 601500, 6341500 which correspond to voxel 250,250.
+        Geometry geometry = new GeometryFactory().createPoint(new Coordinate(44.1655934, 1.7682873));
+        geometry = converter.convert(geometry);
+        assertEquals(250.0, geometry.getCoordinate().x, 0.01);
+        assertEquals(250.0, geometry.getCoordinate().y, 0.01);
+    }
+}


### PR DESCRIPTION
Cette PR déplace une partie du code écrit dans SampleImplementation vers sa classe de destination, Generation.
Des tests ont été ajoutés mais le fonctionnement global n'a pas changé.