### PR TITLE
feat(parser): Add parameters for HeightMaps

### DIFF
--- a/docs/usage/GenerationParameters.md
+++ b/docs/usage/GenerationParameters.md
@@ -5,6 +5,9 @@ Generation parameters can be written in Yaml or Json. Yaml is better for readabi
 These parameters generate a map of 1000x1000 voxels around IGN building at Saint-Mandé (FR), in Minetest format, with 1 meter voxels in every direction:
 
 ```yaml
+heightMaps:
+  - name: ground
+    default: 0
 area:
   center:
     latitude: 48.845
@@ -18,6 +21,9 @@ format: minetest
 ```
 
 Available fields:
+- `heightMaps`: list of the heightmaps
+  - `name`: name of the heightmap (Must be unique)
+  - `default`: default value for all heightmap cells (Must be an integer, `minimal`, `min`, `maximal` or `max`)
  - `area`: Area to be rendered
    - `center`: `longitude` and `latitude` of the center point
    - `extendsX` and `extendsY`: Area extends in both horizontal directions (in voxels)

--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -1,3 +1,6 @@
+heightMaps:
+  - name: ground
+    default: 0
 verticalScale: 1.0
 horizontalScale: 1.0
 area:

--- a/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
+++ b/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
@@ -77,7 +77,7 @@ public final class SampleImplementation {
 
         // Various data stores
         ModelStore store = new ModelStore();
-        HeightMap heightMap = new HeightMap(generation.getWorldBBox2d(), 0);
+        HeightMap groundHeightMap = generation.getHeightMap("ground");
         VoxelWorld world = parser.createVoxelWorld();
 
         Scheduler scheduler = new Scheduler();
@@ -86,7 +86,7 @@ public final class SampleImplementation {
         scheduler.schedule("heightmaps.ground", () -> {
             log("heightmaps.ground", "Downloading height map");
             try {
-                fillGroundHeightMap("https://data.geopf.fr/wms-r/wms?LAYERS=RGEALTI-MNT_PYR-ZIP_FXX_LAMB93_WMS&FORMAT=image/x-bil;bits=32&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&STYLES=&CRS=" + crsName + "&" + bboxURL, heightMap, generation.getVerticalScale());
+                fillGroundHeightMap("https://data.geopf.fr/wms-r/wms?LAYERS=RGEALTI-MNT_PYR-ZIP_FXX_LAMB93_WMS&FORMAT=image/x-bil;bits=32&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&STYLES=&CRS=" + crsName + "&" + bboxURL, groundHeightMap, generation.getVerticalScale());
             } catch (MalformedURLException e) {
                 throw new RuntimeException(e);
             }
@@ -101,7 +101,7 @@ public final class SampleImplementation {
                     generation.makeCoordsConverter(crs),  // This is supposed to be the layer CRS (actually the same for this demo)
                     "building",
                     store,
-                    heightMap.bbox());
+                    groundHeightMap.bbox());
             } catch (TransformException | IOException | ParserConfigurationException | SAXException | FactoryException e) {
                 throw new RuntimeException(e);
             }
@@ -112,7 +112,7 @@ public final class SampleImplementation {
         scheduler.schedule("renderers.ground", () -> {
             log("renderers.ground", "Placing ground");
             try {
-                placeVoxelFromHeightMap(heightMap, world);
+                placeVoxelFromHeightMap(groundHeightMap, world);
             } catch (OutOfWorldException e) {
                 throw new RuntimeException(e);
             }
@@ -122,7 +122,7 @@ public final class SampleImplementation {
         scheduler.schedule("renderers.buildings", () -> {
             log("renderers.buildings", "Placing buildings");
             new VectorRenderer(
-                heightMap,
+                groundHeightMap,
                 store.getByType("building"),
                 world.getFactory().createVoxelType(SemanticType.COBBLE),
                 world.getFactory().createVoxelType(SemanticType.BRICK)
@@ -139,7 +139,7 @@ public final class SampleImplementation {
 
         System.out.println("Saving world");
         VoxelWorldMetadata metadata = world.getMetadata();
-        metadata.setSpawn(new WorldCoords3d(0, 0, heightMap.get(0, 0) + 1));
+        metadata.setSpawn(new WorldCoords3d(0, 0, groundHeightMap.get(0, 0) + 1));
         metadata.setWorldName("Minalac");
         save(cli.getOutputPath().toFile(), world);
 

--- a/src/main/java/com/ignfab/minalac/generator/generation/Generation.java
+++ b/src/main/java/com/ignfab/minalac/generator/generation/Generation.java
@@ -15,6 +15,10 @@ import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.util.AffineTransformation;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
 /**
  * Generation context class.
  * Contains stuff about ongoing generation and its context.
@@ -32,6 +36,8 @@ public class Generation {
 
     // TODO: use a 3d bbox when its implemented:
     private final WorldBBox2d worldBBox;
+
+    private final Map<String, HeightMap> heightMaps = new HashMap<>();
 
     /**
      * Constructs a new generation context.
@@ -127,5 +133,33 @@ public class Generation {
     //To be removed when vertical is used by this class. (Renderers will probably contain that value)
     public double getVerticalScale() {
         return verticalScale;
+    }
+
+    /**
+     * Registers a new {@link HeightMap} with the given name.
+     * Name must be unique, case-sensitive.
+     *
+     * @param name      the name of the heightmap which will be used to identify it
+     * @param heightMap the heightmap to be added
+     * @throws IllegalArgumentException if the specified name is already registered or if the name is null
+     */
+    public void addHeightMap(String name, HeightMap heightMap) throws IllegalArgumentException {
+        if (name == null || heightMaps.containsKey(name))
+            throw new IllegalArgumentException("Illegal name for heightmap, duplicate or null name : " + name);
+        heightMaps.put(name, heightMap);
+    }
+
+    /**
+     * Returns the {@link HeightMap} associated to the given name.
+     *
+     * @param name the name of the heightmap
+     * @return the associated heightmap
+     * @throws NoSuchElementException if there is not a heightmap associated with the specified name
+     */
+    public HeightMap getHeightMap(String name) throws NoSuchElementException {
+        HeightMap heightMap = heightMaps.get(name);
+        if (heightMap == null)
+            throw new NoSuchElementException("This heightMap does not exist : " + name);
+        return heightMap;
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/parsing/ParamsParser.java
+++ b/src/main/java/com/ignfab/minalac/generator/parsing/ParamsParser.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.generation.HeightMap;
 import com.ignfab.minalac.generator.outputs.minecraft.MCVoxelWorld;
 import com.ignfab.minalac.generator.outputs.minetest.MTVoxelWorld;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
@@ -85,7 +86,8 @@ public class ParamsParser {
         } catch (FactoryException | TransformException e) {
             throw new RuntimeException(e);
         }
-        return new Generation(targetCrs,
+        Generation generation = new Generation(
+            targetCrs,
             convertedCoords[0],
             convertedCoords[1],
             rawParams.area.extendX,
@@ -93,6 +95,12 @@ public class ParamsParser {
             rawParams.horizontalScale,
             rawParams.verticalScale
         );
+
+        if (rawParams.heightMaps != null)
+            for (RawParams.HeightMapParams heightMapParams : rawParams.heightMaps)
+                generation.addHeightMap(heightMapParams.name, new HeightMap(generation.getWorldBBox2d(), heightMapParams.defaultValue));
+
+        return generation;
     }
 
     /**

--- a/src/main/java/com/ignfab/minalac/generator/parsing/RawParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parsing/RawParams.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 
 import java.beans.ConstructorProperties;
+import java.util.List;
 
 /**
  * RawParams is a POJO representing the parameters used during the generation.
@@ -20,6 +21,60 @@ import java.beans.ConstructorProperties;
 @SuppressWarnings("checkstyle:VisibilityModifier")
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class RawParams {
+    /**
+     * The list of heightmaps used during the generation.
+     * This field is optional.
+     */
+    public List<HeightMapParams> heightMaps;
+
+    public static class HeightMapParams {
+        /**
+         * The name of the heightmap.
+         * The name must be unique.
+         * This field is required.
+         */
+        public String name;
+        /**
+         * The default value for all height map cells.
+         * This field is required.
+         * When initialized by {@link HeightMapParams}:
+         * <ul>
+         *     <li>"minimal" and "min" are transformed to {@link Integer#MIN_VALUE}</li>
+         *     <li>"maximal" and "max" are transformed to {@link Integer#MAX_VALUE}</li>
+         * </ul>
+         */
+        public int defaultValue;
+
+        /**
+         * Constructor used to ensure that the required fields are present during deserialization.
+         * The {@code defaultValue} must be a valid string integer or one of the following: "minimal", "min", "maximal" or "max".
+         * When parsed "minimal" or "min" will be transformed to {@link Integer#MIN_VALUE}
+         * and "maximal" or "max" will be transformed to {@link Integer#MAX_VALUE}.
+         *
+         * @param name         the name of the heightmap.
+         * @param defaultValue the default value for all heightmap cells. It must be an integer or one of the following: "minimal", "min", "maximal" or "max"
+         * @throws ParseException if {@code defaultValue} is not a valid integer string or is not "minimal", "min", "maximal" or "max"
+         */
+        @ConstructorProperties({"name", "default"})
+        public HeightMapParams(String name, String defaultValue) throws ParseException {
+            this.name = name;
+            this.defaultValue = parseDefaultValue(defaultValue);
+        }
+
+        private int parseDefaultValue(String defaultValue) throws ParseException {
+            return switch (defaultValue) {
+                case "minimal", "min" -> Integer.MIN_VALUE;
+                case "maximal", "max" -> Integer.MAX_VALUE;
+                default -> {
+                    try {
+                        yield Integer.parseInt(defaultValue);
+                    } catch (NumberFormatException e) {
+                        throw new ParseException("Invalid heightmap default field value : " + defaultValue, e);
+                    }
+                }
+            };
+        }
+    }
 
     /**
      * Area to be rendered.

--- a/src/test/java/com/ignfab/minalac/generator/generation/TestGeneration.java
+++ b/src/test/java/com/ignfab/minalac/generator/generation/TestGeneration.java
@@ -1,7 +1,9 @@
 package com.ignfab.minalac.generator.generation;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.api.referencing.FactoryException;
@@ -14,11 +16,34 @@ import org.locationtech.jts.geom.GeometryFactory;
 
 import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
 
+import java.util.NoSuchElementException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
 public class TestGeneration {
+    private static CoordinateReferenceSystem crs2154;
+    private static CoordinateReferenceSystem crs4326;
+    private static Generation generation;
+
+    @BeforeAll
+    public static void setUp() throws FactoryException {
+        crs2154 = CRS.decode("EPSG:2154");
+        crs4326 = CRS.decode("EPSG:4326");
+    }
+
+    @BeforeEach
+    public void init() {
+        generation = new Generation(crs2154, 601000.0, 6341000.0, 501, 501, 2.0, 3.0);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        generation = null;
+    }
+
     @Test
     public void testGeneration() throws FactoryException, TransformException {
-        CoordinateReferenceSystem crs = CRS.decode("EPSG:2154");
-        Generation generation = new Generation(crs, 601000.0, 6341000.0, 501, 501, 2.0, 3.0);
+        Generation generation = new Generation(crs2154, 601000.0, 6341000.0, 501, 501, 2.0, 3.0);
 
         WorldBBox2d box = generation.getWorldBBox2d();
         assertEquals(-250, box.getMinX());
@@ -27,23 +52,45 @@ public class TestGeneration {
         assertEquals(250, box.getMaxY());
 
         // We should have an envelope +/- 500 around center (250 voxel * 2.0 meters/voxels = 500m)
-        Envelope envelope = generation.getEnvelopeForCRS(crs);
+        Envelope envelope = generation.getEnvelopeForCRS(crs2154);
         assertEquals(600500.0, envelope.getMinX(), 0.01);
         assertEquals(6340500.0, envelope.getMinY(), 0.01);
         assertEquals(601500.0, envelope.getMaxX(), 0.01);
         assertEquals(6341500.0, envelope.getMaxY(), 0.01);
 
         // Try another CRS
-        envelope = generation.getEnvelopeForCRS(CRS.decode("EPSG:4326"));
+        envelope = generation.getEnvelopeForCRS(crs4326);
         assertEquals(44.1564, envelope.getMinX(), 0.0002);
         assertEquals(1.7559, envelope.getMinY(), 0.0002);
 
         // Coords converter from WSG84
-        CoordsConverter converter = generation.makeCoordsConverter(CRS.decode("EPSG:4326"));
+        CoordsConverter converter = generation.makeCoordsConverter(crs4326);
         // 44.1655934, 1.7682873 is WSG84 for 601500, 6341500 which correspond to voxel 250,250.
         Geometry geometry = new GeometryFactory().createPoint(new Coordinate(44.1655934, 1.7682873));
         geometry = converter.convert(geometry);
         assertEquals(250.0, geometry.getCoordinate().x, 0.01);
         assertEquals(250.0, geometry.getCoordinate().y, 0.01);
+    }
+
+    @Test
+    public void testAddHeightMap() {
+        HeightMap heightMap = new HeightMap(0, 0, 5, 5, 20);
+
+        assertDoesNotThrow(() -> generation.addHeightMap("ground", heightMap));
+        assertDoesNotThrow(() -> generation.addHeightMap("second-ground", heightMap));
+        assertThrows(IllegalArgumentException.class, () -> generation.addHeightMap("ground", heightMap), "Should not be able to add a heightmap with an existing name");
+        assertThrows(IllegalArgumentException.class, () -> generation.addHeightMap(null, heightMap), "Should not be able to add a heightmap with a null name");
+        assertEquals(heightMap, generation.getHeightMap("ground"));
+    }
+
+    @Test
+    public void testGetHeightMap() {
+        HeightMap heightMap = new HeightMap(0, 0, 5, 5, 20);
+        generation.addHeightMap("ground", heightMap);
+
+        HeightMap retreivedHeightMap = assertDoesNotThrow(() -> generation.getHeightMap("ground"));
+        assertEquals(heightMap, retreivedHeightMap);
+        assertEquals(heightMap, generation.getHeightMap("ground"));
+        assertThrows(NoSuchElementException.class, () -> generation.getHeightMap("foo"));
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/parsing/ParamsParserTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parsing/ParamsParserTest.java
@@ -1,5 +1,6 @@
 package com.ignfab.minalac.generator.parsing;
 
+import com.ignfab.minalac.generator.generation.HeightMap;
 import org.junit.jupiter.api.Test;
 
 import com.ignfab.minalac.generator.generation.Generation;
@@ -9,21 +10,31 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class ParamsParserTest {
     private static final String WORKING_JSON = """
+        {
+            "heightMaps": [
             {
-                "verticalScale": 3,
-                "horizontalScale": 4,
-                "area": {
-                    "center": {
-                        "latitude": 5.8,
-                        "longitude": 2.4
-                    },
-                    "extendX": 500,
-                    "extendY": 2500
-                },
-                "crs": "EPSG:5643",
-                "format": "minetest"
+              "name": "altitude",
+              "default": "minimal"
+            },
+            {
+              "name": "ground",
+              "default": 0
             }
-            """;
+            ],
+            "verticalScale": 3,
+            "horizontalScale": 4,
+            "area": {
+                "center": {
+                    "latitude": 5.8,
+                    "longitude": 2.4
+                },
+                "extendX": 500,
+                "extendY": 2500
+            },
+            "crs": "EPSG:5643",
+            "format": "minetest"
+        }
+        """;
 
     @Test
     public void testSuccessfulJsonInstantiation() {
@@ -33,17 +44,96 @@ public class ParamsParserTest {
     @Test
     public void testSuccessfulYamlInstantiation() {
         assertDoesNotThrow(() -> new ParamsParser("""
-                verticalScale: 3
-                horizontalScale: 4
-                area:
-                    center:
-                        latitude: 5.8
-                        longitude: 2.4
-                    extendX: 500
-                    extendY: 2500
-                crs: EPSG:5643
-                format: minetest
-                """));
+            heightMaps:
+              - name: altitude
+                default: min
+              - name: ground
+                default: 0
+            verticalScale: 3
+            horizontalScale: 4
+            area:
+                center:
+                    latitude: 5.8
+                    longitude: 2.4
+                extendX: 500
+                extendY: 2500
+            crs: EPSG:5643
+            format: minetest
+            """));
+    }
+
+    @Test
+    public void testMissingOptionalFieldsNotThrowingException() {
+        assertDoesNotThrow(() -> new ParamsParser("""
+            {
+                "area": {
+                    "center": {
+                        "latitude": 5.8,
+                        "longitude": 2.4
+                    },
+                    "extendX": 500,
+                    "extendY": 2500
+                },
+                "format": "minetest"
+            }
+            """));
+    }
+
+    @Test
+    public void testOptionalFieldHeightMapEmpty() {
+        assertDoesNotThrow(() -> new ParamsParser("""
+            heightMaps: []
+            verticalScale: 3
+            horizontalScale: 4
+            area:
+                center:
+                    latitude: 5.8
+                    longitude: 2.4
+                extendX: 500
+                extendY: 2500
+            crs: EPSG:5643
+            format: minetest
+            """));
+    }
+
+    @Test
+    public void testMissingRequiredFieldNameHeightMap() {
+        assertThrows(ParseException.class, () -> new ParamsParser("""
+            heightMaps:
+              - name: altitude
+                default: -9
+              - default: 0
+            verticalScale: 3
+            horizontalScale: 4
+            area:
+                center:
+                    latitude: 5.8
+                    longitude: 2.4
+                extendX: 500
+                extendY: 2500
+            crs: EPSG:5643
+            format: minetest
+            """));
+    }
+
+    @Test
+    public void testMissingRequiredFieldDefaultHeightMap() {
+        assertThrows(ParseException.class, () -> new ParamsParser("""
+            heightMaps:
+              - name: altitude
+                default: -9
+              - name: ground
+            verticalScale: 3
+            horizontalScale: 4
+            area:
+                center:
+                    latitude: 5.8
+                    longitude: 2.4
+                extendX: 500
+                extendY: 2500
+            crs: EPSG:5643
+            format: minetest
+            """));
     }
 
     @Test
@@ -161,6 +251,12 @@ public class ParamsParserTest {
         assertEquals(500, generation.getWorldBBox2d().getSize().x());
         assertEquals(2500, generation.getWorldBBox2d().getSize().y());
         assertEquals(3.0, generation.getVerticalScale(), 0.001);
+
+        HeightMap ground = assertDoesNotThrow(() -> generation.getHeightMap("ground"));
+        assertEquals(0, ground.get(0, 0));
+
+        HeightMap altitude = assertDoesNotThrow(() -> generation.getHeightMap("altitude"));
+        assertEquals(Integer.MIN_VALUE, altitude.get(0, 0));
     }
 
     @Test

--- a/src/test/java/com/ignfab/minalac/generator/parsing/RawParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parsing/RawParamsTest.java
@@ -1,0 +1,76 @@
+package com.ignfab.minalac.generator.parsing;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class RawParamsTest {
+    @Test
+    public void testHeightMapParamsDefaultValueDeserialization() {
+        // The "default" field deserialization involves a custom private method within RawParams.HeightMapParams.
+        // This method, parseDefaultValue(), is responsible for mapping certain string value with int value (for example "minimal" with Integer.MIN_VALUE).
+        // Because of that, this test is to ensure that the "default" field is properly deserialized.
+        ObjectMapper mapper = new ObjectMapper();
+
+        RawParams.HeightMapParams heightMapIntegerValue = assertDoesNotThrow(() -> mapper.readValue(
+            """
+            {
+              "name" : "test",
+              "default" : 3
+            }
+            """,
+            RawParams.HeightMapParams.class));
+        assertEquals(3, heightMapIntegerValue.defaultValue);
+
+        RawParams.HeightMapParams heightMapMinimal = assertDoesNotThrow(() -> mapper.readValue(
+            """
+            {
+              "name" : "test",
+              "default" : "minimal"
+            }
+            """,
+            RawParams.HeightMapParams.class));
+        assertEquals(Integer.MIN_VALUE, heightMapMinimal.defaultValue);
+
+        RawParams.HeightMapParams heightMapMin = assertDoesNotThrow(() -> mapper.readValue(
+            """
+            {
+              "name" : "test",
+              "default" : "min"
+            }
+            """,
+            RawParams.HeightMapParams.class));
+        assertEquals(Integer.MIN_VALUE, heightMapMin.defaultValue);
+
+        RawParams.HeightMapParams heightMapMaximal = assertDoesNotThrow(() -> mapper.readValue(
+            """
+            {
+              "name" : "test",
+              "default" : "maximal"
+            }
+            """,
+            RawParams.HeightMapParams.class));
+        assertEquals(Integer.MAX_VALUE, heightMapMaximal.defaultValue);
+
+        RawParams.HeightMapParams heightMapMax = assertDoesNotThrow(() -> mapper.readValue(
+            """
+            {
+              "name" : "test",
+              "default" : "max"
+            }
+            """,
+            RawParams.HeightMapParams.class));
+        assertEquals(Integer.MAX_VALUE, heightMapMax.defaultValue);
+
+        assertThrows(JacksonException.class, () -> mapper.readValue(
+            """
+            {
+              "name" : "test",
+              "default" : "4foo"
+            }
+            """,
+            RawParams.HeightMapParams.class));
+    }
+}


### PR DESCRIPTION
### Type of modification

Types:
- Code
  - Inputs
- Documentation
  - Javadoc Comments
- Other
  - Example file

### Changes

Add support for deserializing the `heightMaps` parameter and instantiation of all `HeightMap` in `Generation`.

[Jira ticket](https://ignfab.atlassian.net/browse/MINALAC-57?atlOrigin=eyJpIjoiNTY4ZGMxMjcwZDI2NDBmNGEyMWIyMzM5OTA5YmViNzMiLCJwIjoiaiJ9)

#### Feature description
The `heightMaps` parameter is an optional list, where each element will be instantiated into a `HeightMap` with the specified `default` value. All of the instantiated `HeightMap` are stored in a `HashMap` of `Generation` where the `name` of each `HeightMap` is the key.

The fields `name` and `default` are mandatory for each element. The `name` must be unique and `default` must be a string integer, "min" or "max" (For now the parser transforms "min"/"max" value into `Integer.MIN_VALUE`/`Integer.MAX_VALUE`)

```yaml
heightMaps:
  - name: altitude
    default: min
  - name: ground
    default: 0
```

#### Technical changes
This PR consists mainly of modifying the classes `ParamsParser`, `RawParams` and `Generation` by adding new structures/functions.



#### Showcase
The command used remains the same : 
```bash
mvn -DskipTests=true clean package && java -jar target/Generator.jar -p examples/default.yaml $HOME/.minetest/worlds/minalac
```

Or, by passing arguments in JSON via the environment : 
```bash
mvn -DskipTests=true clean package && MINALAC_PARAMS='{"heightMaps":[{"name":"ground","default":0}],"verticalScale":1,"horizontalScale":1,"area":{"center":{"latitude":48.845,"longitude":2.425},"extendX":1000,"extendY":1000},"crs":"EPSG:2154","format":"minetest"}' java -jar target/Generator.jar $HOME/.minetest/worlds/minalac
```

### Reason

This part will be needed when adding `Renderer` declaration into the configuration file.

### Self-checks

- [x] The code has unit tests associated
- [x] The code has Javadoc Comments associated
- [x] Complex / Unexpected code is explained / justified with a small comment
- [x] Relevant documentation inside the `/docs` folder has been updated
- [x] All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [x] The texts have been proofread (documentation, error messages, logs, comments...)
