### PR TITLE
fix(gml-version): Properly use GML 3.1 in data provider

### DIFF
--- a/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
+++ b/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
@@ -8,7 +8,7 @@ import com.ignfab.minalac.generator.outputs.minetest.MTVoxelWorld;
 import com.ignfab.minalac.generator.generation.CoordsConverter;
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.generation.HeightMap;
-import com.ignfab.minalac.generator.inputs.WFS2DataProvider;
+import com.ignfab.minalac.generator.inputs.WFS1_1_GML3_1_DataProvider;
 import com.ignfab.minalac.generator.renderers.VectorRenderer;
 import com.ignfab.minalac.generator.utils.network.HttpTrustAllSSL;
 import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
@@ -111,7 +111,7 @@ public final class SampleImplementation {
 
             System.out.println("Downloading buildings");
             downloadVectorFeatures(
-                new WFS2DataProvider("https://data.geopf.fr/wfs/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=BDTOPO_V3:batiment&STARTINDEX=0&COUNT=1000&SRSNAME=urn:ogc:def:crs:EPSG::2154&" + bboxURL + ",urn:ogc:def:crs:EPSG::2154"),
+                new WFS1_1_GML3_1_DataProvider("https://data.geopf.fr/wfs/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=BDTOPO_V3:batiment&STARTINDEX=0&COUNT=1000&SRSNAME=urn:ogc:def:crs:EPSG::2154&" + bboxURL + ",urn:ogc:def:crs:EPSG::2154&outputFormat=text%2Fxml%3B%20subtype%3Dgml%2F3.1.1"),
                 generation.makeCoordsConverter(crs),  // This is supposed to be the layer CRS (actually the same for this demo)
                 "building",
                 store,
@@ -147,7 +147,7 @@ public final class SampleImplementation {
         System.out.println("Execution time: " + (end - start) / 1000 + "s");
     }
 
-    private static void downloadVectorFeatures(WFS2DataProvider provider, CoordsConverter converter, String type, ModelStore store, WorldBBox2d limits)
+    private static void downloadVectorFeatures(WFS1_1_GML3_1_DataProvider provider, CoordsConverter converter, String type, ModelStore store, WorldBBox2d limits)
             throws NoSuchElementException, TransformException, IOException, ParserConfigurationException, SAXException {
         SimpleFeatureIterator iterator = provider.getFeatures().features();
         while (iterator.hasNext())

--- a/src/main/java/com/ignfab/minalac/generator/inputs/WFS1_1_GML3_1_DataProvider.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/WFS1_1_GML3_1_DataProvider.java
@@ -10,10 +10,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 
-public class WFS2DataProvider {
+@SuppressWarnings("checkstyle:TypeName") // Underscore character used to better identify "WFS 1.1" and "GML 3.1"
+public class WFS1_1_GML3_1_DataProvider {
     private final String baseURL;
 
-    public WFS2DataProvider(String baseURL) {
+    public WFS1_1_GML3_1_DataProvider(String baseURL) {
         this.baseURL = baseURL;
     }
 
@@ -24,11 +25,8 @@ public class WFS2DataProvider {
 
         InputStream stream = url.openStream();
 
-        InputStream replacedStream = new ReplacingInputStream(new ReplacingInputStream(new ReplacingInputStream(new ReplacingInputStream(stream,
-                "</wfs:member>\n<wfs:member>", ""),
-                "wfs:member", "gml:featureMembers"),
-                "http://BDTOPO_V3", "http://BDTOPOV3"),
-                "xmlns:gml=\"http://www.opengis.net/gml/3.2\"", "xmlns:gml=\"http://www.opengis.net/gml\"");
+        // Invalidate schema declaration because GML version 3.1 is not used in this schema (version is unspecified, defaulting to 3.2)
+        InputStream replacedStream = new ReplacingInputStream(stream, "http://BDTOPO_V3", "explicitly-invalid");
 
         return gml.decodeFeatureCollection(replacedStream);
    }


### PR DESCRIPTION
### Type of modification

Code: Inputs

### Issue

MINALAC-60

### Changes

Fixed GML version 3.1 in `WFS1_1_GML3_1_DataProvider` class.

#### Feature description

Explicitly request GML 3.1 when retrieving WFS data.
Cleanup some old code no longer required.

#### Showcase

It should all work the same!

### Reason

GeoTools only supports GML 3.1 (referred to as "GML 3"), not 3.2. Data-source at IGN are serving GML 3.2 by default if no version is explicitly requested. This was the reason of the multiple string replacements to fix version. Those are no longer required.

### TODOs

There is only one string replacement left, this is because GeoServer does not forward the requested GML version to sub-requests. Once this erroneous behavior has been addressed, it won't be needed anymore!

### Self-checks

- ~~The code has unit tests associated~~
- ~~The code has Javadoc Comments associated~~
- [x] Complex / Unexpected code is explained / justified with a small comment
- ~~Relevant documentation inside the `/docs` folder has been updated~~
- ~~All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)~~
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [x] The texts have been proofread (documentation, error messages, logs, comments...)
