### PR TITLE
chore(checkstyle): add configuration to support missing Javadoc

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -109,7 +109,7 @@
       <property name="scope" value="protected"/>
     </module>
     <module name="JavadocStyle"/>
-<!--    <module name="MissingJavadocMethod"/>-->
+   <module name="MissingJavadocMethod"/>
 
     <!-- Checks for Naming Conventions.                  -->
     <!-- See https://checkstyle.org/config_naming.html -->
@@ -220,5 +220,12 @@
     <module name="SuppressWarningsHolder" />
 
   </module>
+
+    <!-- Configures the suppression filter to use the suppressions.xml file.
+     It is used to ignore missing Javadoc checks on test classes -->
+    <module name="SuppressionFilter">
+        <property name="file" value="suppressions.xml"/>
+        <property name="optional" value="false"/>
+    </module>
 
 </module>

--- a/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
+++ b/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
@@ -56,6 +56,11 @@ public final class SampleImplementation {
         "minetest", MTVoxelWorld::new
     );
 
+    /**
+     * Serves as the entry point for the program.
+     *
+     * @param args command line arguments
+     */
     public static void main(String[] args)
             throws IOException, OutOfWorldException, MapWriteException, SAXException, FactoryException,
             ParserConfigurationException, TransformException {

--- a/src/main/java/com/ignfab/minalac/generator/inputs/WFS1_1_GML3_1_DataProvider.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/WFS1_1_GML3_1_DataProvider.java
@@ -14,10 +14,21 @@ import java.net.URL;
 public class WFS1_1_GML3_1_DataProvider {
     private final String baseURL;
 
+    /**
+     * Constructs a new {@code WFS1_1_GML3_1_DataProvider}.
+     *
+     * @param baseURL the base URL.
+     */
     public WFS1_1_GML3_1_DataProvider(String baseURL) {
         this.baseURL = baseURL;
     }
 
+
+    /**
+     * Retrieves a collection of features from the data provider.
+     *
+     * @return a collection of features
+     */
     public SimpleFeatureCollection getFeatures() throws IOException, ParserConfigurationException, SAXException {
         GML gml = new GML(GML.Version.GML3);
 

--- a/src/main/java/com/ignfab/minalac/generator/utils/world2d/chunk/EmptyChunk2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world2d/chunk/EmptyChunk2d.java
@@ -16,6 +16,11 @@ public final class EmptyChunk2d implements IterableChunk2d, WritableChunk2d {
 
     private EmptyChunk2d() {}
 
+    /**
+     * Returns the single instance of EmptyChunk2d.
+     *
+     * @return the single instance of EmptyChunk2d
+     */
     public static EmptyChunk2d getInstance() {
         return INSTANCE;
     }

--- a/suppressions.xml
+++ b/suppressions.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC
+    "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+    "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+
+<suppressions>
+    <suppress checks="MissingJavadocMethod" files=".*[\\/]src[\\/]test[\\/]"/>
+
+    <!-- Temporary suppression: This will be removed when the Javadoc is added in an upcoming PR -->
+    <suppress checks="MissingJavadocMethod" files=".*[\\/]minalac[\\/]generator[\\/]outputs[\\/]"/>
+    <!-- Temporary suppression: This will be removed when the Javadoc is added in an upcoming PR -->
+    <suppress checks="MissingJavadocMethod" files=".*[\\/]minalac[\\/]generator[\\/]world[\\/]"/>
+</suppressions>
+


### PR DESCRIPTION
### Changes

This pull request updates the checkstyle configuration to enable checks for missing Javadoc comments.

#### Feature description

+ Ignore missing Javadoc for test classes.
+ Temporarily ignore missing Javadoc for `outputs` and `world` packages (Javadoc updates will be included in an upcoming PR).
+ Add forgotten missing Javadoc in `WFS1_1_GML3_1_DataProvider`, `EmptyChunk2d` and `SampleImplementation`


### Reason

Mainly to make sure that javadoc is not forgotten in future pull requests.

### Self-checks

<!--
Check everything you did about your work in this PR.
The goal here is to save some precious time by self-checking common issues.

In case something is irrelevant to the subject, please remove the [ ] checkbox and ~~strike through~~ the text.
Example:
- [x] This task is done
- ~~This task does not apply to the work done in this PR~~
- [ ] This task still needs to be done
-->

- ~~The code has unit tests associated~~
- ~~The code has Javadoc Comments associated~~
- [x] Complex / Unexpected code is explained / justified with a small comment
- ~~Relevant documentation inside the `/docs` folder has been updated~~
- ~~All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)~~
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [x] The texts have been proofread (documentation, error messages, logs, comments...)
