### PR TITLE
Add ModelStore and fix javadoc workflow

### DIFF
--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -2,11 +2,6 @@ name: Javadoc
 run-name: ${{ github.actor }} is generating Javadoc for ${{ github.repository }}#${{ github.ref_name }}
 on:
   push:
-    # Only deploy main branch.
-    # Deploying a Pull Request as a GitHub Pages preview site
-    # is currently in alpha and not available to the public!
-    branches:
-      - main
     paths:
       - src/main/java/**
       - pom.xml
@@ -31,11 +26,25 @@ jobs:
       - name: Generate Javadoc with Maven
         run: mvn --batch-mode --no-transfer-progress --update-snapshots javadoc:javadoc
       - name: Setup Pages
+        # Only deploy main branch.
+        # Deploying a Pull Request as a GitHub Pages preview site
+        # is currently in alpha and not available to the public!
+        if: ${{ github.ref_name == github.event.repository.default_branch }}
         uses: actions/configure-pages@v5
-      - name: Upload artifact
+      - name: Upload GitHub Pages artifact
+        if: ${{ github.ref_name == github.event.repository.default_branch }}
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ./target/apidocs/
+          path: target/site/apidocs
       - name: Deploy to GitHub Pages
+        if: ${{ github.ref_name == github.event.repository.default_branch }}
         id: deployment
         uses: actions/deploy-pages@v4
+      - name: Upload standard artifact
+        # Fallback to standard artifact on any other branch.
+        if: ${{ github.ref_name != github.event.repository.default_branch }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: Javadoc
+          path: target/site/apidocs
+          if-no-files-found: error

--- a/docs/tools/GitHub-workflows.md
+++ b/docs/tools/GitHub-workflows.md
@@ -49,7 +49,7 @@ The workflow never fails (except if the tools themselves fail, which is unlikely
 
 This workflow triggers when a push on any branch modifies the Java main source files.
 
-It consists of a single job, running the [Javadoc](Javadoc.md) tool to generate the static HTML documentation, and then deploying it to GitHub Pages.
+It consists of a single job, running the [Javadoc](Javadoc.md) tool to generate the static HTML documentation, and then deploying it to GitHub Pages or uploading it as workflow artifact, depending on the branch that triggered the workflow run. This behavior is the result of a technical limitation on GitHub's side: We can't deploy a "preview site" for a pull request. To maintain the Javadoc from the `main` branch available on GitHub Pages, this must be the only existing deployment.
 
 The workflow fails if the Javadoc tool itself fails, meaning there are errors in Javadoc Comments, and static HTML documentation cannot be generated.
 

--- a/docs/tools/Javadoc.md
+++ b/docs/tools/Javadoc.md
@@ -103,7 +103,7 @@ Inserts a link similar to `@see` (but inline). `{@linkplain}` uses a text font i
 ```java
 /**
  * Register a {@linkplain TextLabel text label} for this element.
- * 
+ *
  * @deprecated Labels are now HTML. Use {@link #registerRichLabel(HtmlLabel)} instead.
  */
 ```
@@ -161,4 +161,4 @@ We try to document as much code as possible. However, we prioritize the document
 
 When adding elements that do meet the above criteria, or you think are worth documenting, you should write the documentation at the same time. Do not forget to check if the documentation of elements you modified is still correct!
 
-To generate the static HTML documentation, we use the `maven-javadoc-plugin` to run the Javadoc tool using the [`javadoc:javadoc` Maven goal](Maven.md#generate-javadoc). A [GitHub workflow](GitHub-workflows.md#javadoc) also generates automatically Javadoc on push and deploys it on GitHub Pages. It currently only triggers on the `main` branch.
+To generate the static HTML documentation, we use the `maven-javadoc-plugin` to run the Javadoc tool using the [`javadoc:javadoc` Maven goal](Maven.md#generate-javadoc). A [GitHub workflow](GitHub-workflows.md#javadoc) also generates automatically Javadoc on push. Due to technical limitation on GitHub's side, it currently only deploys on GitHub Pages from the `main` branch, and upload the generated files as workflow artifact otherwise.

--- a/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
+++ b/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
@@ -2,7 +2,7 @@ package com.ignfab.minalac.generator;
 
 
 import com.ignfab.minalac.generator.models.GeometryModel;
-import com.ignfab.minalac.generator.models.Model;
+import com.ignfab.minalac.generator.models.ModelStore;
 import com.ignfab.minalac.generator.outputs.minecraft.MCVoxelWorld;
 import com.ignfab.minalac.generator.outputs.minetest.MTVoxelWorld;
 import com.ignfab.minalac.generator.generation.CoordsConverter;
@@ -20,11 +20,9 @@ import com.ignfab.minalac.generator.world.SemanticType;
 import com.ignfab.minalac.generator.world.VoxelType;
 import com.ignfab.minalac.generator.world.VoxelWorld;
 import com.ignfab.minalac.generator.world.VoxelWorldMetadata;
-import org.geotools.api.feature.simple.SimpleFeature;
 import org.geotools.api.referencing.FactoryException;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.api.referencing.operation.TransformException;
-import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.data.simple.SimpleFeatureIterator;
 import org.geotools.referencing.CRS;
 import org.locationtech.jts.geom.Envelope;
@@ -39,10 +37,8 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.util.Collection;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.function.Supplier;
 
 /**
@@ -107,24 +103,28 @@ public final class SampleImplementation {
             String bboxURL = "BBOX=" + envelope.getMinX() + "," + envelope.getMinY() + "," + envelope.getMaxX() + "," + envelope.getMaxY();
 
             // Downloads
+            ModelStore store = new ModelStore();
+
             System.out.println("Downloading height map");
             HeightMap heightMap = createGroundHeightMap("https://data.geopf.fr/wms-r/wms?LAYERS=RGEALTI-MNT_PYR-ZIP_FXX_LAMB93_WMS&FORMAT=image/x-bil;bits=32&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&STYLES=&CRS=" + crsName + "&" + bboxURL, extendX, extendY, verticalScale);
 
             System.out.println("Downloading buildings");
-            WFS2DataProvider provider = new WFS2DataProvider("https://data.geopf.fr/wfs/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=BDTOPO_V3:batiment&STARTINDEX=0&COUNT=1000&SRSNAME=urn:ogc:def:crs:EPSG::2154&" + bboxURL + ",urn:ogc:def:crs:EPSG::2154");
-            Collection<Model> buildingModels = fetchVectorModels(
-                provider.getFeatures(),
-                generation.makeCoordsConverter(crs) // This is supposed to be the layer CRS (actually the same for this demo)
-            );
+            downloadVectorFeatures(
+                new WFS2DataProvider("https://data.geopf.fr/wfs/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=BDTOPO_V3:batiment&STARTINDEX=0&COUNT=1000&SRSNAME=urn:ogc:def:crs:EPSG::2154&" + bboxURL + ",urn:ogc:def:crs:EPSG::2154"),
+                generation.makeCoordsConverter(crs),  // This is supposed to be the layer CRS (actually the same for this demo)
+                "building",
+                store);
 
             System.out.println("World creation");
             VoxelWorld world = FORMATS.get(format).get();
+
             System.out.println("Placing ground");
             placeVoxelFromHeightMap(heightMap, world);
 
             System.out.println("Placing buildings");
             new VectorRenderer(
-                heightMap, buildingModels,
+                heightMap,
+                store.getByType("building"),
                 world.getFactory().createVoxelType(SemanticType.COBBLE),
                 world.getFactory().createVoxelType(SemanticType.BRICK)
             ).render();
@@ -145,20 +145,11 @@ public final class SampleImplementation {
         System.out.println("Execution time: " + (end - start) / 1000 + "s");
     }
 
-    private static List<Model> fetchVectorModels(SimpleFeatureCollection features, CoordsConverter converter)
-        throws TransformException {
-        List<Model> models = new LinkedList<>();
-
-        try (
-            SimpleFeatureIterator iterator = features.features()
-        ) {
-            while (iterator.hasNext()) {
-                SimpleFeature feature = iterator.next();
-                models.add((Model) (new GeometryModel((Geometry) feature.getDefaultGeometry(), converter)));
-            }
-        }
-
-        return models;
+    private static void downloadVectorFeatures(WFS2DataProvider provider, CoordsConverter converter, String type, ModelStore store)
+            throws NoSuchElementException, TransformException, IOException, ParserConfigurationException, SAXException {
+        SimpleFeatureIterator iterator = provider.getFeatures().features();
+        while (iterator.hasNext())
+            store.add(type, new GeometryModel((Geometry) iterator.next().getDefaultGeometry(), converter));
     }
 
     private static void placeVoxelFromHeightMap(HeightMap map, VoxelWorld world) throws OutOfWorldException {

--- a/src/main/java/com/ignfab/minalac/generator/models/ModelStore.java
+++ b/src/main/java/com/ignfab/minalac/generator/models/ModelStore.java
@@ -1,0 +1,39 @@
+package com.ignfab.minalac.generator.models;
+
+import java.util.Map;
+import java.util.List;
+import java.util.LinkedList;
+import java.util.HashMap;
+
+/**
+ * A basic model store, storing and retrieving models by type.
+ */
+public class ModelStore {
+    private final Map<String, List<Model>> byType = new HashMap<>();
+
+    /**
+     * Add a model of a given type in store.
+     * Store is quite dumb, it is not able to retrieve type from model (anyway Models do not have type for now).
+     *
+     * @param type Type to associate with stored model
+     * @param model Model to be stored
+     */
+    public void add(String type, Model model) {
+        List<Model> list = byType.get(type);
+        if (list == null) {
+            list = new LinkedList<>();
+            byType.put(type, list);
+        }
+        list.add(model);
+    }
+
+    /**
+     * List models by type.
+     *
+     * @param type Type of models to be listed
+     * @return List of models of the given type
+     */
+    public List<Model> getByType(String type) {
+        return byType.get(type);
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/renderers/VectorRenderer.java
+++ b/src/main/java/com/ignfab/minalac/generator/renderers/VectorRenderer.java
@@ -31,7 +31,7 @@ public class VectorRenderer {
      * @param heightMap Height map of the ground (on which features will be placed)
      * @param models Models to be rendered (only Rasterizable ones will be)
      * @param inside Voxel type to draw inside geometries
-     * @param edge Voxel type to draw on edges of geometries (including points & lines)
+     * @param edge Voxel type to draw on edges of geometries (including points and lines)
      */
     public VectorRenderer(HeightMap heightMap, Iterable<Model> models, VoxelType inside, VoxelType edge) {
         this.heightMap = heightMap;

--- a/src/test/java/com/ignfab/minalac/generator/models/ModelStoreTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/models/ModelStoreTest.java
@@ -1,0 +1,20 @@
+package com.ignfab.minalac.generator.models;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ModelStoreTest {
+    class TestModel implements Model {}
+
+    @Test
+    void testAddByType() {
+        ModelStore store = new ModelStore();
+        store.add("toto", new TestModel());
+        store.add("toto", new TestModel());
+        store.add("titi", new TestModel());
+        assertEquals(2, store.getByType("toto").size());
+        assertEquals(1, store.getByType("titi").size());
+        assertNull(store.getByType("tata"));
+    }
+}


### PR DESCRIPTION
### Type of modification

Code, Javadoc & CI/CD

### Changes

Three small changes:

- Add a basic `ModelStore` class for storing ... models. `SampleImplementation` code has been updated to use this class for vector models (height map models aren't yet developped).
- Fix invalid `&` char in javadoc.
- Improve CI/CD to check javadocs before merging them in `main` branch.

#### Feature description

`ModelStore` is used to store vector models by type instead of using a local variable. No other change so behavior is kept strictly the same.

#### Showcase

Tests & already given examples are expected to work exactly the same.
Addition of javadocs are now tested before merging.

### Reason

`ModelStore` is very basic in this version but it will be a very important part of future generation process. It already makes possible to develop sources and renderers independently.

Javadoc check is also very important, it prevents pull request to be merged with problematic javadoc comments.

### Self-checks

- [X] The code has unit tests associated
- [X] The code has Javadoc Comments associated
- ~~Complex / Unexpected code is explained / justified with a small comment~~
- ~~Relevant documentation inside the `/docs` folder has been updated~~
- [X] All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)
- [X] Git history is clean (each commit accomplish a single task and describe it accordingly)
- ~~The texts have been proofread (documentation, error messages, logs, comments...)~~
