### PR TITLE
feat(parser) : Add ParamsParser utility classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,11 @@ cd minalac-generator # All commands are always based on the project root
 ```
 
 Compile and run using Maven:
-<!-- TODO Include a run command with basic options (perhaps referencing an example params file from the repo?) -->
 
+```shell
+mvn -DskipTests=true clean package && java -jar target/Generator.jar -p examples/default.yaml $HOME/.minetest/worlds/minalac
+```
+<!--
 ### From pre-built JAR
 
-<!-- TODO Download JAR from latest release and run it with default params -->
+TODO Download JAR from latest release and run it with default params -->

--- a/docs/usage/GenerationParameters.md
+++ b/docs/usage/GenerationParameters.md
@@ -1,0 +1,27 @@
+# Generation parameters
+
+Generation parameters can be written in Yaml or Json. Yaml is better for readability and Json for communication between programs.
+
+These parameters generate a map of 1000x1000 voxels around IGN building at Saint-Mandé (FR), in Minetest format, with 1 meter voxels in every direction:
+
+```yaml
+area:
+  center:
+    latitude: 48.845
+    longitude: 2.425
+  extendX: 1000
+  extendY: 1000
+verticalScale: 1.0
+horizontalScale: 1.0
+crs: EPSG:2154
+format: minetest
+```
+
+Available fields:
+ - `area`: Area to be rendered
+   - `center`: `longitude` and `latitude` of the center point
+   - `extendsX` and `extendsY`: Area extends in both horizontal directions (in voxels)
+ - `verticalScale`: Vertical size of voxels (in map units, usually meters)
+ - `horizontalScale`: Horizontal size of voxels (in map units, usually meters)
+ - `crs`: Coordinate Reference System to be used for projecting geographical data into voxel world
+ - `format`: Output format (`minetest` or `minecraft`)

--- a/docs/usage/Run.md
+++ b/docs/usage/Run.md
@@ -3,26 +3,41 @@
 > [!IMPORTANT]
 > Don't forget to configure your [proxy](../Proxy.md) if needed!
 
-<!-- TODO Update options with configuration instead of command line arguments -->
-The generator takes input options to configure the work to do. All the snippet below will use the following options:
+## TL;DR;
+
+Run and compile from repository root:
+
 ```shell
-options="$HOME/.minetest/worlds/minalac EPSG:2154 600000 6340000 1000 1000 1.0 10.0 minetest"
+mvn -DskipTests=true clean package && java -jar target/Generator.jar -p examples/default.yaml $HOME/.minetest/worlds/minalac
 ```
 
-For parameters explanation, refer to comments in [`SampleImplementation`](../../src/main/java/com/ignfab/minalac/generator/SampleImplementation.java) class.
+Run jar only:
 
-The simplest way to run the generator is to run the executable JAR file:
 ```shell
-java -jar Generator.jar $options
+java -jar Generator.jar -p examples/default.yaml $HOME/.minetest/worlds/minalac
 ```
 
 This command assume you already have the `Generator.jar` file in your current working directory. If this is not the case, see instructions below and pick the one that best fits your case.
+
+## Generation parameters
+
+Generation involves too many parameters to be passed on command line. They are passed either by file using `-p`/`--param-file` command line option or using `MINALAC_PARAMS` environment variable.
+
+Refer to [generation parameters documentation](GenerationParameters.md) for further information.
+
+## Command line arguments
+
+`-h` `--help` display command usage.
+`-p path` `--param-file path` read generation parameters from given path. If omitted, parameters are read from `MINALAC_PARAMS` environment variable.
+`outputPath` generation output path (required).
+
+Output path and generation parameters has to be provided.
 
 ## Compile and run
 
 If you have cloned the project repository, you can [build the JAR using Maven](../tools/Maven.md#create-an-executable-jar) and run it:
 ```shell
-mvn -DskipTests=true clean package && java -jar target/Generator.jar $options
+mvn -DskipTests=true clean package && java -jar target/Generator.jar -p examples/default.yaml $HOME/.minetest/worlds/minalac
 ```
 
 ## Download workflow artifact
@@ -34,7 +49,7 @@ If you just want to test the JAR from a different branch (e.g. to validate a PR)
 
 Once you downloaded (and extracted) the artifact, you should have the `Generator.jar` file and will be able to run it:
 ```shell
-java -jar Generator.jar $options
+java -jar Generator.jar -p examples/default.yaml $HOME/.minetest/worlds/minalac
 ```
 
 ## Run using Maven
@@ -44,5 +59,5 @@ If, for some reason, you don't want to build the JAR, you can run the [`exec:jav
 mvn clean compile exec:java \
   -Dexec.cleanupDaemonThreads=false \
   -Dexec.mainClass="com.ignfab.minalac.generator.SampleImplementation" \
-  -Dexec.args="$options"
+  -Dexec.args="-p examples/default.yaml $HOME/.minetest/worlds/minalac"
 ```

--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -1,0 +1,10 @@
+verticalScale: 1.0
+horizontalScale: 1.0
+area:
+  center:
+    latitude: 48.845
+    longitude: 2.425
+  extendX: 1000
+  extendY: 1000
+crs: EPSG:2154
+format: minetest

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <geotools.version>31.0</geotools.version>
+        <jackson.version>2.17.0</jackson.version>
     </properties>
 
     <repositories>
@@ -101,6 +102,34 @@
             <groupId>com.github.Querz</groupId>
             <artifactId>NBT</artifactId>
             <version>6.1</version>
+        </dependency>
+        <!-- Jackson (Yaml/Json deserialization) -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <!-- Transitive dependencies for databind (If missing they might have a NoSuchMethodError)-->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <!-- Apache command line argument parsing -->
+        <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+            <version>1.8.0</version>
         </dependency>
 
         <!--

--- a/src/main/java/com/ignfab/minalac/generator/MinalacGeneratorCLI.java
+++ b/src/main/java/com/ignfab/minalac/generator/MinalacGeneratorCLI.java
@@ -1,0 +1,145 @@
+package com.ignfab.minalac.generator;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.apache.commons.cli.Option;
+
+/**
+ * A command line parser and basic processor.
+ * MinalacGeneratorCLI performs parsing, basic validation and some basic tasks such as retrieving generation parameters.
+ */
+public class MinalacGeneratorCLI {
+
+    private static final String PARAMS_ENVVAR_NAME = "MINALAC_PARAMS";
+
+    private Path outputPath;
+    private Path parametersPath;
+
+    private final Options options;
+
+    /**
+     * Creates a new GeneratorCommandLine.
+     */
+    public MinalacGeneratorCLI() {
+        options = new Options();
+        options.addOption(new Option("h", "help", true, "Display command usage"));
+        options.addOption(new Option("p", "param-file", true, "Get generation params from file"));
+    }
+
+    /**
+     * Parses given arguments.
+     *
+     * @param args Argument array (usually those from main method)
+     */
+    public void parse(String[] args) {
+        CommandLineParser parser = new DefaultParser();
+        CommandLine cmd;
+        try {
+            cmd = parser.parse(options, args);
+        } catch (ParseException e) {
+            System.out.println(e.getMessage());
+            usage();
+            System.exit(1);
+            return; // Must please linter with uninitialized cmd
+        }
+
+        if (cmd.hasOption("h")) {
+            usage();
+            System.exit(0);
+        }
+
+        if (cmd.hasOption("p")) {
+            try {
+                parametersPath = Paths.get(cmd.getOptionValue("p"));
+            } catch (InvalidPathException e) {
+                System.out.println("Invalid parameters file path");
+                System.out.println(e.getMessage());
+                System.exit(1);
+            }
+        }
+
+        if (cmd.getArgs().length != 1) {
+            System.out.println("Please provide output path");
+            usage();
+            System.exit(1);
+        }
+
+        try {
+            outputPath = Paths.get(cmd.getArgs()[0]);
+        } catch (InvalidPathException e) {
+            System.out.println("Invalid output path");
+            System.out.println(e.getMessage());
+            System.exit(1);
+        }
+    }
+
+    /**
+     * Prints command line usage.
+     */
+    public void usage() {
+        HelpFormatter helper = new HelpFormatter();
+        helper.printHelp("[-h] [-p <parametersFilePath>] <outputPath>", options);
+    }
+
+    /**
+     * Reads generation parameters from where they are (file or environment variable).
+     *
+     * @return Content of parameters file/variable
+     */
+    public String readParameters() {
+        String parameters = null; // Must please linter with uninitialized parameters
+
+        if (parametersPath != null) {
+            if (!Files.exists(parametersPath)) {
+                System.out.printf("%s does not exist%n", parametersPath);
+                System.exit(1);
+            }
+
+            if (!Files.isRegularFile(parametersPath)) {
+                System.out.printf("%s is not a regular file%n", parametersPath);
+                System.exit(1);
+            }
+
+            if (!Files.isReadable(parametersPath)) {
+                System.out.printf("%s is not readable%n", parametersPath);
+                System.exit(1);
+            }
+
+            try {
+                parameters = Files.readString(parametersPath);
+            } catch (IOException e) {
+                System.out.printf("Error reading parameters from %s%n", parametersPath);
+                e.printStackTrace();
+                System.exit(1);
+            }
+        } else {
+            parameters = System.getenv(PARAMS_ENVVAR_NAME);
+        }
+
+        if (parameters == null) {
+            System.out.printf("Please provide generation parameters (either with -p option or using %s environment variable)%n", PARAMS_ENVVAR_NAME);
+            usage();
+            System.exit(1);
+        }
+        return parameters;
+    }
+
+    /**
+     * Returns output path.
+     *
+     * @return output path
+     */
+    public Path getOutputPath() {
+        return outputPath;
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
+++ b/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
@@ -1,10 +1,9 @@
 package com.ignfab.minalac.generator;
 
-
 import com.ignfab.minalac.generator.models.GeometryModel;
 import com.ignfab.minalac.generator.models.ModelStore;
-import com.ignfab.minalac.generator.outputs.minecraft.MCVoxelWorld;
-import com.ignfab.minalac.generator.outputs.minetest.MTVoxelWorld;
+import com.ignfab.minalac.generator.parsing.ParamsParser;
+import com.ignfab.minalac.generator.parsing.ParseException;
 import com.ignfab.minalac.generator.generation.CoordsConverter;
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.generation.HeightMap;
@@ -12,8 +11,8 @@ import com.ignfab.minalac.generator.inputs.WFS1_1_GML3_1_DataProvider;
 import com.ignfab.minalac.generator.renderers.VectorRenderer;
 import com.ignfab.minalac.generator.utils.network.HttpTrustAllSSL;
 import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
+import com.ignfab.minalac.generator.utils.world2d.WorldSize2d;
 import com.ignfab.minalac.generator.utils.world2d.iterator.Chunk2dElement;
-import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
 import com.ignfab.minalac.generator.world.MapWriteException;
 import com.ignfab.minalac.generator.world.OutOfWorldException;
@@ -31,6 +30,7 @@ import org.locationtech.jts.geom.Geometry;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -38,9 +38,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.function.Supplier;
 
 /**
  * This is a temporary class to have an idea of how the program works.
@@ -51,103 +49,72 @@ public final class SampleImplementation {
         throw new UnsupportedOperationException();
     }
 
-    private static final Map<String, Supplier<VoxelWorld>> FORMATS = Map.of(
-        "minecraft", MCVoxelWorld::new,
-        "minetest", MTVoxelWorld::new
-    );
-
     /**
      * Serves as the entry point for the program.
      *
      * @param args command line arguments
      */
     public static void main(String[] args)
-            throws IOException, OutOfWorldException, MapWriteException, SAXException, FactoryException,
-            ParserConfigurationException, TransformException {
+        throws IOException, OutOfWorldException, MapWriteException, SAXException, FactoryException,
+        ParserConfigurationException, TransformException, ParseException {
         long start = System.currentTimeMillis();
         HttpTrustAllSSL.applyGlobally();
-        if (args.length != 9) {
-            System.out.println("There must be nine arguments : directoryPath, crs, centerX, centerY, extendX, extendY, horizontalScale, verticalScale, format");
-        } else {
-            //Example : "/home/john/.minetest/worlds/map/"
-            String directoryPath = args[0];
 
-            //Example : "EPSG:2154"
-            String crsName = args[1];
-            CoordinateReferenceSystem crs = CRS.decode(crsName);
+        // Command line arguments parsing & basic processing
+        MinalacGeneratorCLI cli = new MinalacGeneratorCLI();
+        cli.parse(args);
 
-            // Center coordinates (in CRS), example : 600000 6340000
-            // TODO: Center should be in Lon/lat in WGS84
-            float centerX = Float.parseFloat(args[2]);
-            float centerY = Float.parseFloat(args[3]);
+        // Generation parameters parsing
+        ParamsParser parser = new ParamsParser(cli.readParameters());
 
-            // Extends in voxel, example: 1000 1000, must be >0
-            int extendX = Integer.parseInt(args[4]);
-            int extendY = Integer.parseInt(args[5]);
+        System.out.println("Creation of the map.");
 
-            // Horizontal scale (horizontal size of voxel in meters), example: 1.0, must be >0
-            float horizontalScale = Float.parseFloat(args[6]);
+        Generation generation = parser.createGeneration();
 
-            // Vertical scale (vertical size of voxel in meters), example: 10.0, must be >0
-            float verticalScale = Float.parseFloat(args[7]);
+        String crsName = "EPSG:2154";
+        CoordinateReferenceSystem crs = CRS.decode(crsName);
+        Envelope envelope = generation.getEnvelopeForCRS(crs);
+        String bboxURL = "BBOX=" + envelope.getMinX() + "," + envelope.getMinY() + "," + envelope.getMaxX() + "," + envelope.getMaxY();
 
-            // Output format
-            String format = args[8].toLowerCase();
-            if (!FORMATS.containsKey(format))
-                throw new IllegalArgumentException("Unknown format: " + format);
+        // Downloads
+        ModelStore store = new ModelStore();
 
-            System.out.println("Creation of the map.");
+        System.out.println("Downloading height map");
+        WorldSize2d size = generation.getWorldBBox2d().getSize();
+        HeightMap heightMap = createGroundHeightMap("https://data.geopf.fr/wms-r/wms?LAYERS=RGEALTI-MNT_PYR-ZIP_FXX_LAMB93_WMS&FORMAT=image/x-bil;bits=32&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&STYLES=&CRS=" + crsName + "&" + bboxURL, size.x(), size.y(), generation.getVerticalScale());
 
-            Generation generation = new Generation(
-                crs,
-                centerX, centerY,
-                extendX, extendY,
-                horizontalScale, verticalScale
-            );
+        System.out.println("Downloading buildings");
+        downloadVectorFeatures(
+            new WFS1_1_GML3_1_DataProvider("https://data.geopf.fr/wfs/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=BDTOPO_V3:batiment&STARTINDEX=0&COUNT=1000&SRSNAME=urn:ogc:def:crs:EPSG::2154&" + bboxURL + ",urn:ogc:def:crs:EPSG::2154&outputFormat=text%2Fxml%3B%20subtype%3Dgml%2F3.1.1"),
+            generation.makeCoordsConverter(crs),  // This is supposed to be the layer CRS (actually the same for this demo)
+            "building",
+            store,
+            heightMap.bbox());
 
-            Envelope envelope = generation.getEnvelopeForCRS(crs);
-            String bboxURL = "BBOX=" + envelope.getMinX() + "," + envelope.getMinY() + "," + envelope.getMaxX() + "," + envelope.getMaxY();
+        // Rendering
+        System.out.println("World creation");
+        VoxelWorld world = parser.createVoxelWorld();
 
-            // Downloads
-            ModelStore store = new ModelStore();
+        System.out.println("Placing ground");
+        placeVoxelFromHeightMap(heightMap, world);
 
-            System.out.println("Downloading height map");
-            HeightMap heightMap = createGroundHeightMap("https://data.geopf.fr/wms-r/wms?LAYERS=RGEALTI-MNT_PYR-ZIP_FXX_LAMB93_WMS&FORMAT=image/x-bil;bits=32&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&STYLES=&CRS=" + crsName + "&" + bboxURL, extendX, extendY, verticalScale);
+        System.out.println("Placing buildings");
+        new VectorRenderer(
+            heightMap,
+            store.getByType("building"),
+            world.getFactory().createVoxelType(SemanticType.COBBLE),
+            world.getFactory().createVoxelType(SemanticType.BRICK)
+        ).render();
 
-            System.out.println("Downloading buildings");
-            downloadVectorFeatures(
-                new WFS1_1_GML3_1_DataProvider("https://data.geopf.fr/wfs/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=BDTOPO_V3:batiment&STARTINDEX=0&COUNT=1000&SRSNAME=urn:ogc:def:crs:EPSG::2154&" + bboxURL + ",urn:ogc:def:crs:EPSG::2154&outputFormat=text%2Fxml%3B%20subtype%3Dgml%2F3.1.1"),
-                generation.makeCoordsConverter(crs),  // This is supposed to be the layer CRS (actually the same for this demo)
-                "building",
-                store,
-                heightMap.bbox());
+        // Save map
+        System.out.println("Saving");
+        VoxelWorldMetadata metadata = world.getMetadata();
+        metadata.setSpawn(new WorldCoords3d(0, 0, heightMap.get(0, 0) + 1));
+        metadata.setWorldName("Minalac");
+        save(cli.getOutputPath().toFile(), world);
 
-            System.out.println("World creation");
-            VoxelWorld world = FORMATS.get(format).get();
+        System.out.println("Done");
 
-            System.out.println("Placing ground");
-            placeVoxelFromHeightMap(heightMap, world);
-
-            System.out.println("Placing buildings");
-            new VectorRenderer(
-                heightMap,
-                store.getByType("building"),
-                world.getFactory().createVoxelType(SemanticType.COBBLE),
-                world.getFactory().createVoxelType(SemanticType.BRICK)
-            ).render();
-
-            System.out.println("Saving");
-            VoxelWorldMetadata metadata = world.getMetadata();
-            metadata.setSpawn(new WorldCoords3d(0, 0, heightMap.get(0, 0) + 1));
-            metadata.setWorldName("Minalac");
-            metadata.setBbox(new WorldBBox3d(-extendX / 2, -extendY / 2, 0, extendX, extendY, 1)); // Z is ignored for now
-            save(new File(directoryPath), world);
-
-            System.out.println("Done");
-
-            // TODO: That's not working. It's an attempt to avoid InterruptExecption thrown by threads started by CRS.decode
-            CRS.cleanupThreadLocals();
-        }
         long end = System.currentTimeMillis();
         System.out.println("Execution time: " + (end - start) / 1000 + "s");
     }
@@ -178,7 +145,7 @@ public final class SampleImplementation {
         }
     }
 
-    private static HeightMap createGroundHeightMap(String partialUrl, int width, int height, float verticalScale) throws MalformedURLException {
+    private static HeightMap createGroundHeightMap(String partialUrl, int width, int height, double verticalScale) throws MalformedURLException {
         float[] mntArray;
         byte[] data;
         URL url = new URL(partialUrl + "&WIDTH=" + width + "&HEIGHT=" + height);

--- a/src/main/java/com/ignfab/minalac/generator/generation/Generation.java
+++ b/src/main/java/com/ignfab/minalac/generator/generation/Generation.java
@@ -81,7 +81,6 @@ public class Generation {
      * in a given CRS.
      *
      * @param crs Coordinate reference system to get envelope for.
-     *
      * @return Envelope covering generated world in CRS.
      */
     public Envelope getEnvelopeForCRS(CoordinateReferenceSystem crs) throws FactoryException, TransformException {
@@ -118,5 +117,15 @@ public class Generation {
      */
     public CoordsConverter makeCoordsConverter(CoordinateReferenceSystem sourceCrs) throws FactoryException {
         return new CoordsConverter(CRS.findMathTransform(sourceCrs, crs), crsToVoxel);
+    }
+
+    /**
+     * Returns the vertical scale.
+     *
+     * @return the vertical scale
+     */
+    //To be removed when vertical is used by this class. (Renderers will probably contain that value)
+    public double getVerticalScale() {
+        return verticalScale;
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/parsing/ParamsParser.java
+++ b/src/main/java/com/ignfab/minalac/generator/parsing/ParamsParser.java
@@ -1,0 +1,115 @@
+package com.ignfab.minalac.generator.parsing;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.outputs.minecraft.MCVoxelWorld;
+import com.ignfab.minalac.generator.outputs.minetest.MTVoxelWorld;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+import com.ignfab.minalac.generator.world.VoxelWorld;
+import org.geotools.api.geometry.Position;
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.api.referencing.operation.MathTransform;
+import org.geotools.api.referencing.operation.TransformException;
+import org.geotools.geometry.Position2D;
+import org.geotools.referencing.CRS;
+import org.geotools.referencing.crs.DefaultGeographicCRS;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * A Json/Yaml parser able to decode parameters into Generation and World objects.
+ */
+public class ParamsParser {
+    private final RawParams rawParams;
+    private final CoordinateReferenceSystem targetCrs;
+    private static final Map<String, Supplier<VoxelWorld>> FORMATS = Map.of(
+        "minecraft", MCVoxelWorld::new,
+        "minetest", MTVoxelWorld::new
+    );
+
+    /**
+     * Builds a parser from a serialized string.
+     *
+     * @param serialized A string containing parameters data in Json or Yaml format
+     */
+    public ParamsParser(String serialized) throws ParseException {
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        mapper.configure(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES, true);
+        try {
+            rawParams = mapper.readValue(serialized, RawParams.class);
+        } catch (JsonProcessingException e) {
+            throw new ParseException(e);
+        }
+        if (rawParams.verticalScale <= 0)
+            throw new ParseException("The field verticalScale must be greater than 0");
+        if (rawParams.horizontalScale <= 0)
+            throw new ParseException("The field horizontalScale must be greater than 0");
+        if (-90 > rawParams.area.center.latitude
+            || rawParams.area.center.latitude > 90
+            || -180 > rawParams.area.center.longitude
+            || rawParams.area.center.longitude > 180)
+            throw new ParseException("The coordinates of the center field are incorrect");
+        if (rawParams.area.extendX <= 0)
+            throw new ParseException("The field extendX must be greater than 0");
+        if (rawParams.area.extendY <= 0)
+            throw new ParseException("The field extendY must be greater than 0");
+        if (!FORMATS.containsKey(rawParams.format))
+            throw new ParseException("The provided format is not supported");
+        try {
+            //TODO : If not provided its default value should be calculated by finding the appropriated projected CRS for the provided center point.
+            // At the moment the default value is EPSG:2154
+            targetCrs = CRS.decode(rawParams.crs == null ? "EPSG:2154" : rawParams.crs);
+        } catch (FactoryException e) {
+            throw new ParseException(e);
+        }
+    }
+
+    /**
+     * Creates generation object from parameters.
+     *
+     * @return A Generation object corresponding to parameters given at construction
+     */
+    public Generation createGeneration() {
+        // This conversion is temporary.
+        // Should be removed when Generation class supports the conversion from WSG84 to targetCRS
+        double[] convertedCoords;
+        try {
+            MathTransform mathTransform = CRS.findMathTransform(DefaultGeographicCRS.WGS84, targetCrs);
+            Position position = new Position2D(DefaultGeographicCRS.WGS84, rawParams.area.center.longitude, rawParams.area.center.latitude);
+            convertedCoords = mathTransform.transform(position, position).getCoordinate();
+        } catch (FactoryException | TransformException e) {
+            throw new RuntimeException(e);
+        }
+        return new Generation(targetCrs,
+            convertedCoords[0],
+            convertedCoords[1],
+            rawParams.area.extendX,
+            rawParams.area.extendY,
+            rawParams.horizontalScale,
+            rawParams.verticalScale
+        );
+    }
+
+    /**
+     * Creates voxel world object from parameters.
+     *
+     * @return A VoxelWorld object corresponding to parameters given at construction
+     */
+    public VoxelWorld createVoxelWorld() {
+        VoxelWorld world = FORMATS.get(rawParams.format).get();
+        world.getMetadata().setBbox(new WorldBBox3d(
+            -rawParams.area.extendX / 2,
+            -rawParams.area.extendY / 2,
+            0, // Not used for now but should be the minimum altitude
+            rawParams.area.extendX,
+            rawParams.area.extendY,
+            1 // Not used for now but should be world z size
+        ));
+        return world;
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/parsing/ParseException.java
+++ b/src/main/java/com/ignfab/minalac/generator/parsing/ParseException.java
@@ -1,0 +1,35 @@
+package com.ignfab.minalac.generator.parsing;
+
+/**
+ * Exception thrown if a problem occurs during parsing.
+ */
+public class ParseException extends Exception {
+
+    /**
+     * Creates a ParseException.
+     *
+     * @param message Message explaining the problem
+     */
+    public ParseException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a ParseException.
+     *
+     * @param message Message explaining the problem
+     * @param cause Throwable that caused the problem
+     */
+    public ParseException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Creates a ParseException.
+     *
+     * @param cause Throwable that caused the problem
+     */
+    public ParseException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/parsing/RawParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parsing/RawParams.java
@@ -1,0 +1,128 @@
+package com.ignfab.minalac.generator.parsing;
+
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+
+import java.beans.ConstructorProperties;
+
+/**
+ * RawParams is a POJO representing the parameters used during the generation.
+ * This class mirrors the structure of the object to be deserialized.
+ * Required fields are initialized by the constructor.
+ * The verification of their presence is done by the constructor via the {@code @ConstructorProperties} annotation, as it is currently the only supported method by the library.
+ * @see <a href="https://github.com/FasterXML/jackson-dataformat-xml/issues/625">GitHub issue about required fields during deserialization</a>.
+ *
+ * Refer to docs/usage/GenerationParameters.md for parameters format.
+ */
+// Since attributes are purposely kept public for this class the checkstyle for visibility is disabled.
+@SuppressWarnings("checkstyle:VisibilityModifier")
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class RawParams {
+
+    /**
+     * Area to be rendered.
+     */
+    public static class Area {
+        /**
+         * Longitude and latitude coordinates.
+         */
+        public static class LatitudeLongitude {
+            /**
+             * Latitude.
+             */
+            public double latitude;
+            /**
+             * Longitude.
+             */
+            public double longitude;
+
+            /**
+             * Constructor used to ensure that the required fields are present during deserialization.
+             *
+             * @param latitude  the latitude of the center.
+             * @param longitude the longitude of the center.
+             */
+            @ConstructorProperties({"latitude", "longitude"})
+            LatitudeLongitude(double latitude, double longitude) {
+                this.latitude = latitude;
+                this.longitude = longitude;
+            }
+        }
+
+        /**
+         * The center of the area.
+         * This field is required during deserialization.
+         */
+        public LatitudeLongitude center;
+        /**
+         * Extends in voxel along the x-axis.
+         * This field is required during deserialization.
+         */
+        public int extendX;
+        /**
+         * Extends in voxel along the y-axis.
+         * This field is required during deserialization.
+         */
+        public int extendY;
+
+        /**
+         * Constructor used to ensure that the required fields are present during deserialization.
+         *
+         * @param center  the center of the area.
+         * @param extendX the extends in voxel along the x-axis.
+         * @param extendY the extends in voxel along the y-axis.
+         */
+        @ConstructorProperties({ "center", "extendX", "extendY" })
+        Area(LatitudeLongitude center, int extendX, int extendY) {
+            this.center = center;
+            this.extendX = extendX;
+            this.extendY = extendY;
+        }
+    }
+
+    // For now :
+    // - field mapName is not yet implemented (should probably be)
+    /**
+     * Vertical scale (vertical size of voxel in meters).
+     * This field is optional. (Default value : 1.0)
+     */
+    @JsonSetter(nulls = Nulls.SKIP)
+    public Double verticalScale = 1.0;
+    /**
+     * The horizontal scale (horizontal size of voxel in meters).
+     * This field is optional. (Default value : 1.0)
+     */
+    @JsonSetter(nulls = Nulls.SKIP)
+    public Double horizontalScale = 1.0;
+    /**
+     * The area of generation represented by a POJO.
+     * This field is required during deserialization.
+     */
+    public Area area;
+    /**
+     * The CRS used when projecting in the world.
+     * This field is optional.
+     * Currently, default value when deserialized by {@code ParamsParser} is EPSG:2154.
+     */
+    public String crs;
+
+    /**
+     * The format of the generated map.
+     * This field is required.
+     */
+    public String format;
+
+    /**
+     * Constructor used to ensure that the required fields are present during deserialization.
+     *
+     * @param area the area of generation represented by a POJO.
+     * @param format the format of the game.
+     */
+    @ConstructorProperties({"area", "format"})
+    public RawParams(Area area, String format) {
+        this.area = area;
+        this.format = format;
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/parsing/ParamsParserTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parsing/ParamsParserTest.java
@@ -1,0 +1,173 @@
+package com.ignfab.minalac.generator.parsing;
+
+import org.junit.jupiter.api.Test;
+
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.world.VoxelWorld;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ParamsParserTest {
+    private static final String WORKING_JSON = """
+            {
+                "verticalScale": 3,
+                "horizontalScale": 4,
+                "area": {
+                    "center": {
+                        "latitude": 5.8,
+                        "longitude": 2.4
+                    },
+                    "extendX": 500,
+                    "extendY": 2500
+                },
+                "crs": "EPSG:5643",
+                "format": "minetest"
+            }
+            """;
+
+    @Test
+    public void testSuccessfulJsonInstantiation() {
+        assertDoesNotThrow(() -> new ParamsParser(WORKING_JSON));
+    }
+
+    @Test
+    public void testSuccessfulYamlInstantiation() {
+        assertDoesNotThrow(() -> new ParamsParser("""
+                verticalScale: 3
+                horizontalScale: 4
+                area:
+                    center:
+                        latitude: 5.8
+                        longitude: 2.4
+                    extendX: 500
+                    extendY: 2500
+                crs: EPSG:5643
+                format: minetest
+                """));
+    }
+
+    @Test
+    public void testMissingRequiredFieldArea() {
+        assertThrows(ParseException.class, () -> new ParamsParser("""
+            {
+              "verticalScale": 3,
+              "horizontalScale": 4,
+              "crs": "EPSG:5643",
+              "format": "minetest"
+            }
+            """));
+    }
+
+    @Test
+    public void testMissingRequiredFieldLatitude() {
+        assertThrows(ParseException.class, () -> new ParamsParser("""
+            {
+                "verticalScale": 3,
+                "horizontalScale": 4,
+                "area": {
+                    "center": {
+                        "longitude": 2.4
+                    },
+                    "extendX": 500,
+                    "extendY": 2500
+                },
+                "crs": "EPSG:5643",
+                "format": "minetest"
+            }
+            """));
+    }
+
+    @Test
+    public void testMissingRequiredFieldLongitude() {
+        assertThrows(ParseException.class, () -> new ParamsParser("""
+            {
+                "verticalScale": 3,
+                "horizontalScale": 4,
+                "area": {
+                    "center": {
+                        "latitude": 5.8
+                    },
+                    "extendX": 500,
+                    "extendY": 2500
+                },
+                "crs": "EPSG:5643",
+                "format": "minetest"
+            }
+            """));
+    }
+
+    @Test
+    public void testMissingRequiredFieldExtendX() {
+        assertThrows(ParseException.class, () -> new ParamsParser("""
+            {
+                "verticalScale": 3,
+                "horizontalScale": 4,
+                "area": {
+                    "center": {
+                        "latitude": 5.8,
+                        "longitude": 2.4
+                    },
+                    "extendY": 2500
+                },
+                "crs": "EPSG:5643",
+                "format": "minetest"
+            }
+            """));
+    }
+
+    @Test
+    public void testMissingRequiredFieldExtendY() {
+        assertThrows(ParseException.class, () -> new ParamsParser("""
+            {
+                "verticalScale": 3,
+                "horizontalScale": 4,
+                "area": {
+                    "center": {
+                        "latitude": 5.8,
+                        "longitude": 2.4
+                    },
+                    "extendX": 500
+                },
+                "crs": "EPSG:5643",
+                "format": "minetest"
+            }
+            """));
+    }
+
+    @Test
+    public void testMissingRequiredFieldFormat() {
+        assertThrows(ParseException.class, () -> new ParamsParser("""
+            {
+                "verticalScale": 3,
+                "horizontalScale": 4,
+                "area": {
+                    "center": {
+                        "latitude": 5.8,
+                        "longitude": 2.4
+                    },
+                    "extendX": 500,
+                    "extendY": 2500
+                },
+                "crs": "EPSG:5643"
+            }
+            """));
+    }
+
+    @Test
+    public void testCreateGeneration() {
+        Generation generation = assertDoesNotThrow(() -> new ParamsParser(WORKING_JSON).createGeneration());
+
+        assertNotNull(generation);
+        assertEquals(500, generation.getWorldBBox2d().getSize().x());
+        assertEquals(2500, generation.getWorldBBox2d().getSize().y());
+        assertEquals(3.0, generation.getVerticalScale(), 0.001);
+    }
+
+    @Test
+    public void testCreateVoxelWorld() {
+        VoxelWorld world = assertDoesNotThrow(() -> new ParamsParser(WORKING_JSON).createVoxelWorld());
+        assertNotNull(world);
+        assertEquals(500, world.getMetadata().getBbox().getSizeX());
+        assertEquals(2500, world.getMetadata().getBbox().getSizeY());
+    }
+}


### PR DESCRIPTION
### Type of modification

Types:
- Code
  - Inputs
- Documentation
  - Javadoc Comments
  - Markdown Files
- Other:
  - Example file

### Changes

Move all generation parameters from command line to Json/Yaml file/variable.

#### Feature description

With this pull request, all generation parameters are passed apart, in Json or Yaml format. Only two command line arguments remains : 
- the output path;
- the path of a file containing generation arguments.

An example of such a file can be found in examples/default.yaml.

#### Technical changes

This pull request consists in adding classes in utils/paramsparser. These classes perfoms deserialization of Json or Yaml content into a Generation object.

A `MinalacGeneratorCLI` class improves command line argument parsing and offers different ways to pass generation parameters.

This pull request was first initiated by Zen and rebased/improved by Pyrollo (main commit tree has been completely rewritten meanwhile).

#### Showcase

Use provided example file:
```
mvn -DskipTests=true clean package && java -jar target/Generator.jar -p examples/default.yaml $HOME/.minetest/worlds/minalac
```

Pass arguments in Json using environement:
```
mvn -DskipTests=true clean package && MINALAC_PARAMS='{"verticalScale":1.0,"horizontalScale":1.0,"area":{"center":{"latitude":44.1519,"longitude":1.7499},"extendX":1000,"extendY":1000},"crs":"EPSG:2154","format":"minetest"}' java -jar target/Generator.jar $HOME/.minetest/worlds/minalac
```

Print help message:
```
mvn -DskipTests=true clean package && java -jar target/Generator.jar -h
```

### Reason

Because it's much better!

### Self-checks

- [X] The code has unit tests associated
- [X] The code has Javadoc Comments associated
- ~~Complex / Unexpected code is explained / justified with a small comment~~
- [X] Relevant documentation inside the `/docs` folder has been updated
- [X] All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)
- [X] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [X] The texts have been proofread (documentation, error messages, logs, comments...)
