### PR TITLE
docs(voxelworld): add missing Javadoc to VoxelWorld and associated classes

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -110,6 +110,7 @@
     </module>
     <module name="JavadocStyle"/>
    <module name="MissingJavadocMethod"/>
+   <module name="MissingJavadocType"/>
 
     <!-- Checks for Naming Conventions.                  -->
     <!-- See https://checkstyle.org/config_naming.html -->

--- a/src/main/java/com/ignfab/minalac/generator/inputs/WFS1_1_GML3_1_DataProvider.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/WFS1_1_GML3_1_DataProvider.java
@@ -10,6 +10,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 
+/**
+ * Data provider using WFS 1.1 and GML 3.1.
+ */
 @SuppressWarnings("checkstyle:TypeName") // Underscore character used to better identify "WFS 1.1" and "GML 3.1"
 public class WFS1_1_GML3_1_DataProvider {
     private final String baseURL;

--- a/src/main/java/com/ignfab/minalac/generator/models/BufferedImageChunk.java
+++ b/src/main/java/com/ignfab/minalac/generator/models/BufferedImageChunk.java
@@ -25,7 +25,7 @@ public class BufferedImageChunk implements IterableChunk2d, WritableChunk2d {
      *
      * @param bbox Bounding box of that chunk
      *
-     * Chunk is initalized with 0 values.
+     * Chunk is initialized with 0 values.
      */
     BufferedImageChunk(WorldBBox2d bbox) {
         this.bbox = bbox;

--- a/src/main/java/com/ignfab/minalac/generator/models/GeometryModel.java
+++ b/src/main/java/com/ignfab/minalac/generator/models/GeometryModel.java
@@ -96,7 +96,7 @@ public class GeometryModel implements Model, Rasterizable {
         this.chunk = chunk;
         Graphics2D graphics = chunk.createGraphics();
 
-        // Draw geometry translated into bounding box relative coordinates (i.e. BufferedImage coordinates))
+        // Draw geometry translated into bounding box relative coordinates (i.e. BufferedImage coordinates)
         Geometry geom = AffineTransformation.translationInstance(-bbox.getMinX(), -bbox.getMinY()).transform(this.geom);
         draw(graphics, geom);
 

--- a/src/main/java/com/ignfab/minalac/generator/models/Model.java
+++ b/src/main/java/com/ignfab/minalac/generator/models/Model.java
@@ -1,3 +1,6 @@
 package com.ignfab.minalac.generator.models;
 
+/**
+ * This interface is intended to evolve. Models are objects that can be rendered.
+ */
 public interface Model {}

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCBlockEntityVoxelType.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCBlockEntityVoxelType.java
@@ -5,17 +5,38 @@ import net.querz.nbt.tag.CompoundTag;
 
 import java.util.Map;
 
+/**
+ * {@code MCBlockEntityVoxelType} abstract class represents a Minecraft block with additional data associated with it.
+ * That additional information is known as block entity.
+ * @see <a href="https://minecraft.wiki/w/Block_entity"> Block entity (Minecraft wiki)</a>
+ */
 public abstract class MCBlockEntityVoxelType extends MCVoxelType {
+    /**
+     * Constructs a new {@code MCBlockEntityVoxelType}.
+     *
+     * @param world the {@link MCVoxelWorld} in which the voxel can be placed
+     * @param type the block type string
+     */
     public MCBlockEntityVoxelType(MCVoxelWorld world, String type) {
         super(world, type);
     }
 
+    /**
+     * Constructs a new {@code MCBlockEntityVoxelType}.
+     *
+     * @param world the {@link MCVoxelWorld} in which the voxel can be placed
+     * @param type the block type string
+     * @param properties the block state properties
+     */
     public MCBlockEntityVoxelType(MCVoxelWorld world, String type, Map<String, String> properties) {
         super(world, type, properties);
     }
 
     protected abstract void serialize(CompoundTag tag);
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void place(int x, int y, int z) throws OutOfWorldException {
         super.place(x, y, z);

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelType.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelType.java
@@ -6,6 +6,10 @@ import net.querz.nbt.tag.CompoundTag;
 
 import java.util.Map;
 
+/**
+ * {@code MCVoxelType} class provides the necessary structure and mechanism in order to implement {@link VoxelType} for Minecraft.
+ * A voxel in Minecraft, known as block, consists of two parameters: type and state properties.
+ */
 public class MCVoxelType implements VoxelType {
     /**
      * The Minecraft World object.
@@ -21,16 +25,32 @@ public class MCVoxelType implements VoxelType {
      */
     protected final Map<String, String> properties;
 
+    /**
+     * Constructs a new {@code MCVoxelType}.
+     *
+     * @param world the {@link MCVoxelWorld} in which the voxel can be placed
+     * @param type the block type string
+     */
     public MCVoxelType(MCVoxelWorld world, String type) {
         this(world, type, null);
     }
 
+    /**
+     * Constructs a new {@code MCVoxelType}.
+     *
+     * @param world the {@link MCVoxelWorld} in which the voxel can be placed
+     * @param type the block type string
+     * @param properties the block state properties
+     */
     public MCVoxelType(MCVoxelWorld world, String type, Map<String, String> properties) {
         this.world = world;
         this.type = type;
         this.properties = properties;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void place(int x, int y, int z) throws OutOfWorldException {
         CompoundTag block = new CompoundTag();

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelTypeFactory.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelTypeFactory.java
@@ -3,13 +3,29 @@ package com.ignfab.minalac.generator.outputs.minecraft;
 import com.ignfab.minalac.generator.world.SemanticType;
 import com.ignfab.minalac.generator.world.VoxelTypeFactory;
 
+/**
+ * Factory for creating {@link MCVoxelType}.
+ */
 public class MCVoxelTypeFactory implements VoxelTypeFactory {
     private final MCVoxelWorld world;
 
+    /**
+     * Constructs a new {@code MCVoxelTypeFactory}.
+     * The created voxels will be only able to be placed in the specified world.
+     *
+     * @param world the {@link MCVoxelWorld} from which the created voxels will be associated
+     */
     public MCVoxelTypeFactory(MCVoxelWorld world) {
         this.world = world;
     }
 
+    /**
+     * Creates a new {@link MCVoxelType} corresponding to the provided {@link SemanticType}.
+     * The created voxels are associated with this factory's world.
+     *
+     * @param semanticType the semantic type of the voxel to be created
+     * @return the corresponding {@link MCVoxelType}
+     */
     @Override
     public MCVoxelType createVoxelType(SemanticType semanticType) {
         return new MCVoxelType(world, switch (semanticType) {

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelWorld.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelWorld.java
@@ -23,6 +23,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 
+/**
+ * Implementation of {@link VoxelWorld} that creates a playable world specifically for Minecraft.
+ */
 public class MCVoxelWorld implements VoxelWorld {
     private final MCVoxelTypeFactory factory;
     private final VoxelWorldMetadata metadata;
@@ -36,22 +39,37 @@ public class MCVoxelWorld implements VoxelWorld {
     private static final int MIN_WORLD_HEIGHT = 0; // -64
     private static final int MAX_WORLD_HEIGHT = 255; // 320
 
+    /**
+     * Constructs a new {@code MCVoxelWorld}.
+     */
     public MCVoxelWorld() {
         factory = new MCVoxelTypeFactory(this);
         metadata = new VoxelWorldMetadata();
         regions = new HashMap<>();
     }
 
+    /**
+     * Returns the factory for creating {@link MCVoxelType}.
+     *
+     * @return the factory for creating voxels
+     */
     @Override
     public MCVoxelTypeFactory getFactory() {
         return factory;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public VoxelWorldMetadata getMetadata() {
         return metadata;
     }
 
+    /**
+     * {@inheritDoc}
+     * The world is exported in a format for Minecraft.
+     */
     @Override
     public void save(File destination) throws MapWriteException {
         try {

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/Region.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/Region.java
@@ -7,11 +7,34 @@ import net.querz.mca.MCAUtil;
 import java.io.File;
 import java.io.IOException;
 
+/**
+ * Represents a Minecraft region.
+ * A region consists of 32x32 chunks and each chunk is 16 blocks wide by 16 blocks long.
+ *
+ * @param regionX the x-coordinate of this region
+ * @param regionZ the y-coordinate of this region
+ * @param file the {@link MCAFile} representing the file used by Minecraft
+ * @see <a href="https://minecraft.wiki/w/Region_file_format">Region (Minecraft Wiki)</a>
+ * @see <a href="https://minecraft.wiki/w/Chunk">Chunk (Minecraft Wiki)</a>
+ */
 public record Region(int regionX, int regionZ, MCAFile file) {
+    /**
+     * Constructs a new {@link Region}.
+     *
+     * @param regionX the x-coordinate of this region
+     * @param regionZ the y-coordinate of this region
+     */
     public Region(int regionX, int regionZ) {
         this(regionX, regionZ, new MCAFile(regionX, regionZ));
     }
 
+    /**
+     * Returns the {@link Chunk} at the specified coordinates or creates it if it doesn't exist.
+     *
+     * @param chunkX the x-coordinate of the chunk
+     * @param chunkZ the z-coordinate of the chunk
+     * @return the corresponding chunk
+     */
     public Chunk getOrCreateChunk(int chunkX, int chunkZ) {
         Chunk chunk = file.getChunk(chunkX, chunkZ);
         if (chunk == null) {
@@ -21,10 +44,21 @@ public record Region(int regionX, int regionZ, MCAFile file) {
         return chunk;
     }
 
+    /**
+     * Returns the filename of this region.
+     *
+     * @return the filename of this region
+     */
     public String getFileName() {
         return MCAUtil.createNameFromRegionLocation(regionX, regionZ);
     }
 
+    /**
+     * Saves the region in the specified directory.
+     *
+     * @param regionDirectory the directory of the region file
+     * @throws IOException if something goes wrong while saving
+     */
     public void save(File regionDirectory) throws IOException {
         file.cleanupPalettesAndBlockStates();
         for (int i = 0; i < 1024; i++) {
@@ -35,6 +69,15 @@ public record Region(int regionX, int regionZ, MCAFile file) {
         MCAUtil.write(file, new File(regionDirectory, getFileName()), true);
     }
 
+    /**
+     * Loads a {@code Region} from a file region.
+     *
+     * @param regionsDirectory the directory where the region file is located
+     * @param regionX the x-value of the location of the region
+     * @param regionZ the z-value of the location of the region
+     * @return a new {@link Region} corresponding to the file region
+     * @throws IOException if something goes wrong while deserializing the file region
+     */
     public static Region load(String regionsDirectory, int regionX, int regionZ) throws IOException {
         return new Region(regionX, regionZ, MCAUtil.read(new File(regionsDirectory, MCAUtil.createNameFromRegionLocation(regionX, regionZ))));
     }

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/Block.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/Block.java
@@ -2,6 +2,12 @@ package com.ignfab.minalac.generator.outputs.minetest;
 
 import java.util.HashMap;
 
+/**
+ * This class is a representation of what Minetest refers as block.
+ * In Minetest, a world is composed of blocks, where a block consists of 16x16x16 voxels (or nodes per Minetest terminology).
+ *
+ * @see <a href="https://github.com/minetest/minetest/blob/master/doc/world_format.md#map-file-format">Minetest world format</a>
+ */
 public class Block {
     private short[] param0;
     private byte[] param1;
@@ -9,6 +15,9 @@ public class Block {
     private HashMap<Integer, String> nameIdMapping;
     private HashMap<String, Integer> idNameMapping;
 
+    /**
+     * Constructs a new {@code Block}.
+     */
     public Block() {
         //Array length defined by map version (https://github.com/minetest/minetest/blob/master/doc/world_format.md#node-data)
         this.param0 = new short[4096];
@@ -20,6 +29,15 @@ public class Block {
         this.idNameMapping.put("air", 0);
     }
 
+    /**
+     * Places the specified voxel on the block by updating the block's three array parameters.
+     * The coordinate system is the one used in Minetest.
+     *
+     * @param x the x-coordinate value relatively to the block
+     * @param y the y-coordinate value relatively to the block
+     * @param z the z-coordinate value relatively to the block
+     * @param voxel the {@link MTVoxelType} to place within the block
+     */
     public void set(int x, int y, int z, MTVoxelType voxel) {
         //Node location on arrays
         //https://github.com/minetest/minetest/blob/master/doc/world_format.md#node-data
@@ -37,18 +55,38 @@ public class Block {
         }
     }
 
+    /**
+     * Returns a mapping of IDs to node names for this block.
+     *
+     * @return a {@code HashMap<Integer, String>} where the values are node names
+     */
     public HashMap<Integer, String> getNameIdMapping() {
         return nameIdMapping;
     }
 
+    /**
+     * Returns the param0 array parameter of this block.
+     *
+     * @return the param0 {@code short} array parameter
+     */
     public short[] getParam0() {
         return param0;
     }
 
+    /**
+     * Returns the param1 array parameter of this block.
+     *
+     * @return the param1 {@code byte} array parameter
+     */
     public byte[] getParam1() {
         return param1;
     }
 
+    /**
+     * Returns the param2 array parameter of this block.
+     *
+     * @return the param2 {@code byte} array parameter
+     */
     public byte[] getParam2() {
         return param2;
     }

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelType.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelType.java
@@ -3,6 +3,11 @@ package com.ignfab.minalac.generator.outputs.minetest;
 import com.ignfab.minalac.generator.world.OutOfWorldException;
 import com.ignfab.minalac.generator.world.VoxelType;
 
+/**
+ * {@code MTVoxelType} is an abstract class to provide the necessary structure and mechanism in order to implement {@link VoxelType} for Minetest.
+ * A voxel in Minetest, known as node, consists of three parameters: type, param1, param2.
+ * @see <a href="https://github.com/minetest/minetest/blob/master/src/mapnode.h#L138">Minetest's MapNode class</a> for more information about the node's parameters
+ */
 public abstract class MTVoxelType implements VoxelType {
     /**
      * The Minetest World object.
@@ -15,13 +20,24 @@ public abstract class MTVoxelType implements VoxelType {
     protected String type;
     /**
      * The param1 data of the node.
+     * This parameter usually contains information about the node's light intensity.
      */
     protected byte param1;
     /**
      * The param2 data of the node.
+     * This parameter usually contains information about the node's spacial orientation.
      */
     protected byte param2;
 
+    /**
+     * Constructs a new {@code MTVoxelType}.
+     *
+     * @param world the {@link MTVoxelWorld} in which the voxel can be placed
+     * @param type the node type string
+     * @param param1 the param1 data of the node
+     * @param param2 the param2 data of the node
+     * @see <a href="https://github.com/minetest/minetest/blob/master/src/mapnode.h#L138">Minetest's MapNode class</a> for more information about the node's parameters
+     */
     public MTVoxelType(MTVoxelWorld world, String type, byte param1, byte param2) {
         this.world = world;
         this.type = type;
@@ -35,14 +51,28 @@ public abstract class MTVoxelType implements VoxelType {
         this.world.set(x, z, y, this);
     }
 
+    /**
+     * Returns the node type string.
+     * @return the node type string
+     */
     public String getType() {
         return type;
     }
 
+    /**
+     * Returns the param1 data of the node.
+     * This parameter usually contains information about the node's light intensity.
+     * @return the param1 data of the node.
+     */
     public byte getParam1() {
         return param1;
     }
 
+    /**
+     * Returns the param2 data of the node.
+     * This parameter usually contains information about the node's spacial orientation.
+     * @return the param2 data of the node
+     */
     public byte getParam2() {
         return param2;
     }

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelTypeFactory.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelTypeFactory.java
@@ -5,13 +5,29 @@ import com.ignfab.minalac.generator.world.VoxelTypeFactory;
 import com.ignfab.minalac.generator.world.VoxelType;
 import com.ignfab.minalac.generator.outputs.minetest.voxelType.MTSimpleVoxelType;
 
+/**
+ * Factory for creating {@link MTVoxelType}.
+ */
 public class MTVoxelTypeFactory implements VoxelTypeFactory {
     private final MTVoxelWorld world;
 
+    /**
+     * Constructs a new {@code MTVoxelTypeFactory}.
+     * The created voxels will be only able to be placed in the specified world.
+     *
+     * @param world the {@link MTVoxelWorld} from which the created voxels will be associated
+     */
     public MTVoxelTypeFactory(MTVoxelWorld world) {
         this.world = world;
     }
 
+    /**
+     * Creates a new {@link MTSimpleVoxelType} corresponding to the provided {@link SemanticType}.
+     * The created voxels are associated with this factory's world.
+     *
+     * @param semanticType the semantic type of the voxel to be created
+     * @return the corresponding {@link MTSimpleVoxelType}
+     */
     @Override
     public VoxelType createVoxelType(SemanticType semanticType) {
         //Node string can be found on https://wiki.minetest.net/Games/Minetest_Game/Nodes

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelWorld.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelWorld.java
@@ -14,30 +14,54 @@ import java.io.PrintWriter;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Implementation of {@link VoxelWorld} that creates a playable world specifically for Minetest.
+ */
 public class MTVoxelWorld implements VoxelWorld {
     private final VoxelTypeFactory factory;
     private final VoxelWorldMetadata metadata;
     private final HashMap<Integer, Block> blocks;
     //See MAX_MAP_GENERATION_LIMIT constant on Minetest
-    //https://github.com/minetest/minetest/blob/e10d8080ba6e53e0f3c4b20b32304f8bb36e5958/src/constants.h#L70
+    //https://github.com/minetest/minetest/blob/master/src/constants.h#L69
     private static final int LIMIT_POSITION = 31_007;
 
+    /**
+     * Constructs a new {@code MTVoxelWorld}.
+     */
     public MTVoxelWorld() {
         this.factory = new MTVoxelTypeFactory(this);
         metadata = new VoxelWorldMetadata();
         this.blocks = new HashMap<>();
     }
 
+    /**
+     * Returns the factory for creating {@link MTVoxelType}.
+     *
+     * @return the factory for creating voxels
+     */
     @Override
     public VoxelTypeFactory getFactory() {
         return this.factory;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public VoxelWorldMetadata getMetadata() {
         return metadata;
     }
 
+    /**
+     * Places the voxel into this world at the specified coordinates.
+     * The specified coordinates must be in the coordinate system used by Minetest.
+     *
+     * @param x the x-coordinate value
+     * @param y the y-coordinate value
+     * @param z the z-coordinate value
+     * @param voxel the voxel to place
+     * @throws OutOfWorldException if the given coordinates are outside the world limits
+     */
     protected void set(int x, int y, int z, MTVoxelType voxel) throws OutOfWorldException {
         if (-LIMIT_POSITION > x || x > LIMIT_POSITION
                 || -LIMIT_POSITION > y || y > LIMIT_POSITION
@@ -54,6 +78,11 @@ public class MTVoxelWorld implements VoxelWorld {
         this.blocks.put(pos, block);
     }
 
+    /**
+     * {@inheritDoc}
+     * The world is exported in a format for Minetest.
+     */
+    @Override
     public void save(File destination) throws MapWriteException {
         createFile(new File(destination, "world.mt"), """
                 world_name = %s

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/utils/SQLiteMapWriter.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/utils/SQLiteMapWriter.java
@@ -11,10 +11,22 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
 
+/**
+ * {@code SQLiteMapWriter} is responsible for creating and updating the {@code map.sqlite} file,
+ * which is used by Minetest to store all blocks of a world.
+ * @see <a href="https://github.com/minetest/minetest/blob/master/doc/world_format.md#mapsqlite-1">Minetest's map world format</a>
+ */
 public class SQLiteMapWriter {
     private final Connection connection;
     private final Serializer serializer;
 
+    /**
+     * Constructs a new {@code SQLiteMapWriter}.
+     * It also creates and initializes {@code map.sqlite}.
+     *
+     * @param directory the {@link File} directory where {@code map.sqlite} will be placed
+     * @throws MapWriteException if the provided {@code File} is not a directory; doesn't exist, or if an {@link SQLException} occurs
+     */
     public SQLiteMapWriter(File directory) throws MapWriteException {
         if (!directory.exists() || !directory.isDirectory())
             throw new MapWriteException("The directory can not be accessed");
@@ -35,6 +47,13 @@ public class SQLiteMapWriter {
         }
     }
 
+    /**
+     * Inserts the specified block into the {@code blocks} table in {@code map.sqlite} which contains all blocks of the world.
+     *
+     * @param pos the position hash associated to the block
+     * @param block the {@link Block} to be inserted
+     * @throws MapWriteException if an {@link SQLException} or {@link IOException} occurs during insertion
+     */
     public void insertBlock(int pos, Block block) throws MapWriteException {
         try {
             PreparedStatement statement = connection.prepareStatement("INSERT INTO blocks VALUES (?,?)");

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/utils/Serializer.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/utils/Serializer.java
@@ -9,16 +9,24 @@ import java.util.Map;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.Deflater;
 
+/**
+ * This class is responsible for providing the serialized {@code Block} needed by the {@code map.sqlite} file.
+ * @see SQLiteMapWriter
+ * @see com.ignfab.minalac.generator.outputs.minetest.MTVoxelWorld#save(File)
+ */
 public class Serializer {
 
     // We use a static buffer to convert int32 and int64 to bytes.
-    // This avoid usage of DeflaterOutputStream.write(int) which performs something similar
+    // This avoids usage of DeflaterOutputStream.write(int) which performs something similar
     // but with a byte array instantiation for each call.
     private final byte[] buffer;
 
     // Using a static deflater avoids many useless instantiations.
     private final Deflater deflater;
 
+    /**
+     * Constructs a new {@code Serializer}.
+     */
     public Serializer() {
         buffer = new byte[8192];
         deflater = new Deflater(Deflater.BEST_COMPRESSION);
@@ -73,9 +81,14 @@ public class Serializer {
         }
     }
 
-    //Serializer for map version 28
-    //See World Format Documentation for version 28
-    //https://github.com/minetest/minetest/blob/master/doc/world_format.md
+    /**
+     * Serialize the specified {@link Block} for Minetest map version 28.
+     *
+     * @param block the block to serialize
+     * @return a {@code byte[]} representing the serialized block
+     * @throws IOException if an error occurs during serialization
+     * @see <a href="https://github.com/minetest/minetest/blob/master/doc/world_format.md#mapblock-serialization-format">Minetest world format documentation</a>
+     */
     public byte[] serialize(Block block) throws IOException {
         ByteArrayOutputStream stream = new ByteArrayOutputStream(16384);
 

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/voxelType/MTSimpleVoxelType.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/voxelType/MTSimpleVoxelType.java
@@ -3,7 +3,17 @@ package com.ignfab.minalac.generator.outputs.minetest.voxelType;
 import com.ignfab.minalac.generator.outputs.minetest.MTVoxelType;
 import com.ignfab.minalac.generator.outputs.minetest.MTVoxelWorld;
 
+/**
+ * A concrete implementation of {@link MTVoxelType}.
+ * Used when there is no need to have specific values for {@code param1} and {@code param2}.
+ */
 public class MTSimpleVoxelType extends MTVoxelType {
+    /**
+     * Constructs a new {@code MTSimpleVoxelType}.
+     *
+     * @param world the {@link MTVoxelWorld} in which the voxel can be placed
+     * @param type the node type string
+     */
     public MTSimpleVoxelType(MTVoxelWorld world, String type) {
         super(world, type, (byte) 0, (byte) 0);
     }

--- a/src/main/java/com/ignfab/minalac/generator/parsing/RawParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parsing/RawParams.java
@@ -27,6 +27,10 @@ public class RawParams {
      */
     public List<HeightMapParams> heightMaps;
 
+    /**
+     * Heightmap used during the generation.
+     * This field is optional.
+     */
     public static class HeightMapParams {
         /**
          * The name of the heightmap.

--- a/src/main/java/com/ignfab/minalac/generator/utils/world3d/WorldBBox3d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world3d/WorldBBox3d.java
@@ -253,7 +253,7 @@ public class WorldBBox3d implements Iterable<WorldCoords3d> {
     }
 
     /**
-     * Returns intersection with another bounind box.
+     * Returns intersection with another bounding box.
      *
      * @param box Other bounding box to intersect with
      *

--- a/src/main/java/com/ignfab/minalac/generator/world/MapWriteException.java
+++ b/src/main/java/com/ignfab/minalac/generator/world/MapWriteException.java
@@ -1,14 +1,35 @@
 package com.ignfab.minalac.generator.world;
 
+/**
+ * Exception thrown if a problem occurs when saving a {@link VoxelWorld}.
+ *
+ * @see VoxelWorld#save(File)
+ */
 public class MapWriteException extends Exception {
+    /**
+     * Creates a new {@code MapWriteException}.
+     *
+     * @param message the message explaining the problem
+     */
     public MapWriteException(String message) {
         this(message, null);
     }
 
+    /**
+     * Creates a new {@code MapWriteException}.
+     *
+     * @param message the message explaining the problem
+     * @param cause   the throwable that caused the problem
+     */
     public MapWriteException(String message, Throwable cause) {
         super("[MapWriteException] " + message, cause);
     }
 
+    /**
+     * Creates a new {@code MapWriteException}.
+     *
+     * @param cause the throwable that caused the problem
+     */
     public MapWriteException(Throwable cause) {
         super(cause);
     }

--- a/src/main/java/com/ignfab/minalac/generator/world/OutOfWorldException.java
+++ b/src/main/java/com/ignfab/minalac/generator/world/OutOfWorldException.java
@@ -1,4 +1,7 @@
 package com.ignfab.minalac.generator.world;
 
+/**
+ * Exception thrown when attempting to place a voxel outside the world limits.
+ */
 public class OutOfWorldException extends Exception {
 }

--- a/src/main/java/com/ignfab/minalac/generator/world/SemanticType.java
+++ b/src/main/java/com/ignfab/minalac/generator/world/SemanticType.java
@@ -1,5 +1,11 @@
 package com.ignfab.minalac.generator.world;
 
+/**
+ * An enum for the semantic representation of voxels.
+ *
+ * @see VoxelType
+ * @see VoxelTypeFactory#createVoxelType(SemanticType)
+ */
 public enum SemanticType {
     /**
      * Represent a grass voxel.

--- a/src/main/java/com/ignfab/minalac/generator/world/VoxelType.java
+++ b/src/main/java/com/ignfab/minalac/generator/world/VoxelType.java
@@ -1,6 +1,19 @@
 package com.ignfab.minalac.generator.world;
 
+/**
+ * The {@code VoxelType} interface represents a type of voxel that can be placed within a {@link VoxelWorld}.
+ */
 public interface VoxelType {
-    //TODO : add the javadoc that explicitly define the coordinate system used + change the QuickStart.md accordingly
+    //TODO : Since the javadoc was added, see if it is still relevant to keep the content of doc/legacy/QuickStart.md
+    /**
+     * Places the voxel in its corresponding {@link VoxelWorld} at the given coordinates.
+     * Coordinates are expressed using the system used in {@link com.ignfab.minalac.generator.utils.world3d.WorldCoords3d}.
+     * In that system, the z-axis represents the altitude and increments correspond to the size of a voxel.
+     *
+     * @param x the x-coordinate value
+     * @param y the y-coordinate value
+     * @param z the z-coordinate value
+     * @throws OutOfWorldException if the given coordinates are outside the world limits
+     */
     void place(int x, int y, int z) throws OutOfWorldException;
 }

--- a/src/main/java/com/ignfab/minalac/generator/world/VoxelTypeFactory.java
+++ b/src/main/java/com/ignfab/minalac/generator/world/VoxelTypeFactory.java
@@ -1,6 +1,15 @@
 package com.ignfab.minalac.generator.world;
 
+/**
+ * Factory for creating {@link VoxelType}.
+ */
 public interface VoxelTypeFactory {
+    /**
+     * Creates a new {@link VoxelType} corresponding to the provided {@link SemanticType}.
+     *
+     * @param semanticType the semantic type of the voxel to be created
+     * @return the corresponding {@link VoxelType}
+     */
     VoxelType createVoxelType(SemanticType semanticType);
     //TODO : implementation of a method that takes into account advanced voxel creation
     //VoxelType createVoxelType(SemanticType semanticType, parameters);

--- a/src/main/java/com/ignfab/minalac/generator/world/VoxelTypeIgnore.java
+++ b/src/main/java/com/ignfab/minalac/generator/world/VoxelTypeIgnore.java
@@ -1,7 +1,7 @@
 package com.ignfab.minalac.generator.world;
 
 /**
- * A voxel type that places no voxel. Can be conveniant to pass
+ * A voxel type that places no voxel. Can be convenient to pass
  * as a no-op voxel type to some operation.
  */
 public class VoxelTypeIgnore implements VoxelType {
@@ -12,5 +12,6 @@ public class VoxelTypeIgnore implements VoxelType {
      * @param y y-coordinate where not to place voxel
      * @param z z-coordinate where not to place voxel
      */
-    public void place(int x, int y, int z) throws OutOfWorldException {};
+    @Override
+    public void place(int x, int y, int z) throws OutOfWorldException {}
 }

--- a/src/main/java/com/ignfab/minalac/generator/world/VoxelWorld.java
+++ b/src/main/java/com/ignfab/minalac/generator/world/VoxelWorld.java
@@ -2,10 +2,33 @@ package com.ignfab.minalac.generator.world;
 
 import java.io.File;
 
+/**
+ * The {@code VoxelWorld} interface represents a three-dimensional world with voxels as the fundamental unit.
+ * Implementations of this interface are primary meant to create playable world for voxel-based games such as Minecraft or Minetest.
+ *
+ * @see VoxelType
+ */
 public interface VoxelWorld {
+    /**
+     * Returns the factory for creating its corresponding {@link VoxelType}.
+     *
+     * @return the factory for creating voxels
+     */
     VoxelTypeFactory getFactory();
 
+    /**
+     * Returns the metadata of this {@code VoxelWorld}.
+     *
+     * @return the {@link VoxelWorldMetadata}
+     */
     VoxelWorldMetadata getMetadata();
 
+    // TODO: There is an inconsistency between the two implementations. When the folder does not exist MTVoxelWorld creates it whereas MCVoxelWorld throws a MapWriteException.
+    /**
+     * Exports the {@code VoxelWorld} and saves it in the specified destination.
+     *
+     * @param destination the {@link File} where the output will be saved. It must represent a directory.
+     * @throws MapWriteException if an error occurs while writing to the specified destination.
+     */
     void save(File destination) throws MapWriteException;
 }

--- a/src/main/java/com/ignfab/minalac/generator/world/VoxelWorldMetadata.java
+++ b/src/main/java/com/ignfab/minalac/generator/world/VoxelWorldMetadata.java
@@ -3,6 +3,9 @@ package com.ignfab.minalac.generator.world;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
 
+/**
+ * The {@code VoxelWorldMetadata} class contains the different metadata for a {@link VoxelWorld}.
+ */
 public class VoxelWorldMetadata {
     /**
      * Initial position of the player.
@@ -18,26 +21,56 @@ public class VoxelWorldMetadata {
      */
     protected WorldBBox3d bbox;
 
+    /**
+     * Returns the initial position of the player.
+     *
+     * @return the spawn of the player
+     */
     public WorldCoords3d getSpawn() {
         return spawn;
     }
 
+    /**
+     * Sets the initial position of the player.
+     *
+     * @param spawn the initial position of the player
+     */
     public void setSpawn(WorldCoords3d spawn) {
         this.spawn = spawn;
     }
 
+    /**
+     * Returns the name of the world.
+     *
+     * @return the name of the world
+     */
     public String getWorldName() {
         return worldName;
     }
 
+    /**
+     * Sets the name of the world.
+     *
+     * @param worldName the name of the world
+     */
     public void setWorldName(String worldName) {
         this.worldName = worldName;
     }
 
+    /**
+     * Returns the {@link WorldBBox3d} of the world.
+     *
+     * @return the {@link WorldBBox3d} of the world
+     */
     public WorldBBox3d getBbox() {
         return bbox;
     }
 
+    /**
+     * Sets the {@link WorldBBox3d} of the world.
+     *
+     * @param bbox the {@link WorldBBox3d} of the world
+     */
     public void setBbox(WorldBBox3d bbox) {
         this.bbox = bbox;
     }

--- a/src/test/java/com/ignfab/minalac/generator/outputs/testing/TestingVoxelType.java
+++ b/src/test/java/com/ignfab/minalac/generator/outputs/testing/TestingVoxelType.java
@@ -4,8 +4,7 @@ import com.ignfab.minalac.generator.world.OutOfWorldException;
 import com.ignfab.minalac.generator.world.VoxelType;
 
 /**
- * A dummuy voxelType implementation for {@code TestingVoxelWorld}.
- *
+ * A dummy voxelType implementation for {@code TestingVoxelWorld}.
  * All testing voxel type are represented by simple strings.
  */
 public class TestingVoxelType implements VoxelType {

--- a/src/test/java/com/ignfab/minalac/generator/utils/world2d/WorldBBox2dTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/world2d/WorldBBox2dTest.java
@@ -16,7 +16,7 @@ public class WorldBBox2dTest {
         assertEquals(new WorldCoords2d(3, 5), box.getMax());
         assertEquals(new WorldSize2d(3, 4), box.getSize());
 
-        // Instanciating a 0 sized bounding box
+        // Instantiating a 0 sized bounding box
         assertDoesNotThrow(() -> new WorldBBox2d(0, 0, 0, 0));
 
         // Instantiating a negative sized bounding box
@@ -122,7 +122,7 @@ public class WorldBBox2dTest {
         assertTrue(box.intersection(new WorldBBox2d(-2, -2, 3, 3)).isEmpty());
         assertTrue(box.intersection(new WorldBBox2d(3, 3, 3, 3)).isEmpty());
 
-        // Various intersectig boxes
+        // Various intersecting boxes
         box = new WorldBBox2d(-2, -2, 5, 5);
         assertEquals(new WorldBBox2d(-2, -2, 3, 3), box.intersection(new WorldBBox2d(-3, -3, 4, 4)));
         assertEquals(new WorldBBox2d(0, -2, 3, 3), box.intersection(new WorldBBox2d(0, -3, 4, 4)));

--- a/src/test/java/com/ignfab/minalac/generator/utils/world3d/WorldBBox3dTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/world3d/WorldBBox3dTest.java
@@ -16,7 +16,7 @@ public class WorldBBox3dTest {
         assertEquals(new WorldCoords3d(4, 6, 8), box.getMax());
         assertEquals(new WorldSize3d(4, 5, 6), box.getSize());
 
-        // Instanciating a 0 sized bounding box
+        // Instantiating a 0 sized bounding box
         assertDoesNotThrow(() -> new WorldBBox3d(0, 0, 0, 0, 0, 0));
 
         // Instantiating a negative sized bounding box

--- a/suppressions.xml
+++ b/suppressions.xml
@@ -6,10 +6,6 @@
 
 <suppressions>
     <suppress checks="MissingJavadocMethod" files=".*[\\/]src[\\/]test[\\/]"/>
-
-    <!-- Temporary suppression: This will be removed when the Javadoc is added in an upcoming PR -->
-    <suppress checks="MissingJavadocMethod" files=".*[\\/]minalac[\\/]generator[\\/]outputs[\\/]"/>
-    <!-- Temporary suppression: This will be removed when the Javadoc is added in an upcoming PR -->
-    <suppress checks="MissingJavadocMethod" files=".*[\\/]minalac[\\/]generator[\\/]world[\\/]"/>
+    <suppress checks="MissingJavadocType" files=".*[\\/]src[\\/]test[\\/]"/>
 </suppressions>
 


### PR DESCRIPTION
**Edit:**
+ *2024-08-05*: Added javadoc to `HeightMapParams`

### Type of modification
Types:
- Documentation
  - Javadoc Comments
- Other: checkstyle configuration

### Issue

**JIRA ticket**: [MINALAC-58](https://ignfab.atlassian.net/browse/MINALAC-58)
Essentially it is to remove the temporary suppressed checks added in [this](https://github.com/ignfab/minalac-generator/pull/27) PR.
### Changes

This pull request adds the missing java documentation to `VoxelWorld` and all of its associated classes.

Detailed changes : 
+ Added java documentation to `VoxelWorld` and all of its associated classes
+ Added class definition on `WFS1_1_GML3_1_DataProvider`, `Model` and `HeightMapParams` as they were missing
+ Added a `MissingJavadocType` check as there were no checks for class definitions
+ Corrected the typos I found.
### Reason

Because it is better : )

### TODOs

Added:
+ On `save(File destination)` in `VoxelWorld` : I found that there is an inconsistency between the two implementations.  When the folder does not exist `MTVoxelWorld` creates it whereas `MCVoxelWorld` throws `MapWriteException`.  I haven't "fix" as I want to keep this PR solely about javadoc.

I updated the TODO about `QuickStart.md` as I am unsure whether it should be updated or removed.

### Self-checks

- ~~The code has unit tests associated~~
- [x] The code has Javadoc Comments associated
- ~~Complex / Unexpected code is explained / justified with a small comment~~
- ~~Relevant documentation inside the `/docs` folder has been updated~~
- ~~All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)~~
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [x] The texts have been proofread (documentation, error messages, logs, comments...)

[MINALAC-58]: https://ignfab.atlassian.net/browse/MINALAC-58?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ