### PR TITLE
Add basic vector renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,37 @@
-# Compile
-```
+# How to use that stuff
+Place yourself into proper directory:
+```shell
 cd minalac-generator
-mvn clean package
-```
-
-# Test
-```
-cd minalac-generator
-mvn test
-```
-
-# Validate code-style
-```
-cd minalac-generator
-mvn verify
-```
-
-# Execute
-```
-cd minalac-generator
-mvn package && java -jar ./target/Generator.jar $HOME/.minetest/worlds/minalac EPSG:2154 600000 6340000 1000 1000 1.0 10.0 minetest
 ```
 
 If behind a proxy, don't forget to:
-```
+```shell
 export JAVA_OPTS="-Dhttp.proxyHost=proxy.ign.fr -Dhttp.proxyPort=3128 -Dhttps.proxyHost=proxy.ign.fr -Dhttps.proxyPort=3128"
+# For Oracle Java:
+export JAVA_TOOL_OPTIONS=$JAVA_OPTS
+# For Maven:
 export MAVEN_OPTS=$JAVA_OPTS
 ```
+
+## Compile
+```shell
+mvn clean package
+```
+
+## Test
+```shell
+mvn test
+```
+
+## Validate code-style
+```shell
+mvn verify
+```
+
+## Execute
+```shell
+mvn package && java -jar ./target/Generator.jar $HOME/.minetest/worlds/minalac EPSG:2154 600000 6340000 1000 1000 1.0 10.0 minetest
+```
+
+For parameters explanation, refer to comments in `SampleImplementation` class.
+

--- a/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
+++ b/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
@@ -1,21 +1,17 @@
 package com.ignfab.minalac.generator;
 
-import com.ignfab.minalac.generator.generation.CoordsConverter;
-import com.ignfab.minalac.generator.generation.Generation;
-import com.ignfab.minalac.generator.inputs.WFS2DataProvider;
-import com.ignfab.minalac.generator.models.BufferedImageChunk;
+
 import com.ignfab.minalac.generator.models.GeometryModel;
+import com.ignfab.minalac.generator.models.Model;
 import com.ignfab.minalac.generator.outputs.minecraft.MCVoxelWorld;
 import com.ignfab.minalac.generator.outputs.minetest.MTVoxelWorld;
+import com.ignfab.minalac.generator.generation.CoordsConverter;
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.generation.HeightMap;
+import com.ignfab.minalac.generator.inputs.WFS2DataProvider;
+import com.ignfab.minalac.generator.renderers.VectorRenderer;
 import com.ignfab.minalac.generator.utils.network.HttpTrustAllSSL;
-import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
-import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
-import com.ignfab.minalac.generator.utils.world2d.WorldSize2d;
-import com.ignfab.minalac.generator.utils.world2d.chunk.ArrayChunk2d;
-import com.ignfab.minalac.generator.utils.world2d.chunk.IterableChunk2d;
 import com.ignfab.minalac.generator.utils.world2d.iterator.Chunk2dElement;
-import com.ignfab.minalac.generator.utils.world2d.iterator.Chunk2dIterator;
-import com.ignfab.minalac.generator.utils.world2d.iterator.Chunk2dIteratorAll;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
 import com.ignfab.minalac.generator.world.MapWriteException;
@@ -43,6 +39,9 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -107,22 +106,28 @@ public final class SampleImplementation {
             Envelope envelope = generation.getEnvelopeForCRS(crs);
             String bboxURL = "BBOX=" + envelope.getMinX() + "," + envelope.getMinY() + "," + envelope.getMaxX() + "," + envelope.getMaxY();
 
-            // Creation of heightmap
-
+            // Downloads
             System.out.println("Downloading height map");
             HeightMap heightMap = createGroundHeightMap("https://data.geopf.fr/wms-r/wms?LAYERS=RGEALTI-MNT_PYR-ZIP_FXX_LAMB93_WMS&FORMAT=image/x-bil;bits=32&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&STYLES=&CRS=" + crsName + "&" + bboxURL, extendX, extendY, verticalScale);
+
+            System.out.println("Downloading buildings");
+            WFS2DataProvider provider = new WFS2DataProvider("https://data.geopf.fr/wfs/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=BDTOPO_V3:batiment&STARTINDEX=0&COUNT=1000&SRSNAME=urn:ogc:def:crs:EPSG::2154&" + bboxURL + ",urn:ogc:def:crs:EPSG::2154");
+            Collection<Model> buildingModels = fetchVectorModels(
+                provider.getFeatures(),
+                generation.makeCoordsConverter(crs) // This is supposed to be the layer CRS (actually the same for this demo)
+            );
 
             System.out.println("World creation");
             VoxelWorld world = FORMATS.get(format).get();
             System.out.println("Placing ground");
             placeVoxelFromHeightMap(heightMap, world);
 
-            // Add a vector layer
-            System.out.println("Add vector layer");
-            WFS2DataProvider provider = new WFS2DataProvider("https://data.geopf.fr/wfs/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=BDTOPO_V3:batiment&STARTINDEX=0&COUNT=1000&SRSNAME=urn:ogc:def:crs:EPSG::2154&" + bboxURL + ",urn:ogc:def:crs:EPSG::2154");
-            placeVectorFeatures(provider.getFeatures(),
-                generation.makeCoordsConverter(crs), // This is supposed to be the layer CRS (actually the same for this demo)
-                world, heightMap);
+            System.out.println("Placing buildings");
+            new VectorRenderer(
+                heightMap, buildingModels,
+                world.getFactory().createVoxelType(SemanticType.COBBLE),
+                world.getFactory().createVoxelType(SemanticType.BRICK)
+            ).render();
 
             System.out.println("Saving");
             VoxelWorldMetadata metadata = world.getMetadata();
@@ -140,39 +145,20 @@ public final class SampleImplementation {
         System.out.println("Execution time: " + (end - start) / 1000 + "s");
     }
 
-    private static void placeVectorFeatures(SimpleFeatureCollection features, CoordsConverter converter, VoxelWorld world, HeightMap heightMap)
-        throws TransformException, OutOfWorldException {
-        VoxelType insideVT = world.getFactory().createVoxelType(SemanticType.COBBLE);
-        VoxelType wallVT = world.getFactory().createVoxelType(SemanticType.BRICK);
+    private static List<Model> fetchVectorModels(SimpleFeatureCollection features, CoordsConverter converter)
+        throws TransformException {
+        List<Model> models = new LinkedList<>();
+
         try (
             SimpleFeatureIterator iterator = features.features()
         ) {
             while (iterator.hasNext()) {
                 SimpleFeature feature = iterator.next();
-
-                // Create a model out of feature geometry
-                GeometryModel model = new GeometryModel((Geometry) feature.getDefaultGeometry(), converter);
-
-                // Rasterize that model into a chunk
-                BufferedImageChunk chunk = model.getChunk();
-
-                // Iterate over chunk and draw shape on map at heightMap altitude
-                for (Chunk2dElement element : chunk) {
-                    WorldCoords2d c = element.getCoords();
-                    // TODO: Make Iterator able to intersect with another box
-                    // TODO: Have a world bbox rather
-                    if (heightMap.bbox().contains(c))
-                        switch (element.getValue()) {
-                            case GeometryModel.INSIDE:
-                                insideVT.place(c.x(), c.y(), heightMap.get(c) + 1);
-                                break;
-                            case GeometryModel.BORDER:
-                                wallVT.place(c.x(), c.y(), heightMap.get(c) + 1);
-                                break;
-                        }
-                }
+                models.add((Model) (new GeometryModel((Geometry) feature.getDefaultGeometry(), converter)));
             }
         }
+
+        return models;
     }
 
     private static void placeVoxelFromHeightMap(HeightMap map, VoxelWorld world) throws OutOfWorldException {
@@ -250,54 +236,5 @@ public final class SampleImplementation {
                 deleteDirectory(file);
         }
         directoryToBeDeleted.delete();
-    }
-
-    //This class will probably be added on an upcoming pull-request (since it doesn't belong to the package utils.world2d.chunk)
-    @SuppressWarnings("checkstyle:RedundantModifier")
-    private static class HeightMap extends ArrayChunk2d implements IterableChunk2d {
-        protected int minZ;
-        protected int maxZ;
-
-        public HeightMap(int originX, int originY, int sizeX, int sizeY, int defaultValue) {
-            super(originX, originY, sizeX, sizeY, defaultValue);
-            minZ = defaultValue;
-            maxZ = defaultValue;
-        }
-
-        public HeightMap(WorldBBox2d box, int defaultValue) {
-            super(box, defaultValue);
-            minZ = defaultValue;
-            maxZ = defaultValue;
-        }
-
-        public HeightMap(WorldCoords2d coords, WorldSize2d size, int defaultValue) {
-            super(coords, size, defaultValue);
-            minZ = defaultValue;
-            maxZ = defaultValue;
-        }
-
-        @Override
-        public void set(int x, int y, int value) {
-            super.set(x, y, value);
-            minZ = Math.min(minZ, value);
-            maxZ = Math.max(maxZ, value);
-        }
-
-        @Override
-        public Chunk2dIterator iterator() {
-            return new Chunk2dIteratorAll(this);
-        }
-
-        public WorldBBox3d bbox3d() {
-            return bbox.to3d(minZ, maxZ - minZ + 1);
-        }
-
-        public int getMinZ() {
-            return minZ;
-        }
-
-        public int getMaxZ() {
-            return maxZ;
-        }
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/generation/HeightMap.java
+++ b/src/main/java/com/ignfab/minalac/generator/generation/HeightMap.java
@@ -1,0 +1,59 @@
+package com.ignfab.minalac.generator.generation;
+
+import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
+import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
+import com.ignfab.minalac.generator.utils.world2d.WorldSize2d;
+import com.ignfab.minalac.generator.utils.world2d.chunk.ArrayChunk2d;
+import com.ignfab.minalac.generator.utils.world2d.chunk.IterableChunk2d;
+import com.ignfab.minalac.generator.utils.world2d.iterator.Chunk2dIterator;
+import com.ignfab.minalac.generator.utils.world2d.iterator.Chunk2dIteratorAll;
+
+/**
+ * A 2d height map in voxel world units.
+ */
+public class HeightMap extends ArrayChunk2d implements IterableChunk2d {
+
+    /**
+     * Constructs a new HeightMap.
+     *
+     * @param originX X-coordinate of origin point
+     * @param originY Y-coordinate of origin point
+     * @param sizeX Size of height map along X-axis
+     * @param sizeY Size of height map along Y-axis
+     * @param defaultValue Default value for all height map cells
+     */
+    public HeightMap(int originX, int originY, int sizeX, int sizeY, int defaultValue) {
+        super(originX, originY, sizeX, sizeY, defaultValue);
+    }
+
+    /**
+     * Constructs a new HeightMap.
+     *
+     * @param box Bounding box of height map
+     * @param defaultValue Default value for all height map cells
+     */
+    public HeightMap(WorldBBox2d box, int defaultValue) {
+        super(box, defaultValue);
+    }
+
+    /**
+     * Constructs a new HeightMap.
+     *
+     * @param origin Origin point of height map
+     * @param size Size of height map
+     * @param defaultValue Default value for all height map cells
+     */
+    public HeightMap(WorldCoords2d origin, WorldSize2d size, int defaultValue) {
+        super(origin, size, defaultValue);
+    }
+
+    /**
+     * Returns a default iterator for a height map.
+     *
+     * @return A {@code Chunk2dIterator} iterating over all elements of the height map
+     */
+    @Override
+    public Chunk2dIterator iterator() {
+        return new Chunk2dIteratorAll(this);
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/models/GeometryModel.java
+++ b/src/main/java/com/ignfab/minalac/generator/models/GeometryModel.java
@@ -19,7 +19,7 @@ import java.awt.Graphics2D;
  * It is rasterizable. Rasterized chunk will include three values:
  * 0: Not in geometry, 1: On its edge, 2: Inside it (polygons only).
  */
-public class GeometryModel implements Rasterizable {
+public class GeometryModel implements Model, Rasterizable {
     private final Geometry geom;
     private BufferedImageChunk chunk;
 
@@ -39,8 +39,6 @@ public class GeometryModel implements Rasterizable {
     private static final Color OUTSIDE_COLOR = BufferedImageChunk.colorFor(OUTSIDE); // Not in shape color
     private static final Color BORDER_COLOR = BufferedImageChunk.colorFor(BORDER); // Shape border color
     private static final Color INSIDE_COLOR = BufferedImageChunk.colorFor(INSIDE); // Inside shape (fill) color
-
-
 
     /**
      * Constructs a new {@code GeometryModel}.
@@ -84,7 +82,7 @@ public class GeometryModel implements Rasterizable {
         Graphics2D graphics = chunk.createGraphics();
 
         // Draw geometry translated into bounding box relative coordinates (i.e. BufferedImage coordinates))
-        Geometry geom = AffineTransformation.translationInstance(-Math.floor(envelope.getMinX()), -Math.floor(envelope.getMinY())).transform(this.geom);
+        Geometry geom = AffineTransformation.translationInstance(-bbox.getMinX(), -bbox.getMinY()).transform(this.geom);
         draw(graphics, geom);
 
         graphics.dispose();

--- a/src/main/java/com/ignfab/minalac/generator/models/Model.java
+++ b/src/main/java/com/ignfab/minalac/generator/models/Model.java
@@ -1,0 +1,3 @@
+package com.ignfab.minalac.generator.models;
+
+public interface Model {}

--- a/src/main/java/com/ignfab/minalac/generator/renderers/HeightMapRenderer.txt
+++ b/src/main/java/com/ignfab/minalac/generator/renderers/HeightMapRenderer.txt
@@ -1,0 +1,9 @@
+package com.ignfab.minalac.generator.renderers;
+
+public class HeightMapRenderer {
+
+    public HeightMapRenderer(HeightMap heightMap, Models models, )
+    --> Il faudrait une interface pour les Raster 32bits ou float
+    --> Il faut faire la classe HeightMap
+
+}

--- a/src/main/java/com/ignfab/minalac/generator/renderers/VectorRenderer.java
+++ b/src/main/java/com/ignfab/minalac/generator/renderers/VectorRenderer.java
@@ -1,0 +1,80 @@
+package com.ignfab.minalac.generator.renderers;
+
+import com.ignfab.minalac.generator.generation.HeightMap;
+import com.ignfab.minalac.generator.models.GeometryModel;
+import com.ignfab.minalac.generator.models.Model;
+import com.ignfab.minalac.generator.models.Rasterizable;
+import com.ignfab.minalac.generator.utils.world2d.chunk.IterableChunk2d;
+import com.ignfab.minalac.generator.utils.world2d.iterator.Chunk2dElement;
+import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
+import com.ignfab.minalac.generator.world.OutOfWorldException;
+import com.ignfab.minalac.generator.world.VoxelType;
+import com.ignfab.minalac.generator.world.VoxelTypeIgnore;
+
+/**
+ * A basic example of vector renderer intended to evolve.
+ */
+public class VectorRenderer {
+
+    private HeightMap heightMap;
+    private Iterable<Model> models;
+
+    // This may evolve in something more elaborated, like edge and inside voxel patterns,
+    // or even closures (one for inside, one for edge and another for init)
+    private VoxelType inside;
+    private VoxelType edge;
+    private static final VoxelType IGNORE = new VoxelTypeIgnore();
+
+    /**
+     * Creates a new VectorRenderer.
+     *
+     * @param heightMap Height map of the ground (on which features will be placed)
+     * @param models Models to be rendered (only Rasterizable ones will be)
+     * @param inside Voxel type to draw inside geometries
+     * @param edge Voxel type to draw on edges of geometries (including points & lines)
+     */
+    public VectorRenderer(HeightMap heightMap, Iterable<Model> models, VoxelType inside, VoxelType edge) {
+        this.heightMap = heightMap;
+        this.models = models;
+        this.inside = inside;
+        this.edge = edge;
+    }
+
+    /**
+     * Performs rendering.
+     */
+    public void render() {
+        for (Model model : models) {
+            if (!(model instanceof Rasterizable rasterizable)) {
+                // TODO: Better warning about not possible to render a non rasterizable model
+                System.out.println("Ignoring non rasterizable model.");
+                continue;
+            }
+
+            if (!(rasterizable.getChunk() instanceof IterableChunk2d chunk)) {
+                // TODO: Better warning about not possible to render a non iterable model
+                System.out.println("Ignoring non iterable chunk.");
+                continue;
+            }
+
+            // Iterate over chunk and draw shape on map at heightMap altitude
+            for (Chunk2dElement element : chunk) {
+                WorldCoords2d c = element.getCoords();
+                // TODO: Make Iterator able to intersect with another box
+                // TODO: Have a world bbox rather
+                try {
+                    if (heightMap.bbox().contains(c)) {
+                        VoxelType vt = switch (element.getValue()) {
+                            case GeometryModel.INSIDE -> inside;
+                            case GeometryModel.BORDER -> edge;
+                            default -> IGNORE; // Should never get there
+                        };
+                        vt.place(c.x(), c.y(), heightMap.get(c) + 1);
+                    }
+                } catch (OutOfWorldException e) {
+                    // TODO: Would be much better to intersect feature and word bbox rather.
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/world/VoxelTypeIgnore.java
+++ b/src/main/java/com/ignfab/minalac/generator/world/VoxelTypeIgnore.java
@@ -1,0 +1,16 @@
+package com.ignfab.minalac.generator.world;
+
+/**
+ * A voxel type that places no voxel. Can be conveniant to pass
+ * as a no-op voxel type to some operation.
+ */
+public class VoxelTypeIgnore implements VoxelType {
+    /**
+     * Does not place any voxel at x, y, z.
+     *
+     * @param x x-coordinate where not to place voxel
+     * @param y y-coordinate where not to place voxel
+     * @param z z-coordinate where not to place voxel
+     */
+    public void place(int x, int y, int z) throws OutOfWorldException {};
+}

--- a/src/test/java/com/ignfab/minalac/generator/models/TestingRasterizableModel.java
+++ b/src/test/java/com/ignfab/minalac/generator/models/TestingRasterizableModel.java
@@ -1,0 +1,28 @@
+package com.ignfab.minalac.generator.models;
+
+import com.ignfab.minalac.generator.utils.world2d.chunk.ReadableChunk2d;
+
+/**
+ * A simple Rasterizable Model implementation for test purposes.
+ * It just stores a given chunk and give it back as return value of {@code getChunk}.
+ */
+public class TestingRasterizableModel implements Model, Rasterizable {
+    private ReadableChunk2d chunk;
+
+    /**
+     * Constructs a new {@code TestingRasterizableModel}.
+     *
+     * @param chunk Chunk to be returned by {@code getChunk}
+     */
+    public TestingRasterizableModel(ReadableChunk2d chunk) {
+        this.chunk = chunk;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ReadableChunk2d getChunk() {
+        return chunk;
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/outputs/testing/TestingVoxelType.java
+++ b/src/test/java/com/ignfab/minalac/generator/outputs/testing/TestingVoxelType.java
@@ -1,0 +1,53 @@
+package com.ignfab.minalac.generator.outputs.testing;
+
+import com.ignfab.minalac.generator.world.OutOfWorldException;
+import com.ignfab.minalac.generator.world.VoxelType;
+
+/**
+ * A dummuy voxelType implementation for {@code TestingVoxelWorld}.
+ *
+ * All testing voxel type are represented by simple strings.
+ */
+public class TestingVoxelType implements VoxelType {
+    /**
+     * World where voxel are placed.
+     */
+    protected TestingVoxelWorld world;
+
+    /**
+     * Type of the voxel type.
+     */
+    protected String type;
+
+    /**
+     * Creates a new TestingVoxelType.
+     *
+     * @param world World in which this voxel type will be placed
+     * @param type A string for this voxel type (this value will be set in voxel world)
+     */
+    protected TestingVoxelType(TestingVoxelWorld world, String type) {
+        this.world = world;
+        this.type = type;
+    }
+
+    /**
+     * Places a voxel of this type in the world.
+     *
+     * @param x x-coordinate where to place voxel
+     * @param y y-coordinate where to place voxel
+     * @param z z-coordinate where to place voxel
+     */
+    @Override
+    public void place(int x, int y, int z) throws OutOfWorldException {
+        this.world.set(x, y, z, this);
+    }
+
+    /**
+     * Returns the string type of that voxel type.
+     *
+     * @return Voxel type as string
+     */
+    protected String getType() {
+        return type;
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/outputs/testing/TestingVoxelTypeFactory.java
+++ b/src/test/java/com/ignfab/minalac/generator/outputs/testing/TestingVoxelTypeFactory.java
@@ -1,0 +1,26 @@
+package com.ignfab.minalac.generator.outputs.testing;
+
+import com.ignfab.minalac.generator.world.SemanticType;
+import com.ignfab.minalac.generator.world.VoxelTypeFactory;
+import com.ignfab.minalac.generator.world.VoxelType;
+
+public class TestingVoxelTypeFactory implements VoxelTypeFactory {
+    private TestingVoxelWorld world;
+
+    public TestingVoxelTypeFactory(TestingVoxelWorld world) {
+        this.world = world;
+    }
+
+    @Override
+    public VoxelType createVoxelType(SemanticType semanticType) {
+        return switch (semanticType) {
+            case GRASS  -> new TestingVoxelType(this.world, "grass");
+            case STONE  -> new TestingVoxelType(this.world, "stone");
+            case DIRT   -> new TestingVoxelType(this.world, "dirt");
+            case COBBLE -> new TestingVoxelType(this.world, "cobble");
+            case BRICK  -> new TestingVoxelType(this.world, "brick");
+            case WATER  -> new TestingVoxelType(this.world, "water");
+            default     -> new TestingVoxelType(this.world, "air");
+        };
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/outputs/testing/TestingVoxelWorld.java
+++ b/src/test/java/com/ignfab/minalac/generator/outputs/testing/TestingVoxelWorld.java
@@ -1,0 +1,179 @@
+package com.ignfab.minalac.generator.outputs.testing;
+
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
+import com.ignfab.minalac.generator.world.MapWriteException;
+import com.ignfab.minalac.generator.world.OutOfWorldException;
+import com.ignfab.minalac.generator.world.VoxelTypeFactory;
+import com.ignfab.minalac.generator.world.VoxelWorld;
+import com.ignfab.minalac.generator.world.VoxelWorldMetadata;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Testing purpose voxel world output.
+ *
+ * TestingVoxelWorld does not produce any file output. It is intended to be used in unit tests
+ * as output world.
+ */
+public class TestingVoxelWorld implements VoxelWorld {
+    private VoxelTypeFactory factory;
+    private WorldBBox3d bbox;
+    private String[] voxels;
+    private VoxelWorldMetadata metadata;
+
+    /**
+     * Constructs a new TestingVoxelWorld.
+     *
+     * @param bbox Bounding box of the voxel world to create
+     *
+     * Beware: Avoid large bounding boxes!
+     * Each voxel is stored in memory as a string, which could be very large.
+     */
+    public TestingVoxelWorld(WorldBBox3d bbox) {
+        this.bbox = bbox;
+        factory = new TestingVoxelTypeFactory(this);
+        voxels = new String[bbox.getSize().volume()];
+        metadata = new VoxelWorldMetadata();
+    }
+
+    @Override
+    public VoxelTypeFactory getFactory() {
+        return this.factory;
+    }
+
+    @Override
+    public void save(File destination) throws MapWriteException {}
+
+    @Override
+    public VoxelWorldMetadata getMetadata() {
+        return metadata;
+    };
+
+    private int index(int x, int y, int z) throws OutOfWorldException {
+        if (!bbox.contains(x, y, z))
+            throw new OutOfWorldException();
+        return x - bbox.getMinX() + bbox.getSizeX()
+            * (y - bbox.getMinY() + bbox.getSizeY()
+            * (z - bbox.getMinZ()));
+    }
+
+    protected void set(int x, int y, int z, TestingVoxelType voxelType) throws OutOfWorldException {
+        set(x, y, z, voxelType.getType());
+    }
+
+    /**
+     * Set voxel string value at a given position.
+     *
+     * @param x X-coordinates of position to set
+     * @param y Y-coordinates of position to set
+     * @param z Z-coordinates of position to set
+     * @param value Voxel value to set at this position
+     */
+    public void set(int x, int y, int z, String value) throws OutOfWorldException {
+        voxels[index(x, y, z)] = value;
+    }
+
+    /**
+     * Get voxel string value at a given position.
+     *
+     * @param x X-coordinates of position to get
+     * @param y Y-coordinates of position to get
+     * @param z Z-coordinates of position to get
+     * @return Voxel value at this position
+     */
+    public String get(int x, int y, int z) throws OutOfWorldException {
+        return voxels[index(x, y, z)];
+    }
+
+    /**
+     * Asserts a voxel has an expected value.
+     *
+     * @param expected Expected value
+     * @param x x-coordinate of tested voxel
+     * @param y y-coordinate of tested voxel
+     * @param z z-coordinate of tested voxel
+     * @param message Message to be displayed in case of failure
+     */
+    public void assertVoxel(String expected, int x, int y, int z, String message) throws OutOfWorldException {
+        assertEquals(expected, get(x, y, z), message);
+    }
+
+    /**
+     * Asserts a voxel has an expected value.
+     *
+     * @param expected Expected value
+     * @param x x-coordinate of tested voxel
+     * @param y y-coordinate of tested voxel
+     * @param z z-coordinate of tested voxel
+     */
+    public void assertVoxel(String expected, int x, int y, int z) throws OutOfWorldException {
+        assertVoxel(expected, x, y, z, "Voxel mismatch at (%d, %d, %d)".formatted(x, y, z));
+    }
+
+    /**
+     * Asserts a voxel has an expected value.
+     *
+     * @param expected Expected value
+     * @param pos Position of tested voxel
+     * @param message Message to be displayed in case of failure
+     */
+    public void assertVoxel(String expected, WorldCoords3d pos, String message) throws OutOfWorldException {
+        assertVoxel(expected, pos.x(), pos.y(), pos.z(), message);
+    }
+
+    /**
+     * Asserts a voxel has an expected value.
+     *
+     * @param expected Expected value
+     * @param pos Position of tested voxel
+     */
+    public void assertVoxel(String expected, WorldCoords3d pos) throws OutOfWorldException {
+        assertVoxel(expected, pos.x(), pos.y(), pos.z());
+    }
+
+    /**
+     * Asserts a voxel has no value.
+     *
+     * @param x x-coordinate of tested voxel
+     * @param y y-coordinate of tested voxel
+     * @param z z-coordinate of tested voxel
+     * @param message Message to be displayed in case of failure
+     */
+    public void assertVoxelNull(int x, int y, int z, String message) throws OutOfWorldException {
+        assertNull(get(x, y, z), message);
+    }
+
+    /**
+     * Asserts a voxel has no value.
+     *
+     * @param x x-coordinate of tested voxel
+     * @param y y-coordinate of tested voxel
+     * @param z z-coordinate of tested voxel
+     */
+    public void assertVoxelNull(int x, int y, int z) throws OutOfWorldException {
+        assertVoxelNull(x, y, z, "Voxel mismatch at (%d, %d, %d)".formatted(x, y, z));
+    }
+
+    /**
+     * Asserts a voxel has no value.
+     *
+     * @param pos Position of tested voxel
+     * @param message Message to be displayed in case of failure
+     */
+    public void assertVoxelNull(WorldCoords3d pos, String message) throws OutOfWorldException {
+        assertVoxelNull(pos.x(), pos.y(), pos.z(), message);
+    }
+
+    /**
+     * Asserts a voxel has no value.
+     *
+     * @param pos Position of tested voxel
+     */
+    public void assertVoxelNull(WorldCoords3d pos) throws OutOfWorldException {
+        assertVoxelNull(pos.x(), pos.y(), pos.z());
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/outputs/testing/TestingVoxelWorldTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/outputs/testing/TestingVoxelWorldTest.java
@@ -1,0 +1,50 @@
+package com.ignfab.minalac.generator.outputs.testing;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+import com.ignfab.minalac.generator.world.OutOfWorldException;
+import com.ignfab.minalac.generator.world.SemanticType;
+import com.ignfab.minalac.generator.world.VoxelType;
+
+import java.io.File;
+
+public class TestingVoxelWorldTest {
+    @Test
+    @DisplayName("Ensure that everything that is stored in the world can be retreived")
+    public void testSetAndGet() throws OutOfWorldException {
+        TestingVoxelWorld world = new TestingVoxelWorld(new WorldBBox3d(-1, -2, -3, 5, 4, 3));
+        // Fill the world with unique values
+        for (int x = -1; x <= 3; x++)
+            for (int y = -2; y <= 1; y++)
+                for (int z = -3; z <= -1; z++)
+                    world.set(x, y, z, x + " " + y + " " + z);
+
+        // Test values are retrieved
+        for (int z = -3; z <= -1; z++)
+            for (int y = -2; y <= 1; y++)
+                for (int x = -1; x <= 3; x++)
+                    world.assertVoxel(x + " " + y + " " + z, x, y, z);
+    }
+
+    @Test
+    @DisplayName("Test setting in the world using voxel type can be retrieved")
+    public void testGetVoxelType() throws OutOfWorldException {
+        TestingVoxelWorld world = new TestingVoxelWorld(new WorldBBox3d(1, 2, 3, 4, 5, 6));
+        VoxelType vt1 = world.getFactory().createVoxelType(SemanticType.STONE);
+        VoxelType vt2 = world.getFactory().createVoxelType(SemanticType.DIRT);
+        vt1.place(1, 2, 3);
+        vt2.place(3, 4, 5);
+        world.assertVoxel("stone", 1, 2, 3);
+        world.assertVoxel("dirt", 3, 4, 5);
+    }
+
+    @Test
+    @DisplayName("Just ensure save throws no exception")
+    public void testSave() {
+        TestingVoxelWorld world = new TestingVoxelWorld(new WorldBBox3d(0, 0, 0, 1, 1, 1));
+        assertDoesNotThrow(() -> world.save(new File("toto")));
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/renderers/TestingIterableArrayChunk2d.java
+++ b/src/test/java/com/ignfab/minalac/generator/renderers/TestingIterableArrayChunk2d.java
@@ -1,0 +1,16 @@
+package com.ignfab.minalac.generator.renderers;
+
+import com.ignfab.minalac.generator.utils.world2d.chunk.ArrayChunk2d;
+import com.ignfab.minalac.generator.utils.world2d.chunk.IterableChunk2d;
+import com.ignfab.minalac.generator.utils.world2d.iterator.Chunk2dIteratorAll;
+import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
+
+public class TestingIterableArrayChunk2d extends ArrayChunk2d implements IterableChunk2d {
+    public TestingIterableArrayChunk2d(WorldBBox2d bbox, int defaultValue) {
+        super(bbox, defaultValue);
+    }
+
+    public Chunk2dIteratorAll iterator() {
+        return new Chunk2dIteratorAll(this);
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/renderers/VectorRendererTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/renderers/VectorRendererTest.java
@@ -1,0 +1,149 @@
+package com.ignfab.minalac.generator.renderers;
+
+import com.ignfab.minalac.generator.generation.HeightMap;
+import com.ignfab.minalac.generator.models.GeometryModel;
+import com.ignfab.minalac.generator.models.Model;
+import com.ignfab.minalac.generator.models.TestingRasterizableModel;
+import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
+import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
+import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
+import com.ignfab.minalac.generator.world.OutOfWorldException;
+import com.ignfab.minalac.generator.world.SemanticType;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedList;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class VectorRendererTest {
+    private TestingVoxelWorld world;
+    private HeightMap heightMap;
+    private WorldBBox3d bbox;
+    private LinkedList<Model> models;
+
+    @BeforeEach
+    public void setUp() {
+        bbox = new WorldBBox3d(-1, -2, -3, 4, 5, 6);
+        world = new TestingVoxelWorld(bbox);
+        heightMap = new HeightMap(bbox.to2d(), -1);
+        models = new LinkedList<>();
+    }
+
+    private void render() {
+        assertDoesNotThrow(
+            () -> new VectorRenderer(
+                    heightMap,
+                    models,
+                    world.getFactory().createVoxelType(SemanticType.COBBLE),
+                    world.getFactory().createVoxelType(SemanticType.BRICK)
+                ).render()
+        );
+    }
+
+    @Test
+    @DisplayName("Test a simple rendering on flat height map")
+    public void testRenderFlat() throws OutOfWorldException {
+        // Prepare a chunk smaller than the whole world
+        WorldBBox2d modelBbox = new WorldBBox2d(0, -1, 2, 3);
+
+        // Add one model covering the whole map with INSIDE voxels
+        models.add(new TestingRasterizableModel(new TestingIterableArrayChunk2d(modelBbox, GeometryModel.INSIDE)));
+
+        render();
+
+        for (WorldCoords3d pos : bbox) {
+            if (pos.z() == 0 && modelBbox.contains(pos.to2d()))
+                world.assertVoxel("cobble", pos);
+            else
+                world.assertVoxelNull(pos);
+        }
+    }
+
+    @Test
+    @DisplayName("Test rendering outside, inside and border")
+    public void testRenderOutsideInsideBorder() throws OutOfWorldException {
+        // Prepare a chunk with only three pixels, one per available value
+        TestingIterableArrayChunk2d chunk = new TestingIterableArrayChunk2d(new WorldBBox2d(0, 0, 1, 3), GeometryModel.OUTSIDE);
+        chunk.set(0, 1, GeometryModel.BORDER);
+        chunk.set(0, 2, GeometryModel.INSIDE);
+
+        // Add one model covering the whole map with INSIDE voxels
+        models.add(new TestingRasterizableModel(chunk));
+
+        render();
+
+        for (WorldCoords3d pos : bbox) {
+            if (pos.z() == 0 && pos.x() == 0 && pos.y() == 1)
+                world.assertVoxel("brick", pos);
+            else if (pos.z() == 0 && pos.x() == 0 && pos.y() == 2)
+                world.assertVoxel("cobble", pos);
+            else
+                world.assertVoxelNull(pos);
+        }
+    }
+
+    @Test
+    @DisplayName("Test rendering on a non flat height map")
+    public void testRenderHeightMap() throws OutOfWorldException {
+        // Prepare a non flat HeightMap
+        for (WorldCoords2d pos : bbox.to2d())
+            heightMap.set(pos, (pos.x() + pos.y()) / 2);
+
+        // Add one model covering the whole map with BORDER voxels
+        models.add(new TestingRasterizableModel(new TestingIterableArrayChunk2d(bbox.to2d(), GeometryModel.BORDER)));
+
+        render();
+
+        for (WorldCoords3d pos : bbox) {
+            if (pos.z() == (pos.x() + pos.y()) / 2 + 1) // + 1 because vector renderer places voxels 1 pos above height map
+                world.assertVoxel("brick", pos);
+            else
+                world.assertVoxelNull(pos);
+        }
+    }
+
+    @Test
+    @DisplayName("Test rendering with a height map over world vertical limits")
+    public void testRenderVerticalOverflow() throws OutOfWorldException {
+        // A heightmap overflowing under and over world limits
+        for (WorldCoords2d pos : bbox.to2d())
+            // At (2, 2), height will be 6, above max world z (i.e. 2)
+            // At (-1, -2), height will be -5, under min world z (i.e. -3)
+            heightMap.set(pos, pos.x() + pos.y() * 2);
+
+        // Add one model covering the whole map with BORDER voxels
+        models.add(new TestingRasterizableModel(new TestingIterableArrayChunk2d(bbox.to2d(), GeometryModel.BORDER)));
+
+        render();
+
+        for (WorldCoords3d pos : bbox) {
+            if (pos.z() == pos.x() + pos.y() * 2 + 1)
+                world.assertVoxel("brick", pos);
+            else
+                world.assertVoxelNull(pos);
+        }
+    }
+
+    @Test
+    @DisplayName("Test rendering of a chunk larger than world horizontal limits")
+    public void testRenderHorizontalOverflow() throws OutOfWorldException {
+        // Prepare a larger model bbox
+        WorldBBox2d modelBbox = new WorldBBox2d(bbox.getMinX() - 1, bbox.getMinY() - 1, bbox.getSizeX() + 2, bbox.getSizeY() + 2);
+
+        models.add(new TestingRasterizableModel(new TestingIterableArrayChunk2d(modelBbox, GeometryModel.INSIDE)));
+
+        render();
+
+        for (WorldCoords3d pos : bbox) {
+            if (pos.z() == 0)
+                world.assertVoxel("cobble", pos);
+            else
+                world.assertVoxelNull(pos);
+        }
+    }
+}


### PR DESCRIPTION
Cette PR déplace le code de rendu des vecteurs de SampleImplémentation vers d'autres classes et ajoute quelques tests.

Le déplacement de `HeightMap` entre en concurrence avec la #10 . A voir laquelle sera fusionnée en premier.

Le VectorRenderer est une implémentaton basique pour tester le rendu vectoriel et montrer un exemple, elle reste à améliorer dans de futures PR.

Pour tester, vérifier que cela ne change rien au résultat :D : 
```
mvn package && java -jar ./target/Generator.jar $HOME/.minetest/worlds/minalac EPSG:2154 600000 6340000 1000 1000 1.0 10.0
```

Des "batiments" doivent être posés sur le paysage.