### PR TITLE
Allow spatial limitation of model rasterization.

### DIFF
--- a/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
+++ b/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
@@ -11,6 +11,7 @@ import com.ignfab.minalac.generator.generation.HeightMap;
 import com.ignfab.minalac.generator.inputs.WFS2DataProvider;
 import com.ignfab.minalac.generator.renderers.VectorRenderer;
 import com.ignfab.minalac.generator.utils.network.HttpTrustAllSSL;
+import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
 import com.ignfab.minalac.generator.utils.world2d.iterator.Chunk2dElement;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
@@ -113,7 +114,8 @@ public final class SampleImplementation {
                 new WFS2DataProvider("https://data.geopf.fr/wfs/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=BDTOPO_V3:batiment&STARTINDEX=0&COUNT=1000&SRSNAME=urn:ogc:def:crs:EPSG::2154&" + bboxURL + ",urn:ogc:def:crs:EPSG::2154"),
                 generation.makeCoordsConverter(crs),  // This is supposed to be the layer CRS (actually the same for this demo)
                 "building",
-                store);
+                store,
+                heightMap.bbox());
 
             System.out.println("World creation");
             VoxelWorld world = FORMATS.get(format).get();
@@ -145,11 +147,11 @@ public final class SampleImplementation {
         System.out.println("Execution time: " + (end - start) / 1000 + "s");
     }
 
-    private static void downloadVectorFeatures(WFS2DataProvider provider, CoordsConverter converter, String type, ModelStore store)
+    private static void downloadVectorFeatures(WFS2DataProvider provider, CoordsConverter converter, String type, ModelStore store, WorldBBox2d limits)
             throws NoSuchElementException, TransformException, IOException, ParserConfigurationException, SAXException {
         SimpleFeatureIterator iterator = provider.getFeatures().features();
         while (iterator.hasNext())
-            store.add(type, new GeometryModel((Geometry) iterator.next().getDefaultGeometry(), converter));
+            store.add(type, new GeometryModel((Geometry) iterator.next().getDefaultGeometry(), converter, limits));
     }
 
     private static void placeVoxelFromHeightMap(HeightMap map, VoxelWorld world) throws OutOfWorldException {

--- a/src/main/java/com/ignfab/minalac/generator/models/GeometryModel.java
+++ b/src/main/java/com/ignfab/minalac/generator/models/GeometryModel.java
@@ -3,6 +3,9 @@ package com.ignfab.minalac.generator.models;
 import com.ignfab.minalac.generator.generation.CoordsConverter;
 import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
 import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
+import com.ignfab.minalac.generator.utils.world2d.chunk.EmptyChunk2d;
+import com.ignfab.minalac.generator.utils.world2d.chunk.IterableChunk2d;
+
 import org.geotools.api.referencing.operation.TransformException;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
@@ -21,7 +24,8 @@ import java.awt.Graphics2D;
  */
 public class GeometryModel implements Model, Rasterizable {
     private final Geometry geom;
-    private BufferedImageChunk chunk;
+    private IterableChunk2d chunk;
+    private WorldBBox2d limits;
 
     /**
      * Outside the geometry.
@@ -45,18 +49,20 @@ public class GeometryModel implements Model, Rasterizable {
      *
      * @param geom A JTS Geometry
      * @param converter Converter from geometry CRS to world coordinates
+     * @param limits A bounding box of rendering limits
      */
-    public GeometryModel(Geometry geom, CoordsConverter converter) throws TransformException {
+    public GeometryModel(Geometry geom, CoordsConverter converter, WorldBBox2d limits) throws TransformException {
         // Until there is no need of it we don't keep original geometry.
         // Geometry is stored transformed into world coordinates
         this.geom = converter.convert(geom);
+        this.limits = limits;
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public BufferedImageChunk getChunk() {
+    public IterableChunk2d getChunk() {
 
         if (chunk == null) {
             makeChunk();
@@ -77,8 +83,17 @@ public class GeometryModel implements Model, Rasterizable {
             new WorldCoords2d((int) Math.floor(envelope.getMinX()), (int) Math.floor(envelope.getMinY())),
             new WorldCoords2d((int) Math.floor(envelope.getMaxX()), (int) Math.floor(envelope.getMaxY())));
 
+        if (limits != null)
+            bbox = bbox.intersection(limits);
+
+        if (bbox.isEmpty()) {
+            chunk = EmptyChunk2d.getInstance();
+            return;
+        }
+
         // Create chunk
-        chunk = new BufferedImageChunk(bbox);
+        BufferedImageChunk chunk = new BufferedImageChunk(bbox);
+        this.chunk = chunk;
         Graphics2D graphics = chunk.createGraphics();
 
         // Draw geometry translated into bounding box relative coordinates (i.e. BufferedImage coordinates))

--- a/src/main/java/com/ignfab/minalac/generator/utils/world2d/WorldBBox2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world2d/WorldBBox2d.java
@@ -199,6 +199,30 @@ public class WorldBBox2d implements Iterable<WorldCoords2d> {
         return min.equals(that.min) && max.equals(that.max);
     }
 
+    /**
+     * Tells if box is empty.
+     *
+     * @return true if box is empty
+     */
+    public boolean isEmpty() {
+        return size.x() == 0 || size.y() == 0;
+    }
+
+    /**
+     * Returns intersection with another bounind box.
+     *
+     * @param box Other bounding box to intersect with
+     *
+     * @return A new bounding box representing the intersection (may be empty)
+     */
+    public WorldBBox2d intersection(WorldBBox2d box) {
+        int minX = Math.max(min.x(), box.getMinX());
+        int minY = Math.max(min.y(), box.getMinY());
+        int maxX = Math.min(max.x(), box.getMaxX());
+        int maxY = Math.min(max.y(), box.getMaxY());
+        return new WorldBBox2d(minX, minY, Math.max(0, maxX - minX + 1), Math.max(0, maxY - minY + 1));
+    }
+
     @Override
     public int hashCode() {
         int result = min.hashCode();

--- a/src/main/java/com/ignfab/minalac/generator/utils/world2d/WorldSize2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world2d/WorldSize2d.java
@@ -22,8 +22,8 @@ public record WorldSize2d(int x, int y) {
      * @throws IllegalArgumentException if either {@code x} or {@code y} is less than or equal to 0.
      */
     public WorldSize2d {
-        if (x <= 0 || y <= 0)
-            throw new IllegalArgumentException("Invalid size: x and y must be greater than 0");
+        if (x < 0 || y < 0)
+            throw new IllegalArgumentException("Invalid size: x and y must be positive numbers");
     }
 
     /**

--- a/src/main/java/com/ignfab/minalac/generator/utils/world2d/chunk/EmptyChunk2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world2d/chunk/EmptyChunk2d.java
@@ -1,0 +1,53 @@
+package com.ignfab.minalac.generator.utils.world2d.chunk;
+
+import java.util.Collections;
+import java.util.Iterator;
+
+import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
+import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
+import com.ignfab.minalac.generator.utils.world2d.iterator.Chunk2dElement;
+
+/**
+ * A 2d chunk of size 0.
+ */
+public final class EmptyChunk2d implements IterableChunk2d, WritableChunk2d {
+    private static final EmptyChunk2d INSTANCE = new EmptyChunk2d();
+    private static final WorldBBox2d BBOX = new WorldBBox2d(0, 0, 0, 0);
+
+    private EmptyChunk2d() {}
+
+    public static EmptyChunk2d getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public WorldBBox2d bbox() {
+        return BBOX;
+    }
+
+    @Override
+    public int get(int x, int y) {
+        throw new IndexOutOfBoundsException(String.format("%s: Index out of range at (x=%d, y=%d)", getClass().getSimpleName(), x, y));
+    }
+
+    @Override
+    public int get(WorldCoords2d pos) {
+        throw new IndexOutOfBoundsException(String.format("%s: Index out of range at (x=%d, y=%d)", getClass().getSimpleName(), pos.x(), pos.y()));
+    }
+
+    @Override
+    public void set(int x, int y, int value) {
+        throw new IndexOutOfBoundsException(String.format("%s: Index out of range at (x=%d, y=%d)", getClass().getSimpleName(), x, y));
+    }
+
+    @Override
+    public void set(WorldCoords2d pos, int value) {
+        throw new IndexOutOfBoundsException(String.format("%s: Index out of range at (x=%d, y=%d)", getClass().getSimpleName(), pos.x(), pos.y()));
+    }
+
+    @Override
+    public Iterator<Chunk2dElement> iterator() {
+        return Collections.emptyIterator();
+    }
+
+}

--- a/src/main/java/com/ignfab/minalac/generator/utils/world2d/chunk/IterableChunk2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world2d/chunk/IterableChunk2d.java
@@ -1,7 +1,8 @@
 package com.ignfab.minalac.generator.utils.world2d.chunk;
 
+import java.util.Iterator;
+
 import com.ignfab.minalac.generator.utils.world2d.iterator.Chunk2dElement;
-import com.ignfab.minalac.generator.utils.world2d.iterator.Chunk2dIterator;
 
 /**
  * The {@code IterableChunk2d} interface represents an iterable {@link ReadableChunk2d}.
@@ -12,5 +13,5 @@ public interface IterableChunk2d extends ReadableChunk2d, Iterable<Chunk2dElemen
      *
      * @return a {@link com.ignfab.minalac.generator.utils.world2d.iterator.Chunk2dIterator} to iterate over the elements.
      */
-    Chunk2dIterator iterator();
+    Iterator<Chunk2dElement> iterator();
 }

--- a/src/main/java/com/ignfab/minalac/generator/utils/world2d/iterator/WorldBBox2dIterator.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world2d/iterator/WorldBBox2dIterator.java
@@ -22,11 +22,13 @@ public class WorldBBox2dIterator implements Iterator<WorldCoords2d> {
      */
     public WorldBBox2dIterator(WorldBBox2d bbox) {
         this.bbox = bbox;
-        x = bbox.getMin().x();
-        y = bbox.getMin().y();
-
-        if (bbox.getSize().area() > 0)
+        if (bbox.isEmpty()) {
+            hasNext = false;
+        } else {
+            x = bbox.getMin().x();
+            y = bbox.getMin().y();
             hasNext = true;
+        }
     }
 
     private void moveOn() {

--- a/src/main/java/com/ignfab/minalac/generator/utils/world3d/WorldBBox3d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world3d/WorldBBox3d.java
@@ -230,6 +230,32 @@ public class WorldBBox3d implements Iterable<WorldCoords3d> {
         return min.equals(that.min) && max.equals(that.max);
     }
 
+    /**
+     * Tells if box is empty.
+     *
+     * @return true if box is empty
+     */
+    public boolean isEmpty() {
+        return size.x() == 0 || size.y() == 0 || size.z() == 0;
+    }
+
+    /**
+     * Returns intersection with another bounind box.
+     *
+     * @param box Other bounding box to intersect with
+     *
+     * @return A new bounding box representing the intersection (may be empty)
+     */
+    public WorldBBox3d intersection(WorldBBox3d box) {
+        int minX = Math.max(min.x(), box.getMinX());
+        int minY = Math.max(min.y(), box.getMinY());
+        int minZ = Math.max(min.z(), box.getMinZ());
+        int maxX = Math.min(max.x(), box.getMaxX());
+        int maxY = Math.min(max.y(), box.getMaxY());
+        int maxZ = Math.min(max.z(), box.getMaxZ());
+        return new WorldBBox3d(minX, minY, minZ, Math.max(0, maxX - minX + 1), Math.max(0, maxY - minY + 1), Math.max(0, maxZ - minZ + 1));
+    }
+
     @Override
     public int hashCode() {
         int result = min.hashCode();

--- a/src/main/java/com/ignfab/minalac/generator/utils/world3d/WorldSize3d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world3d/WorldSize3d.java
@@ -24,8 +24,8 @@ public record WorldSize3d(int x, int y, int z) {
      * @throws IllegalArgumentException if either {@code x}, {@code y} or {@code z} is less than or equal to 0
      */
     public WorldSize3d {
-        if (x <= 0 || y <= 0 || z <= 0)
-            throw new IllegalArgumentException("Invalid size: x, y and z must be greater than 0");
+        if (x < 0 || y < 0 || z < 0)
+            throw new IllegalArgumentException("Invalid size: x, y and z must be positive numbers");
     }
 
     /**

--- a/src/main/java/com/ignfab/minalac/generator/utils/world3d/iterator/WorldBBox3dIterator.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world3d/iterator/WorldBBox3dIterator.java
@@ -23,12 +23,14 @@ public class WorldBBox3dIterator implements Iterator<WorldCoords3d> {
      */
     public WorldBBox3dIterator(WorldBBox3d bbox) {
         this.bbox = bbox;
-        x = bbox.getMin().x();
-        y = bbox.getMin().y();
-        z = bbox.getMin().z();
-
-        if (bbox.getSize().volume() > 0)
+        if (bbox.isEmpty()) {
+            hasNext = false;
+        } else {
+            x = bbox.getMin().x();
+            y = bbox.getMin().y();
+            z = bbox.getMin().z();
             hasNext = true;
+        }
     }
 
     private void moveOn() {

--- a/src/test/java/com/ignfab/minalac/generator/models/GeometryModelTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/models/GeometryModelTest.java
@@ -1,9 +1,11 @@
 package com.ignfab.minalac.generator.models;
 
 import com.ignfab.minalac.generator.generation.CoordsConverter;
+import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
 import com.ignfab.minalac.generator.utils.world2d.chunk.ReadableChunk2d;
 import org.geotools.api.referencing.operation.TransformException;
 import org.geotools.referencing.operation.transform.IdentityTransform;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
@@ -13,14 +15,15 @@ import org.locationtech.jts.geom.util.AffineTransformation;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SuppressWarnings("checkstyle:ParenPad")
-public class TestGeometryModel {
+public class GeometryModelTest {
     private static final CoordsConverter CONVERTER = new CoordsConverter(IdentityTransform.create(2), new AffineTransformation());
     private static final GeometryFactory FACTORY = new GeometryFactory();
+    private static final WorldBBox2d LARGEBOX = new WorldBBox2d(-100, -100, 200, 200);
 
     @Test
-    public void testPointRasterization() throws TransformException {
-        System.out.println("testPointRasterization");
-        GeometryModel model = new GeometryModel(FACTORY.createPoint(new Coordinate(10.0, -20.0)), CONVERTER);
+    @DisplayName("Test point geometry rasterization")
+    public void testGetChunkPoint() throws TransformException {
+        GeometryModel model = new GeometryModel(FACTORY.createPoint(new Coordinate(10.0, -20.0)), CONVERTER, LARGEBOX);
         ReadableChunk2d chunk = model.getChunk();
 
         assertEquals(chunk.bbox().getSize().x(),  1, "x-size");
@@ -30,13 +33,14 @@ public class TestGeometryModel {
     }
 
     @Test
-    public void testLineStringRasterization() throws TransformException {
+    @DisplayName("Test linestring geometry rasterization")
+    public void testGetChunkLineString() throws TransformException {
         Coordinate[] coords = {
             new Coordinate(-1.0, -1.0),
             new Coordinate(-1.0,  1.0),
             new Coordinate( 2.0,  1.0)
         };
-        GeometryModel model = new GeometryModel(FACTORY.createLineString(coords), CONVERTER);
+        GeometryModel model = new GeometryModel(FACTORY.createLineString(coords), CONVERTER, LARGEBOX);
         ReadableChunk2d chunk = model.getChunk();
 
         // Expected :
@@ -66,13 +70,14 @@ public class TestGeometryModel {
     }
 
     @Test
-    public void testPolygonRasterization() throws TransformException {
+    @DisplayName("Test polygon geometry rasterization")
+    public void testGetChunkPolygon() throws TransformException {
         Coordinate[] coords = {
             new Coordinate(-2.0, -2.0),
             new Coordinate( 2.0,  2.0),
             new Coordinate( 2.0, -2.0),
             new Coordinate(-2.0, -2.0)};
-        GeometryModel model = new GeometryModel(FACTORY.createPolygon(coords), CONVERTER);
+        GeometryModel model = new GeometryModel(FACTORY.createPolygon(coords), CONVERTER, LARGEBOX);
         ReadableChunk2d chunk = model.getChunk();
 
         // Expected :
@@ -121,7 +126,8 @@ public class TestGeometryModel {
     }
 
     @Test
-    public void testPolygonWithHoleRasterization() throws TransformException {
+    @DisplayName("Test polygon with hole geometry rasterization")
+    public void testGetChunkPolygonWithHole() throws TransformException {
         Coordinate[] shapecoords = {
             new Coordinate(-2.0, -2.0),
             new Coordinate(-2.0,  2.0),
@@ -139,7 +145,7 @@ public class TestGeometryModel {
         LinearRing[] holes = { FACTORY.createLinearRing(holecoords) };
         LinearRing shape = FACTORY.createLinearRing(shapecoords);
 
-        GeometryModel model = new GeometryModel(FACTORY.createPolygon(shape, holes), CONVERTER);
+        GeometryModel model = new GeometryModel(FACTORY.createPolygon(shape, holes), CONVERTER, LARGEBOX);
         ReadableChunk2d chunk = model.getChunk();
 
         // Expected :
@@ -185,5 +191,56 @@ public class TestGeometryModel {
         assertEquals(chunk.get( 0,  2), GeometryModel.BORDER,  "(0, 2)");
         assertEquals(chunk.get( 1,  2), GeometryModel.BORDER,  "(1, 2)");
         assertEquals(chunk.get( 2,  2), GeometryModel.BORDER,  "(2, 2)");
+    }
+
+    @Test
+    @DisplayName("Test rasterization when intersecting with small box")
+    public void testGetChunkSmallBox() throws TransformException {
+        Coordinate[] coords = {
+            new Coordinate(-1.0,  1.0),
+            new Coordinate(-1.0, -5.0),
+            new Coordinate(-4.0, -2.0),
+            new Coordinate(-1.0,  1.0)};
+        GeometryModel model = new GeometryModel(
+            FACTORY.createPolygon(coords), CONVERTER, new WorldBBox2d(-3, -3, 5, 4));
+        ReadableChunk2d chunk = model.getChunk();
+
+        // This is what we have drawn:
+        // X = Four points of the polygon
+        // x = Rest of the polygon edge
+        // o = Inside of the polygon
+        // [] = Marks the limit bounding box
+
+        //     -4 -3 -2 -1  0  1
+        //   1           X
+        //   0    [   x  x      ]
+        //  -1    [x  o  x      ]
+        //  -2  X [o  o  x      ]
+        //  -3    [x  o  x      ]
+        //  -4        x  x
+        //  -5           X
+
+        // Bbox check
+        assertEquals( 3, chunk.bbox().getSize().x(), "x-size"); // Intersection only
+        assertEquals( 4, chunk.bbox().getSize().y(), "y-size");
+        assertEquals(-3, chunk.bbox().getMin().x(),  "x-min");
+        assertEquals(-3, chunk.bbox().getMin().y(),  "y-min");
+
+        // Pixel check
+        assertEquals(GeometryModel.OUTSIDE, chunk.get(-3,  0), "(-3, 0)");
+        assertEquals(GeometryModel.BORDER,  chunk.get(-2,  0), "(-2, 0)");
+        assertEquals(GeometryModel.BORDER,  chunk.get(-1,  0), "(-1, 0)");
+
+        assertEquals(GeometryModel.BORDER,  chunk.get(-3, -1), "(-3, -1)");
+        assertEquals(GeometryModel.INSIDE,  chunk.get(-2, -1), "(-2, -1)");
+        assertEquals(GeometryModel.BORDER,  chunk.get(-1, -1), "(-1, -1)");
+
+        assertEquals(GeometryModel.INSIDE,  chunk.get(-3, -2), "(-3, -2)");
+        assertEquals(GeometryModel.INSIDE,  chunk.get(-2, -2), "(-2, -2)");
+        assertEquals(GeometryModel.BORDER,  chunk.get(-1, -2), "(-1, -2)");
+
+        assertEquals(GeometryModel.BORDER,  chunk.get(-3, -3), "(-3, -3)");
+        assertEquals(GeometryModel.INSIDE,  chunk.get(-2, -3), "(-2, -3)");
+        assertEquals(GeometryModel.BORDER,  chunk.get(-1, -3), "(-1, -3)");
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/utils/world2d/WorldBBox2dTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/world2d/WorldBBox2dTest.java
@@ -5,17 +5,19 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class TestWorldBBox2d {
+public class WorldBBox2dTest {
     @Test
     public void testConstructor() {
-        // Instantiating a new voxel box
+        // Instantiating a new bounding box
         WorldBBox2d box = assertDoesNotThrow(() -> new WorldBBox2d(0, 0, 10, 10));
         assertEquals(new WorldCoords2d(0, 0), box.getMin());
         assertEquals(new WorldCoords2d(9, 9), box.getMax());
         assertEquals(new WorldSize2d(10, 10), box.getSize());
 
-        // Instantiating a 0 sized voxel box
-        assertThrows(IllegalArgumentException.class, () -> new WorldBBox2d(0, 0, 0, 0));
+        // Instanciating a 0 sized bounding box
+        assertDoesNotThrow(() -> new WorldBBox2d(0, 0, 0, 0));
+
+        // Instantiating a negative sized bounding box
         assertThrows(IllegalArgumentException.class, () -> new WorldBBox2d(0, 0, -1, -1));
     }
 
@@ -66,5 +68,37 @@ public class TestWorldBBox2d {
         WorldBBox2d box = new WorldBBox2d(-1, -2, 4, 5);
 
         assertEquals(new WorldBBox3d(-1, -2, -3, 4, 5, 6), box.to3d(-3, 6), "BBOX to 3d");
+    }
+
+    @Test
+    public void testIsEmpty() {
+        assertFalse(new WorldBBox2d(-1, 2, 3, 2).isEmpty());
+        assertTrue(new WorldBBox2d(-1, 2, 0, 2).isEmpty());
+        assertTrue(new WorldBBox2d(-1, 2, 3, 0).isEmpty());
+    }
+
+    @Test
+    public void testIntersection() {
+        WorldBBox2d box;
+        WorldBBox2d box2;
+
+        box = new WorldBBox2d(-2, 3, 5, 7);
+        box2 = new WorldBBox2d(-3, 2, 7, 8);
+
+        // Contained intersections and commutativity
+        assertEquals(box, box.intersection(box2));
+        assertEquals(box, box2.intersection(box));
+
+        // Various non intersecting boxes
+        assertTrue(box.intersection(new WorldBBox2d(3, -2, 3, 3)).isEmpty());
+        assertTrue(box.intersection(new WorldBBox2d(-2, -2, 3, 3)).isEmpty());
+        assertTrue(box.intersection(new WorldBBox2d(3, 3, 3, 3)).isEmpty());
+
+        // Various intersectig boxes
+        box = new WorldBBox2d(-2, -2, 5, 5);
+        assertEquals(new WorldBBox2d(-2, -2, 3, 3), box.intersection(new WorldBBox2d(-3, -3, 4, 4)));
+        assertEquals(new WorldBBox2d(0, -2, 3, 3), box.intersection(new WorldBBox2d(0, -3, 4, 4)));
+        assertEquals(new WorldBBox2d(-2, 0, 3, 3), box.intersection(new WorldBBox2d(-3, 0, 4, 4)));
+        assertEquals(new WorldBBox2d(0, 0, 3, 3), box.intersection(new WorldBBox2d(0, 0, 4, 4)));
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/utils/world2d/iterator/WorldBBox2dIteratorTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/world2d/iterator/WorldBBox2dIteratorTest.java
@@ -6,7 +6,9 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class TestWorldBBox2dIterator {
+import java.util.NoSuchElementException;
+
+public class WorldBBox2dIteratorTest {
     @Test
     public void testIterator() {
         WorldBBox2d bbox = new WorldBBox2d(1, 2, 3, 4);
@@ -24,10 +26,20 @@ public class TestWorldBBox2dIterator {
             count++;
         }
 
+        assertThrows(NoSuchElementException.class, () -> iterator.next());
+
         // Check if the iterator has visited every place exactly once.
         assertEquals(12, count, "Unexpected number of iterated element");
         for (int x = 0; x < 3; x++)
             for (int y = 0; y < 4; y++)
                 assertTrue(done[x][y], String.format("Coordinates (x = %d, y = %d) skipped !", x + 1, y + 2));
+    }
+
+    @Test
+    public void testIteratorOnEmptyBox() {
+        WorldBBox2d bbox = new WorldBBox2d(1, 2, 0, 0);
+        WorldBBox2dIterator iterator = new WorldBBox2dIterator(bbox);
+        assertFalse(iterator.hasNext());
+        assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/utils/world3d/WorldBBox3dTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/world3d/WorldBBox3dTest.java
@@ -13,7 +13,8 @@ public class WorldBBox3dTest {
         assertEquals(new WorldCoords3d(9, 9, 9), box.getMax(), "BBOX max");
         assertEquals(new WorldSize3d(10, 10, 10), box.getSize(), "BBOX size");
 
-        assertThrows(IllegalArgumentException.class, () -> new WorldBBox3d(0, 0, 0, 0, 0, 0), "Invalid BBOX (size 0)");
+        assertDoesNotThrow(() -> new WorldBBox3d(0, 0, 0, 0, 0, 0), "Valid empty bounding box");
+
         assertThrows(IllegalArgumentException.class, () -> new WorldBBox3d(0, 0, 0, -1, -1, -1), "Invalid BBOX (negative size)");
     }
 
@@ -53,4 +54,43 @@ public class WorldBBox3dTest {
 
         assertEquals(new WorldBBox2d(-1, -2, 4, 5), box.to2d(), "BBOX to 2d");
     }
+
+    @Test
+    public void testIsEmpty() {
+        assertFalse(new WorldBBox3d(-1, 2, 0, 3, 2, 4).isEmpty());
+        assertTrue(new WorldBBox3d(-1, 2, 0, 0, 2, 4).isEmpty());
+        assertTrue(new WorldBBox3d(-1, 2, 0, 3, 0, 4).isEmpty());
+        assertTrue(new WorldBBox3d(-1, 2, 0, 3, 2, 0).isEmpty());
+    }
+
+    @Test
+    public void testIntersection() {
+        WorldBBox3d box;
+        WorldBBox3d box2;
+
+        box = new WorldBBox3d(-2, 3, -1, 5, 7, 6);
+        box2 = new WorldBBox3d(-3, 2, -2, 7, 9, 8);
+
+        // Contained intersections and commutativity
+        assertEquals(box, box.intersection(box2));
+        assertEquals(box, box2.intersection(box));
+
+        // Various non intersecting boxes
+        assertTrue(box.intersection(new WorldBBox3d(3, -2, 5, 3, 3, 3)).isEmpty());
+        assertTrue(box.intersection(new WorldBBox3d(-2, -2, -1, 3, 3, 3)).isEmpty());
+        assertTrue(box.intersection(new WorldBBox3d(3, 3, -1, 3, 3, 3)).isEmpty());
+        assertTrue(box.intersection(new WorldBBox3d(3, -2, 3, 3, 3, 3)).isEmpty());
+
+        // Various intersectig boxes
+        box = new WorldBBox3d(-2, -2, -2, 5, 5, 5);
+        assertEquals(new WorldBBox3d(-2, -2, -2, 3, 3, 3), box.intersection(new WorldBBox3d(-3, -3, -3, 4, 4, 4)));
+        assertEquals(new WorldBBox3d(0, -2, -2, 3, 3, 3), box.intersection(new WorldBBox3d(0, -3, -3, 4, 4, 4)));
+        assertEquals(new WorldBBox3d(-2, 0, -2, 3, 3, 3), box.intersection(new WorldBBox3d(-3, 0, -3, 4, 4, 4)));
+        assertEquals(new WorldBBox3d(0, 0, -2, 3, 3, 3), box.intersection(new WorldBBox3d(0, 0, -3, 4, 4, 4)));
+        assertEquals(new WorldBBox3d(-2, -2, 0, 3, 3, 3), box.intersection(new WorldBBox3d(-3, -3, 0, 4, 4, 4)));
+        assertEquals(new WorldBBox3d(0, -2, 0, 3, 3, 3), box.intersection(new WorldBBox3d(0, -3, 0, 4, 4, 4)));
+        assertEquals(new WorldBBox3d(-2, 0, 0, 3, 3, 3), box.intersection(new WorldBBox3d(-3, 0, 0, 4, 4, 4)));
+        assertEquals(new WorldBBox3d(0, 0, 0, 3, 3, 3), box.intersection(new WorldBBox3d(0, 0, 0, 4, 4, 4)));
+    }
 }
+

--- a/src/test/java/com/ignfab/minalac/generator/utils/world3d/iterator/WorldBBox3dIteratorTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/world3d/iterator/WorldBBox3dIteratorTest.java
@@ -4,6 +4,8 @@ import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
 import org.junit.jupiter.api.Test;
 
+import java.util.NoSuchElementException;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 public class WorldBBox3dIteratorTest {
@@ -25,6 +27,8 @@ public class WorldBBox3dIteratorTest {
             count++;
         }
 
+        assertThrows(NoSuchElementException.class, () -> iterator.next());
+
         // Check if the iterator has visited every place exactly once.
         assertEquals(24, count, "Unexpected number of iterated element");
         for (int x = 0; x < 4; x++)
@@ -32,4 +36,13 @@ public class WorldBBox3dIteratorTest {
                 for (int z = 0; z < 2; z++)
                     assertTrue(done[x][y][z], String.format("Coordinates (x = %d, y = %d, z = %d) skipped !", x + 1, y + 2, z + 3));
     }
+
+    @Test
+    public void testIteratorOnEmptyBox() {
+        WorldBBox3d bbox = new WorldBBox3d(1, 2, 3, 0, 0, 0);
+        WorldBBox3dIterator iterator = new WorldBBox3dIterator(bbox);
+        assertFalse(iterator.hasNext());
+        assertThrows(NoSuchElementException.class, () -> iterator.next());
+    }
+
 }


### PR DESCRIPTION
### Type of modification
- Code
- Tests

### Changes

Allow spatial limitation of model rasterization.

#### Feature description

This PR :
- Allows WorldSize2d to be 0;
- Adds intersection computation on BBoxes;
- Uses these intersections to limit rasterization;
- Implements that limit in SampleImplementation;

#### Showcase

Everything should just work the same.
Another useless PR :p...

### Reason
... because it's beautiful.
Actually, because limiting rasterization will ensure indexes are always inside generation box when rendering.

### TODOs

This PR is still in progress.
- Add javadoc everywhere it is needed;
- Verify rendering code is simplified or simplify it accordingly;

### Self-checks

- [X] The code has unit tests associated
- [X] The code has Javadoc Comments associated
- [X] Complex / Unexpected code is explained / justified with a small comment (I hope so!)
- ~~Relevant documentation inside the `/docs` folder has been updated~~
- [X] All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)
- [X] Git history is clean (each commit accomplish a single task and describe it accordingly)
- ~~The texts have been proofread (documentation, error messages, logs, comments...)~~
