### PR TITLE
feat(scheduler): Add a task scheduler to manage operations

### DIFF
--- a/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
+++ b/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
@@ -2,16 +2,17 @@ package com.ignfab.minalac.generator;
 
 import com.ignfab.minalac.generator.models.GeometryModel;
 import com.ignfab.minalac.generator.models.ModelStore;
-import com.ignfab.minalac.generator.parsing.ParamsParser;
-import com.ignfab.minalac.generator.parsing.ParseException;
 import com.ignfab.minalac.generator.generation.CoordsConverter;
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.generation.HeightMap;
 import com.ignfab.minalac.generator.inputs.WFS1_1_GML3_1_DataProvider;
+import com.ignfab.minalac.generator.parsing.ParamsParser;
+import com.ignfab.minalac.generator.parsing.ParseException;
 import com.ignfab.minalac.generator.renderers.VectorRenderer;
+import com.ignfab.minalac.generator.utils.execution.Scheduler;
+import com.ignfab.minalac.generator.utils.execution.TaskFailedException;
 import com.ignfab.minalac.generator.utils.network.HttpTrustAllSSL;
 import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
-import com.ignfab.minalac.generator.utils.world2d.WorldSize2d;
 import com.ignfab.minalac.generator.utils.world2d.iterator.Chunk2dElement;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
 import com.ignfab.minalac.generator.world.MapWriteException;
@@ -30,7 +31,6 @@ import org.locationtech.jts.geom.Geometry;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -39,6 +39,7 @@ import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.NoSuchElementException;
+import java.util.concurrent.TimeUnit;
 
 /**
  * This is a temporary class to have an idea of how the program works.
@@ -54,9 +55,7 @@ public final class SampleImplementation {
      *
      * @param args command line arguments
      */
-    public static void main(String[] args)
-        throws IOException, OutOfWorldException, MapWriteException, SAXException, FactoryException,
-        ParserConfigurationException, TransformException, ParseException {
+    public static void main(String[] args) throws FactoryException, InterruptedException, MapWriteException, ParseException, TaskFailedException, TransformException {
         long start = System.currentTimeMillis();
         HttpTrustAllSSL.applyGlobally();
 
@@ -76,38 +75,69 @@ public final class SampleImplementation {
         Envelope envelope = generation.getEnvelopeForCRS(crs);
         String bboxURL = "BBOX=" + envelope.getMinX() + "," + envelope.getMinY() + "," + envelope.getMaxX() + "," + envelope.getMaxY();
 
-        // Downloads
+        // Various data stores
         ModelStore store = new ModelStore();
-
-        System.out.println("Downloading height map");
-        WorldSize2d size = generation.getWorldBBox2d().getSize();
-        HeightMap heightMap = createGroundHeightMap("https://data.geopf.fr/wms-r/wms?LAYERS=RGEALTI-MNT_PYR-ZIP_FXX_LAMB93_WMS&FORMAT=image/x-bil;bits=32&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&STYLES=&CRS=" + crsName + "&" + bboxURL, size.x(), size.y(), generation.getVerticalScale());
-
-        System.out.println("Downloading buildings");
-        downloadVectorFeatures(
-            new WFS1_1_GML3_1_DataProvider("https://data.geopf.fr/wfs/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=BDTOPO_V3:batiment&STARTINDEX=0&COUNT=1000&SRSNAME=urn:ogc:def:crs:EPSG::2154&" + bboxURL + ",urn:ogc:def:crs:EPSG::2154&outputFormat=text%2Fxml%3B%20subtype%3Dgml%2F3.1.1"),
-            generation.makeCoordsConverter(crs),  // This is supposed to be the layer CRS (actually the same for this demo)
-            "building",
-            store,
-            heightMap.bbox());
-
-        // Rendering
-        System.out.println("World creation");
+        HeightMap heightMap = new HeightMap(generation.getWorldBBox2d(), 0);
         VoxelWorld world = parser.createVoxelWorld();
 
-        System.out.println("Placing ground");
-        placeVoxelFromHeightMap(heightMap, world);
+        Scheduler scheduler = new Scheduler();
 
-        System.out.println("Placing buildings");
-        new VectorRenderer(
-            heightMap,
-            store.getByType("building"),
-            world.getFactory().createVoxelType(SemanticType.COBBLE),
-            world.getFactory().createVoxelType(SemanticType.BRICK)
-        ).render();
+        // Downloads
+        scheduler.schedule("heightmaps.ground", () -> {
+            log("heightmaps.ground", "Downloading height map");
+            try {
+                fillGroundHeightMap("https://data.geopf.fr/wms-r/wms?LAYERS=RGEALTI-MNT_PYR-ZIP_FXX_LAMB93_WMS&FORMAT=image/x-bil;bits=32&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&STYLES=&CRS=" + crsName + "&" + bboxURL, heightMap, generation.getVerticalScale());
+            } catch (MalformedURLException e) {
+                throw new RuntimeException(e);
+            }
+            log("heightmaps.ground", "Downloaded height map");
+        });
 
-        // Save map
-        System.out.println("Saving");
+        scheduler.schedule("models.buildings", () -> {
+            log("models.buildings", "Downloading buildings");
+            try {
+                downloadVectorFeatures(
+                    new WFS1_1_GML3_1_DataProvider("https://data.geopf.fr/wfs/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=BDTOPO_V3:batiment&STARTINDEX=0&COUNT=1000&SRSNAME=urn:ogc:def:crs:EPSG::2154&" + bboxURL + ",urn:ogc:def:crs:EPSG::2154&outputFormat=text%2Fxml%3B%20subtype%3Dgml%2F3.1.1"),
+                    generation.makeCoordsConverter(crs),  // This is supposed to be the layer CRS (actually the same for this demo)
+                    "building",
+                    store,
+                    heightMap.bbox());
+            } catch (TransformException | IOException | ParserConfigurationException | SAXException | FactoryException e) {
+                throw new RuntimeException(e);
+            }
+            log("models.buildings", "Downloaded buildings");
+        });
+
+        // Rendering
+        scheduler.schedule("renderers.ground", () -> {
+            log("renderers.ground", "Placing ground");
+            try {
+                placeVoxelFromHeightMap(heightMap, world);
+            } catch (OutOfWorldException e) {
+                throw new RuntimeException(e);
+            }
+            log("renderers.ground", "Placed ground");
+        }, "heightmaps.ground");
+
+        scheduler.schedule("renderers.buildings", () -> {
+            log("renderers.buildings", "Placing buildings");
+            new VectorRenderer(
+                heightMap,
+                store.getByType("building"),
+                world.getFactory().createVoxelType(SemanticType.COBBLE),
+                world.getFactory().createVoxelType(SemanticType.BRICK)
+            ).render();
+            log("renderers.buildings", "Placed buildings");
+        }, "heightmaps.ground", "models.buildings");
+
+        scheduler.start();
+        try {
+            scheduler.waitUntilAllTasksFinished(5, TimeUnit.MINUTES);
+        } finally {
+            scheduler.shutdown();
+        }
+
+        System.out.println("Saving world");
         VoxelWorldMetadata metadata = world.getMetadata();
         metadata.setSpawn(new WorldCoords3d(0, 0, heightMap.get(0, 0) + 1));
         metadata.setWorldName("Minalac");
@@ -119,11 +149,16 @@ public final class SampleImplementation {
         System.out.println("Execution time: " + (end - start) / 1000 + "s");
     }
 
+    private static void log(String prefix, String message) {
+        System.out.printf("[%s] (%s) %s%n", Thread.currentThread().getName(), prefix, message);
+    }
+
     private static void downloadVectorFeatures(WFS1_1_GML3_1_DataProvider provider, CoordsConverter converter, String type, ModelStore store, WorldBBox2d limits)
             throws NoSuchElementException, TransformException, IOException, ParserConfigurationException, SAXException {
-        SimpleFeatureIterator iterator = provider.getFeatures().features();
-        while (iterator.hasNext())
-            store.add(type, new GeometryModel((Geometry) iterator.next().getDefaultGeometry(), converter, limits));
+        try (SimpleFeatureIterator iterator = provider.getFeatures().features()) {
+            while (iterator.hasNext())
+                store.add(type, new GeometryModel((Geometry) iterator.next().getDefaultGeometry(), converter, limits));
+        }
     }
 
     private static void placeVoxelFromHeightMap(HeightMap map, VoxelWorld world) throws OutOfWorldException {
@@ -145,11 +180,12 @@ public final class SampleImplementation {
         }
     }
 
-    private static HeightMap createGroundHeightMap(String partialUrl, int width, int height, double verticalScale) throws MalformedURLException {
-        float[] mntArray;
-        byte[] data;
+    private static void fillGroundHeightMap(String partialUrl, HeightMap heightMap, double verticalScale) throws MalformedURLException {
+        int width = heightMap.bbox().getSizeX();
+        int height = heightMap.bbox().getSizeY();
         URL url = new URL(partialUrl + "&WIDTH=" + width + "&HEIGHT=" + height);
 
+        byte[] data;
         try (InputStream inputStream = url.openStream()) {
             int total = 0;
             int read;
@@ -162,22 +198,19 @@ public final class SampleImplementation {
             throw new RuntimeException(e);
         }
 
-        mntArray = byteArrayToFloatArray(data);
+        float[] mntArray = byteArrayToFloatArray(data);
 
-        int xMin = -width / 2;
-        int yMin = -height / 2;
-
-        HeightMap heightMap = new HeightMap(xMin, yMin, width, height, 0);
+        int xMin = heightMap.bbox().getMinX();
+        int yMin = heightMap.bbox().getMinY();
 
         int index = 0;
 
-        for (int y = height - 1; y >= 0; y--) // In raster, Y axis is downwards
+        for (int y = height - 1; y >= 0; y--) { // In raster, Y axis is downwards
             for (int x = 0; x < width; x++) {
                 heightMap.set(x + xMin, y + yMin, (int) (mntArray[index] / verticalScale));
                 index++;
             }
-
-        return heightMap;
+        }
     }
 
     private static float[] byteArrayToFloatArray(byte[] byteData) {

--- a/src/main/java/com/ignfab/minalac/generator/utils/execution/ScheduledTask.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/execution/ScheduledTask.java
@@ -1,0 +1,87 @@
+package com.ignfab.minalac.generator.utils.execution;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * A task registered in the {@link Scheduler}.
+ */
+public class ScheduledTask {
+    private final String id;
+    private final Runnable task;
+    private final Set<String> conditions;
+    private ScheduledTaskState state = ScheduledTaskState.WAITING;
+
+    /**
+     * Creates a new task with the given characteristics.
+     *
+     * @param id the ID of the task
+     * @param task the runnable to execute
+     * @param conditions the IDs of the tasks that need to complete before this one can run
+     */
+    public ScheduledTask(String id, Runnable task, String... conditions) {
+        this(id, task, Arrays.asList(conditions));
+    }
+
+    /**
+     * Creates a new task with the given characteristics.
+     *
+     * @param id the ID of the task
+     * @param task the runnable to execute
+     * @param conditions the IDs of the tasks that need to complete before this one can run
+     */
+    public ScheduledTask(String id, Runnable task, Collection<String> conditions) {
+        this.id = id;
+        this.task = task;
+        // Synchronized collections are thread-safe equivalent of regular collections
+        // This is important to ensure no problem occurs if two required tasks finishes at the same time
+        this.conditions = Collections.synchronizedSet(new HashSet<>(conditions));
+    }
+
+    /**
+     * Returns the ID of the task.
+     *
+     * @return the ID of the task
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Runs this task's runnable.
+     * This method will return when the runnable returns.
+     */
+    public void run() {
+        task.run();
+    }
+
+    /**
+     * Returns the IDs of the tasks that need to complete before this one can run.
+     *
+     * @return the conditions of this task
+     */
+    public Set<String> getConditions() {
+        return conditions;
+    }
+
+    /**
+     * Returns the state of this task.
+     *
+     * @return the state of this task
+     */
+    public ScheduledTaskState getState() {
+        return state;
+    }
+
+    /**
+     * Sets the state of this task.
+     *
+     * @param state the new state of the task
+     */
+    public void setState(ScheduledTaskState state) {
+        this.state = state;
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/utils/execution/ScheduledTaskState.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/execution/ScheduledTaskState.java
@@ -1,0 +1,28 @@
+package com.ignfab.minalac.generator.utils.execution;
+
+/**
+ * The state of a {@link ScheduledTask}.
+ */
+public enum ScheduledTaskState {
+    /**
+     * The task is waiting for other tasks to complete.
+     * It will be launched once all conditions are fulfilled.
+     */
+    WAITING,
+    /**
+     * All conditions have been fulfilled, the task is being launched.
+     * It will be running once the execution service has a thread ready.
+     */
+    LAUNCHING,
+    /**
+     * The task is running.
+     * It will be finished once the task's runnable returns.
+     * If an error occurs, it will stop everything and the state won't be updated.
+     */
+    RUNNING,
+    /**
+     * The task has finished.
+     * It ran without error, and will be removed from the scheduler.
+     */
+    FINISHED
+}

--- a/src/main/java/com/ignfab/minalac/generator/utils/execution/Scheduler.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/execution/Scheduler.java
@@ -1,0 +1,161 @@
+package com.ignfab.minalac.generator.utils.execution;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A scheduler is a service managing execution of tasks.
+ * It can perform parallel operations and ensure execution order between some tasks.
+ */
+public class Scheduler {
+    // An executor using a thread pool to run tasks
+    private final ExecutorService executor = Executors.newCachedThreadPool();
+    // Synchronized collections are thread-safe equivalent of regular collections
+    // This is important to ensure no problem occurs if two required tasks finishes at the same time
+    private final List<ScheduledTask> tasks = Collections.synchronizedList(new ArrayList<>());
+
+    // Stores the exception that occurred, if any.
+    // Needed to pass the exception between threads
+    private TaskFailedException error = null;
+    // Object used for synchronized blocks, like a mutex.
+    // .wait() / .notify() operations are performed on this object
+    private final Object lock = new Object();
+
+    /**
+     * Schedules the task to be executed when all conditions are fulfilled.
+     * If the task has no condition, it will be executed at {@link #start()}.
+     *
+     * @param id the ID of the task
+     * @param task the task to be scheduled
+     * @param conditions the conditions before the task may run
+     */
+    public void schedule(String id, Runnable task, Collection<String> conditions) {
+        schedule(new ScheduledTask(id, task, conditions));
+    }
+
+    /**
+     * Schedules the task to be executed when all conditions are fulfilled.
+     * If the task has no condition, it will be executed at {@link #start()}.
+     *
+     * @param id the ID of the task
+     * @param task the task to be scheduled
+     * @param conditions the conditions before the task may run
+     */
+    public void schedule(String id, Runnable task, String... conditions) {
+        schedule(new ScheduledTask(id, task, conditions));
+    }
+
+    /**
+     * Schedules the task to be executed when all conditions are fulfilled.
+     * If the task has no condition, it will be executed at {@link #start()}.
+     *
+     * @param task the task to be scheduled
+     */
+    public void schedule(ScheduledTask task) {
+        tasks.add(task);
+    }
+
+    // This method is synchronized to prevent multiple concurrent trigger of the same task
+    private synchronized void execute(ScheduledTask task) {
+        // Only a waiting task can be executed
+        if (task.getState() != ScheduledTaskState.WAITING)
+            return;
+        task.setState(ScheduledTaskState.LAUNCHING);
+        // The .execute() method asks for execution but real execution can be delayed if no thread is currently available
+        executor.execute(() -> {
+            try {
+                task.setState(ScheduledTaskState.RUNNING);
+                task.run();
+                task.setState(ScheduledTaskState.FINISHED);
+                // The synchronized block prevents ConcurrentModificationException
+                synchronized (tasks) {
+                    // Once the task has been run, we remove it from our list
+                    // This is not strictly necessary, but avoid the need to loop on every
+                    // task and check their state to find out whether some task remains or not
+                    tasks.remove(task);
+                }
+                // Signals that the task finished to trigger any dependent task
+                conditionFulfilled(task.getId());
+                // If this was the last task, we wake up the main thread
+                // The synchronized block is mandatory to take ownership of the lock
+                synchronized (lock) {
+                    // The synchronized block prevents ConcurrentModificationException
+                    synchronized (tasks) {
+                        if (tasks.isEmpty())
+                            lock.notifyAll();
+                    }
+                }
+            } catch (RuntimeException e) {
+                // If an error occurs, we take note of the task failure and wake up the main thread
+                // The synchronized block is mandatory to take ownership of the lock
+                synchronized (lock) {
+                    error = new TaskFailedException(task, e);
+                    lock.notifyAll();
+                }
+            }
+        });
+    }
+
+    /**
+     * Signals the fulfillment of a condition.
+     * If this condition was the last one of the task, it will be executed.
+     *
+     * @param condition the fulfilled condition
+     */
+    public void conditionFulfilled(String condition) {
+        // The synchronized block prevents ConcurrentModificationException
+        synchronized (tasks) {
+            for (ScheduledTask task : tasks) {
+                Set<String> conditions = task.getConditions();
+                conditions.remove(condition);
+                // If this was the last condition, the task may now run
+                if (conditions.isEmpty())
+                    execute(task);
+            }
+        }
+    }
+
+    /**
+     * Starts this scheduler.
+     * Any task scheduled without condition will be executed right now.
+     */
+    public void start() {
+        // Simulates a condition fulfill to trigger tasks without any condition
+        this.conditionFulfilled(null);
+    }
+
+    /**
+     * Stops the underlying executor service.
+     *
+     * @see ExecutorService#shutdown()
+     */
+    public void shutdown() {
+        executor.shutdown();
+    }
+
+    /**
+     * Pauses this thread until all tasks are over, or a single task fails.
+     *
+     * @param timeout the maximum amount of time before timing out
+     * @param unit the unit of time for the timeout
+     * @throws InterruptedException if the thread is interrupted
+     * @throws TaskFailedException if a task fails
+     */
+    public void waitUntilAllTasksFinished(long timeout, TimeUnit unit) throws InterruptedException, TaskFailedException {
+        // Pause this thread by sleeping until being waked up by the end / failure of tasks
+        // The synchronized block is mandatory to take ownership of the lock
+        synchronized (lock) {
+            // TODO Spurious wakeup guard
+            lock.wait(unit.toMillis(timeout));
+        }
+        // Propagates the task failure, if any
+        if (error != null)
+            throw error;
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/utils/execution/TaskFailedException.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/execution/TaskFailedException.java
@@ -1,0 +1,28 @@
+package com.ignfab.minalac.generator.utils.execution;
+
+/**
+ * Exception thrown when an exception occurs in a {@link ScheduledTask}.
+ */
+public class TaskFailedException extends Exception {
+    private final ScheduledTask task;
+
+    /**
+     * Creates a new exception.
+     *
+     * @param task the failed task
+     * @param cause the exception causing the failure
+     */
+    public TaskFailedException(ScheduledTask task, Throwable cause) {
+        super("Task failed: " + task.getId(), cause);
+        this.task = task;
+    }
+
+    /**
+     * Returns the failed task.
+     *
+     * @return the failed task
+     */
+    public ScheduledTask getTask() {
+        return task;
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/utils/execution/SchedulerTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/execution/SchedulerTest.java
@@ -1,0 +1,88 @@
+package com.ignfab.minalac.generator.utils.execution;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SchedulerTest {
+    private Scheduler scheduler;
+
+    @BeforeEach
+    public void setUp() {
+        scheduler = new Scheduler();
+    }
+
+    @Test
+    public void testTasksWithoutCondition() {
+        List<String> actual = Collections.synchronizedList(new ArrayList<>());
+
+        scheduler.schedule("a", () -> actual.add("a"));
+        scheduler.schedule("b", () -> actual.add("b"));
+        scheduler.schedule("c", () -> actual.add("c"));
+
+        scheduler.start();
+        assertDoesNotThrow(() -> scheduler.waitUntilAllTasksFinished(50, TimeUnit.MILLISECONDS));
+        scheduler.shutdown();
+
+        List<String> expected = Arrays.asList("a", "b", "c");
+        assertTrue(expected.size() == actual.size() && expected.containsAll(actual) && actual.containsAll(expected),
+            () -> "List elements expected to be the same (ignoring order). Expected: " + expected + ", actual: " + actual);
+    }
+
+    @Test
+    public void testTasksWithCondition() {
+        List<String> actual = Collections.synchronizedList(new ArrayList<>());
+
+        scheduler.schedule("1", () -> actual.add("1"));
+        scheduler.schedule("2", () -> actual.add("2"), "1");
+        scheduler.schedule("3", () -> actual.add("3"), "1", "2");
+
+        scheduler.start();
+        assertDoesNotThrow(() -> scheduler.waitUntilAllTasksFinished(50, TimeUnit.MILLISECONDS));
+        scheduler.shutdown();
+
+        List<String> expected = Arrays.asList("1", "2", "3");
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testFailingTask() {
+        ScheduledTask task = new ScheduledTask("id", () -> {
+            throw new RuntimeException("Boom!");
+        });
+        scheduler.schedule(task);
+
+        scheduler.start();
+        TaskFailedException e = assertThrows(TaskFailedException.class, () -> scheduler.waitUntilAllTasksFinished(50, TimeUnit.MILLISECONDS));
+        scheduler.shutdown();
+
+        assertEquals(task, e.getTask());
+    }
+
+    @Test
+    public void testLongTaskTimedOut() {
+        AtomicBoolean executed = new AtomicBoolean(false);
+        scheduler.schedule("id", () -> {
+            try {
+                Thread.sleep(10_000); // Completes after 10s
+            } catch (InterruptedException e) {
+                fail("Thread interrupted");
+            }
+            executed.set(true); // Should never happen because timeout is 50ms
+        });
+
+        scheduler.start();
+        assertDoesNotThrow(() -> scheduler.waitUntilAllTasksFinished(50, TimeUnit.MILLISECONDS));
+        scheduler.shutdown();
+
+        assertFalse(executed.get());
+    }
+}


### PR DESCRIPTION
### Type of modification

- Code
  - Tools

### Issue

MINALAC-61

### Changes

Add a task scheduler to manage operations.

#### Feature description

A task scheduler has been added to manage operations and dependencies such as "Task B must execute after task A".

#### Showcase

Everything works the same.

On the developer side:
```java
scheduler.schedule(() -> { /* task */ }, "task.id", "dependsOnTask1", "dependsOnTask2"...)
```

### Reason

Allows parallel execution of code, and still respect required execution order.

### TODOs

- Error management is a bit brutal (error => panic).
- Circular dependencies are not validated.

### Self-checks

- [x] The code has unit tests associated
- [x] The code has Javadoc Comments associated
- [x] Complex / Unexpected code is explained / justified with a small comment
- ~~Relevant documentation inside the `/docs` folder has been updated~~
- ~~All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)~~
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- ~~The texts have been proofread (documentation, error messages, logs, comments...)~~
