### PR TITLE
feat(voxelworld): Remove OutOfWorldException

### DIFF
--- a/docs/legacy/QuickStart.md
+++ b/docs/legacy/QuickStart.md
@@ -79,7 +79,6 @@ Same perspective but during sunset. In Minetest, the sun's path aligns with the 
 ```java
 import com.ignfab.minalac.generator.outputs.minetest.MTVoxelWorld;
 import com.ignfab.minalac.generator.world.MapWriteException;
-import com.ignfab.minalac.generator.world.OutOfWorldException;
 import com.ignfab.minalac.generator.world.SemanticType;
 import com.ignfab.minalac.generator.world.VoxelType;
 import com.ignfab.minalac.generator.world.VoxelTypeFactory;
@@ -88,7 +87,7 @@ import com.ignfab.minalac.generator.world.VoxelWorld;
 import java.io.File;
 
 public class SampleCode {
-    public static void main(String[] args) throws OutOfWorldException, MapWriteException {
+    public static void main(String[] args) throws MapWriteException {
         VoxelWorld minetestWorld = new MTVoxelWorld();
         VoxelTypeFactory voxelTypeFactory = minetestWorld.getFactory();
 

--- a/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
+++ b/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
@@ -16,7 +16,6 @@ import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
 import com.ignfab.minalac.generator.utils.world2d.iterator.Chunk2dElement;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
 import com.ignfab.minalac.generator.world.MapWriteException;
-import com.ignfab.minalac.generator.world.OutOfWorldException;
 import com.ignfab.minalac.generator.world.SemanticType;
 import com.ignfab.minalac.generator.world.VoxelType;
 import com.ignfab.minalac.generator.world.VoxelWorld;
@@ -111,11 +110,7 @@ public final class SampleImplementation {
         // Rendering
         scheduler.schedule("renderers.ground", () -> {
             log("renderers.ground", "Placing ground");
-            try {
-                placeVoxelFromHeightMap(groundHeightMap, world);
-            } catch (OutOfWorldException e) {
-                throw new RuntimeException(e);
-            }
+            placeVoxelFromHeightMap(groundHeightMap, world);
             log("renderers.ground", "Placed ground");
         }, "heightmaps.ground");
 
@@ -161,7 +156,7 @@ public final class SampleImplementation {
         }
     }
 
-    private static void placeVoxelFromHeightMap(HeightMap map, VoxelWorld world) throws OutOfWorldException {
+    private static void placeVoxelFromHeightMap(HeightMap map, VoxelWorld world) {
         VoxelType grassVT = world.getFactory().createVoxelType(SemanticType.GRASS);
         VoxelType stoneVT = world.getFactory().createVoxelType(SemanticType.STONE);
         VoxelType dirtVT = world.getFactory().createVoxelType(SemanticType.DIRT);

--- a/src/main/java/com/ignfab/minalac/generator/generation/Generation.java
+++ b/src/main/java/com/ignfab/minalac/generator/generation/Generation.java
@@ -130,7 +130,7 @@ public class Generation {
      *
      * @return the vertical scale
      */
-    //To be removed when vertical is used by this class. (Renderers will probably contain that value)
+    // To be removed when vertical is used by this class. (Renderers will probably contain that value)
     public double getVerticalScale() {
         return verticalScale;
     }

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCBlockEntityVoxelType.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCBlockEntityVoxelType.java
@@ -1,6 +1,5 @@
 package com.ignfab.minalac.generator.outputs.minecraft;
 
-import com.ignfab.minalac.generator.world.OutOfWorldException;
 import net.querz.nbt.tag.CompoundTag;
 
 import java.util.Map;
@@ -38,7 +37,7 @@ public abstract class MCBlockEntityVoxelType extends MCVoxelType {
      * {@inheritDoc}
      */
     @Override
-    public void place(int x, int y, int z) throws OutOfWorldException {
+    public void place(int x, int y, int z)  {
         super.place(x, y, z);
         CompoundTag block = new CompoundTag();
         block.putString("id", type);

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelType.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelType.java
@@ -1,6 +1,5 @@
 package com.ignfab.minalac.generator.outputs.minecraft;
 
-import com.ignfab.minalac.generator.world.OutOfWorldException;
 import com.ignfab.minalac.generator.world.VoxelType;
 import net.querz.nbt.tag.CompoundTag;
 
@@ -52,7 +51,7 @@ public class MCVoxelType implements VoxelType {
      * {@inheritDoc}
      */
     @Override
-    public void place(int x, int y, int z) throws OutOfWorldException {
+    public void place(int x, int y, int z)  {
         CompoundTag block = new CompoundTag();
         block.putString("Name", type);
         if (properties != null) {

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelWorld.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelWorld.java
@@ -1,9 +1,9 @@
 package com.ignfab.minalac.generator.outputs.minecraft;
 
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldSize3d;
 import com.ignfab.minalac.generator.world.MapWriteException;
-import com.ignfab.minalac.generator.world.OutOfWorldException;
 import com.ignfab.minalac.generator.world.VoxelWorld;
 import com.ignfab.minalac.generator.world.VoxelWorldMetadata;
 import net.querz.mca.Chunk;
@@ -26,26 +26,34 @@ import java.util.Random;
 /**
  * Implementation of {@link VoxelWorld} that creates a playable world specifically for Minecraft.
  */
-public class MCVoxelWorld implements VoxelWorld {
+public class MCVoxelWorld extends VoxelWorld {
     private final MCVoxelTypeFactory factory;
-    private final VoxelWorldMetadata metadata;
     private final Map<Integer, Region> regions;
-
-    private static final int WORLD_SIZE = 30_000_000;
-    // Note: Theses two values aren't strictly hard-limits.
+    // Note: The two z-component values aren't strictly hard-limits.
     // We can extends from -2032 to 2031 but the client
     // will need higher performances to play the game!
     // The Querz library does not support extended limits...
-    private static final int MIN_WORLD_HEIGHT = 0; // -64
-    private static final int MAX_WORLD_HEIGHT = 255; // 320
+    private static final WorldBBox3d MAX_LIMIT = new WorldBBox3d(
+        new WorldCoords3d(-30_000_000, -30_000_000, 0),
+        new WorldCoords3d(30_000_000, 30_000_000, 255)
+    );
 
     /**
      * Constructs a new {@code MCVoxelWorld}.
+     * The limits of the world have to be set using {@link #setLimits(WorldBBox3d)}
      */
     public MCVoxelWorld() {
+        super(new VoxelWorldMetadata());
         factory = new MCVoxelTypeFactory(this);
-        metadata = new VoxelWorldMetadata();
         regions = new HashMap<>();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public WorldBBox3d maxLimits() {
+        return MAX_LIMIT;
     }
 
     /**
@@ -56,14 +64,6 @@ public class MCVoxelWorld implements VoxelWorld {
     @Override
     public MCVoxelTypeFactory getFactory() {
         return factory;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public VoxelWorldMetadata getMetadata() {
-        return metadata;
     }
 
     /**
@@ -97,9 +97,8 @@ public class MCVoxelWorld implements VoxelWorld {
             CompoundTag data = new CompoundTag();
             {
                 data.putBoolean("allowCommands", true);
-
-                WorldBBox3d bbox = metadata.getBbox();
-                WorldSize3d size = bbox.getSize();
+                WorldBBox3d bbox = limits();
+                WorldSize3d size = limits().getSize();
                 double minSize = Math.max(size.x(), size.y());
                 data.putDouble("BorderCenterX", (bbox.getMinX() + bbox.getMaxX()) / 2d);
                 data.putDouble("BorderCenterZ", (bbox.getMinY() + bbox.getMaxY()) / 2d); // Y => Z
@@ -299,7 +298,7 @@ public class MCVoxelWorld implements VoxelWorld {
                         pos.addDouble(metadata.getSpawn().x() + 0.5);
                         // TODO Replace by a better constraint management mechanism
                         // pos.addDouble(metadata.getSpawn().z());
-                        pos.addDouble(Math.min(Math.max(MIN_WORLD_HEIGHT, metadata.getSpawn().z()), MAX_WORLD_HEIGHT));
+                        pos.addDouble(Math.min(Math.max(limits().getMinZ(), metadata.getSpawn().z()), limits().getMaxZ()));
                         pos.addDouble(metadata.getSpawn().y() + 0.5);
                     }
                     player.put("Pos", pos);
@@ -365,7 +364,7 @@ public class MCVoxelWorld implements VoxelWorld {
                 data.putInt("SpawnX", metadata.getSpawn().x());
                 // TODO Replace by a better constraint management mechanism
                 // data.putInt("SpawnY", metadata.getSpawn().z());
-                data.putInt("SpawnY", Math.min(Math.max(MIN_WORLD_HEIGHT, metadata.getSpawn().z()), MAX_WORLD_HEIGHT));
+                data.putInt("SpawnY", Math.min(Math.max(limits().getMinZ(), metadata.getSpawn().z()), limits().getMaxZ()));
                 data.putInt("SpawnZ", metadata.getSpawn().y());
 
                 data.putBoolean("thundering", false);
@@ -473,15 +472,15 @@ public class MCVoxelWorld implements VoxelWorld {
     }
 
     // In-Game coords
-    /* package-private */ void setBlockState(int blockX, int blockY, int blockZ, CompoundTag block) throws OutOfWorldException {
-        if (shouldClipHeight_RemoveThisMethodWhenABetterSolutionIsImplemented(blockY)) return;
-        getOrCreateRegion(blockX, blockY, blockZ).file().setBlockStateAt(blockX, blockY, blockZ, block, false);
+    /* package-private */ void setBlockState(int blockX, int blockY, int blockZ, CompoundTag block) {
+        if (isOutOfLimits(blockX, blockY, blockZ)) return;
+        getOrCreateRegion(blockX, blockZ).file().setBlockStateAt(blockX, blockY, blockZ, block, false);
     }
 
     // In-Game coords
-    /* package-private */ void addBlockEntity(int blockX, int blockY, int blockZ, CompoundTag block) throws OutOfWorldException {
-        if (shouldClipHeight_RemoveThisMethodWhenABetterSolutionIsImplemented(blockY)) return;
-        Chunk chunk = getOrCreateRegion(blockX, blockY, blockZ).getOrCreateChunk(MCAUtil.blockToChunk(blockX), MCAUtil.blockToChunk(blockZ));
+    /* package-private */ void addBlockEntity(int blockX, int blockY, int blockZ, CompoundTag block)  {
+        if (isOutOfLimits(blockX, blockY, blockZ)) return;
+        Chunk chunk = getOrCreateRegion(blockX, blockZ).getOrCreateChunk(MCAUtil.blockToChunk(blockX), MCAUtil.blockToChunk(blockZ));
         ListTag<CompoundTag> blockEntities = chunk.getTileEntities();
         if (blockEntities == null) {
             blockEntities = new ListTag<>(CompoundTag.class);
@@ -491,8 +490,7 @@ public class MCVoxelWorld implements VoxelWorld {
     }
 
     // In-Game coords
-    private Region getOrCreateRegion(int blockX, int blockY, int blockZ) throws OutOfWorldException {
-        checkLimits(blockX, blockY, blockZ);
+    private Region getOrCreateRegion(int blockX, int blockZ)  {
         int regionX = MCAUtil.blockToRegion(blockX);
         int regionZ = MCAUtil.blockToRegion(blockZ);
         int key = computeRegionKey(regionX, regionZ);
@@ -510,25 +508,8 @@ public class MCVoxelWorld implements VoxelWorld {
     }
 
     // In-Game coords
-    /* package-private */ void checkLimits(int blockX, int blockY, int blockZ) throws OutOfWorldException {
-        if (blockX < -WORLD_SIZE || blockX > WORLD_SIZE
-                || blockZ < -WORLD_SIZE || blockZ > WORLD_SIZE
-                || blockY < MIN_WORLD_HEIGHT || blockY > MAX_WORLD_HEIGHT)
-            throw new OutOfWorldException();
-    }
-
-    // TODO Replace by a better constraint management mechanism
-    private boolean warnAboutClipping = true;
-
-    @SuppressWarnings("checkstyle:MethodName")
-    private boolean shouldClipHeight_RemoveThisMethodWhenABetterSolutionIsImplemented(int y) {
-        if (y < MIN_WORLD_HEIGHT || y > MAX_WORLD_HEIGHT) {
-            if (warnAboutClipping) {
-                System.err.println("WARNING! Some blocks have been clipped out of the map because they were beyond height limits!");
-                warnAboutClipping = false;
-            }
-            return true;
-        }
-        return false;
+    /* package-private */ boolean isOutOfLimits(int blockX, int blockY, int blockZ) {
+        // (In-Game coords to world coords) XZY => XYZ
+        return !limits().contains(blockX, blockZ, blockY);
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelWorld.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelWorld.java
@@ -147,9 +147,9 @@ public class MCVoxelWorld extends VoxelWorld {
                 {
                     // Commented out gamerule were added after 1.16.1
                     gameRules.putString("announceAdvancements", "true");
-                    //gameRules.putString("blockExplosionDropDecay", "true"); // 1.19.3
+                    // gameRules.putString("blockExplosionDropDecay", "true"); // 1.19.3
                     gameRules.putString("commandBlockOutput", "true");
-                    //gameRules.putString("commandModificationBlockLimit", "32768"); // 1.19.4
+                    // gameRules.putString("commandModificationBlockLimit", "32768"); // 1.19.4
                     gameRules.putString("disableElytraMovementCheck", "false");
                     gameRules.putString("disableRaids", "false");
                     gameRules.putString("doDaylightCycle", "true");
@@ -163,49 +163,49 @@ public class MCVoxelWorld extends VoxelWorld {
                     gameRules.putString("doPatrolSpawning", "true");
                     gameRules.putString("doTileDrops", "true");
                     gameRules.putString("doTraderSpawning", "true");
-                    //gameRules.putString("doVinesSpread", "true"); // 1.19.4
+                    // gameRules.putString("doVinesSpread", "true"); // 1.19.4
                     gameRules.putString("doWeatherCycle", "true");
-                    //gameRules.putString("doWardenSpawning", "true"); // 1.19
+                    // gameRules.putString("doWardenSpawning", "true"); // 1.19
                     gameRules.putString("drowningDamage", "true");
-                    //gameRules.putString("enderPearlsVanishOnDeath", "true"); // 1.20.2
+                    // gameRules.putString("enderPearlsVanishOnDeath", "true"); // 1.20.2
                     gameRules.putString("fallDamage", "true");
                     gameRules.putString("fireDamage", "true");
                     gameRules.putString("forgiveDeadPlayers", "true");
-                    //gameRules.putString("freezeDamage", "true"); // 1.17
-                    //gameRules.putString("globalSoundEvents", "true"); // 1.19.3
+                    // gameRules.putString("freezeDamage", "true"); // 1.17
+                    // gameRules.putString("globalSoundEvents", "true"); // 1.19.3
                     gameRules.putString("keepInventory", "false");
-                    //gameRules.putString("lavaSourceConversion", "false"); // 1.19.3
+                    // gameRules.putString("lavaSourceConversion", "false"); // 1.19.3
                     gameRules.putString("logAdminCommands", "true");
                     gameRules.putString("maxCommandChainLength", "65536");
-                    //gameRules.putString("maxCommandForkCount", "65536"); // 1.20.3
+                    // gameRules.putString("maxCommandForkCount", "65536"); // 1.20.3
                     gameRules.putString("maxEntityCramming", "24");
-                    //gameRules.putString("mobExplosionDropDecay", "true"); // 1.19.3
+                    // gameRules.putString("mobExplosionDropDecay", "true"); // 1.19.3
                     gameRules.putString("mobGriefing", "true");
                     gameRules.putString("naturalRegeneration", "true");
-                    //gameRules.putString("playersNetherPortalCreativeDelay", "1"); // 1.20.3
-                    //gameRules.putString("playersNetherPortalDefaultDelay", "80"); // 1.20.3
-                    //gameRules.putString("playersSleepingPercentage", "100"); // 1.17
-                    //gameRules.putString("projectilesCanBreakBlocks", "true"); // 1.20.3
+                    // gameRules.putString("playersNetherPortalCreativeDelay", "1"); // 1.20.3
+                    // gameRules.putString("playersNetherPortalDefaultDelay", "80"); // 1.20.3
+                    // gameRules.putString("playersSleepingPercentage", "100"); // 1.17
+                    // gameRules.putString("projectilesCanBreakBlocks", "true"); // 1.20.3
                     gameRules.putString("randomTickSpeed", "3");
                     gameRules.putString("reducedDebugInfo", "false");
                     gameRules.putString("sendCommandFeedback", "true");
                     gameRules.putString("showDeathMessages", "true");
-                    //gameRules.putString("snowAccumulationHeight", "1"); // 1.19.3
-                    //gameRules.putString("spawnChunkRadius", "2"); // 1.20.5
+                    // gameRules.putString("snowAccumulationHeight", "1"); // 1.19.3
+                    // gameRules.putString("spawnChunkRadius", "2"); // 1.20.5
                     gameRules.putString("spawnRadius", "10");
                     gameRules.putString("spectatorsGenerateChunks", "true");
-                    //gameRules.putString("tntExplosionDropDecay", "false"); // 1.19.3
+                    // gameRules.putString("tntExplosionDropDecay", "false"); // 1.19.3
                     gameRules.putString("universalAnger", "false");
-                    //gameRules.putString("waterSourceConversion", "true"); // 1.19.3
+                    // gameRules.putString("waterSourceConversion", "true"); // 1.19.3
                 }
                 data.put("GameRules", gameRules);
 
                 data.putInt("GameType", 1);
 
                 // Legacy (1.15 and below)
-                //data.putString("generatorName", "default");
-                //data.putInt("generatorVersion", 0);
-                //data.putString("generatorOptions", "generatorOptions");
+                // data.putString("generatorName", "default");
+                // data.putInt("generatorVersion", 0);
+                // data.putString("generatorOptions", "generatorOptions");
 
                 data.putBoolean("hardcore", false);
 

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/Block.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/Block.java
@@ -19,7 +19,7 @@ public class Block {
      * Constructs a new {@code Block}.
      */
     public Block() {
-        //Array length defined by map version (https://github.com/minetest/minetest/blob/master/doc/world_format.md#node-data)
+        // Array length defined by map version (https://github.com/minetest/minetest/blob/master/doc/world_format.md#node-data)
         this.param0 = new short[4096];
         this.param1 = new byte[4096];
         this.param2 = new byte[4096];
@@ -39,8 +39,8 @@ public class Block {
      * @param voxel the {@link MTVoxelType} to place within the block
      */
     public void set(int x, int y, int z, MTVoxelType voxel) {
-        //Node location on arrays
-        //https://github.com/minetest/minetest/blob/master/doc/world_format.md#node-data
+        // Node location on arrays
+        // https://github.com/minetest/minetest/blob/master/doc/world_format.md#node-data
         int i = z << 8 | y << 4 | x;
         param1[i] = voxel.getParam1();
         param2[i] = voxel.getParam2();

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelType.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelType.java
@@ -1,6 +1,5 @@
 package com.ignfab.minalac.generator.outputs.minetest;
 
-import com.ignfab.minalac.generator.world.OutOfWorldException;
 import com.ignfab.minalac.generator.world.VoxelType;
 
 /**
@@ -46,7 +45,7 @@ public abstract class MTVoxelType implements VoxelType {
     }
 
     @Override
-    public void place(int x, int y, int z) throws OutOfWorldException {
+    public void place(int x, int y, int z)  {
         //The y-axis in Minetest corresponds, in our chosen coordinate system, to the z-axis, hence the inversion
         this.world.set(x, z, y, this);
     }

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelType.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelType.java
@@ -46,7 +46,7 @@ public abstract class MTVoxelType implements VoxelType {
 
     @Override
     public void place(int x, int y, int z)  {
-        //The y-axis in Minetest corresponds, in our chosen coordinate system, to the z-axis, hence the inversion
+        // The y-axis in Minetest corresponds, in our chosen coordinate system, to the z-axis, hence the inversion
         this.world.set(x, z, y, this);
     }
 

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelTypeFactory.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelTypeFactory.java
@@ -30,7 +30,7 @@ public class MTVoxelTypeFactory implements VoxelTypeFactory {
      */
     @Override
     public VoxelType createVoxelType(SemanticType semanticType) {
-        //Node string can be found on https://wiki.minetest.net/Games/Minetest_Game/Nodes
+        // Node string can be found on https://wiki.minetest.net/Games/Minetest_Game/Nodes
         return switch (semanticType) {
             case GRASS -> new MTSimpleVoxelType(this.world, "default:dirt_with_grass");
             case STONE -> new MTSimpleVoxelType(this.world, "default:stone");

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelWorld.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelWorld.java
@@ -1,7 +1,8 @@
 package com.ignfab.minalac.generator.outputs.minetest;
 
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
 import com.ignfab.minalac.generator.world.MapWriteException;
-import com.ignfab.minalac.generator.world.OutOfWorldException;
 import com.ignfab.minalac.generator.world.VoxelTypeFactory;
 import com.ignfab.minalac.generator.world.VoxelWorld;
 import com.ignfab.minalac.generator.outputs.minetest.utils.SQLiteMapWriter;
@@ -17,21 +18,33 @@ import java.util.Map;
 /**
  * Implementation of {@link VoxelWorld} that creates a playable world specifically for Minetest.
  */
-public class MTVoxelWorld implements VoxelWorld {
+public class MTVoxelWorld extends VoxelWorld {
     private final VoxelTypeFactory factory;
-    private final VoxelWorldMetadata metadata;
     private final HashMap<Integer, Block> blocks;
     //See MAX_MAP_GENERATION_LIMIT constant on Minetest
     //https://github.com/minetest/minetest/blob/master/src/constants.h#L69
-    private static final int LIMIT_POSITION = 31_007;
+    private static final WorldBBox3d MAX_LIMIT = new WorldBBox3d(
+        new WorldCoords3d(-31_007, -31_007, -31_007),
+        new WorldCoords3d(31_007, 31_007, 31_007)
+    );
 
     /**
      * Constructs a new {@code MTVoxelWorld}.
+     * The limits of the world have to be set using {@link #setLimits(WorldBBox3d)}
      */
     public MTVoxelWorld() {
-        this.factory = new MTVoxelTypeFactory(this);
-        metadata = new VoxelWorldMetadata();
-        this.blocks = new HashMap<>();
+        super(new VoxelWorldMetadata());
+        factory = new MTVoxelTypeFactory(this);
+        blocks = new HashMap<>();
+    }
+
+    /**
+     * {@inheritDoc}
+     * Maximum limits represent the hard limits of the format.
+     */
+    @Override
+    public WorldBBox3d maxLimits() {
+        return MAX_LIMIT;
     }
 
     /**
@@ -41,15 +54,7 @@ public class MTVoxelWorld implements VoxelWorld {
      */
     @Override
     public VoxelTypeFactory getFactory() {
-        return this.factory;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public VoxelWorldMetadata getMetadata() {
-        return metadata;
+        return factory;
     }
 
     /**
@@ -60,13 +65,10 @@ public class MTVoxelWorld implements VoxelWorld {
      * @param y the y-coordinate value
      * @param z the z-coordinate value
      * @param voxel the voxel to place
-     * @throws OutOfWorldException if the given coordinates are outside the world limits
      */
-    protected void set(int x, int y, int z, MTVoxelType voxel) throws OutOfWorldException {
-        if (-LIMIT_POSITION > x || x > LIMIT_POSITION
-                || -LIMIT_POSITION > y || y > LIMIT_POSITION
-                || -LIMIT_POSITION > z || z > LIMIT_POSITION)
-            throw new OutOfWorldException();
+    protected void set(int x, int y, int z, MTVoxelType voxel) {
+        // (In-Game coords to world coords) XZY => XYZ
+        if (!limits().contains(x, z, y)) return;
 
         int pos = getPosValue(getBlockPosition(x), getBlockPosition(y), getBlockPosition(z));
         Block block = blocks.get(pos);

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelWorld.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelWorld.java
@@ -21,8 +21,8 @@ import java.util.Map;
 public class MTVoxelWorld extends VoxelWorld {
     private final VoxelTypeFactory factory;
     private final HashMap<Integer, Block> blocks;
-    //See MAX_MAP_GENERATION_LIMIT constant on Minetest
-    //https://github.com/minetest/minetest/blob/master/src/constants.h#L69
+    // See MAX_MAP_GENERATION_LIMIT constant on Minetest
+    // https://github.com/minetest/minetest/blob/master/src/constants.h#L69
     private static final WorldBBox3d MAX_LIMIT = new WorldBBox3d(
         new WorldCoords3d(-31_007, -31_007, -31_007),
         new WorldCoords3d(31_007, 31_007, 31_007)
@@ -123,8 +123,8 @@ public class MTVoxelWorld extends VoxelWorld {
         }
     }
 
-    //See position hashing algorithm on world format documentation
-    //https://github.com/minetest/minetest/blob/master/doc/world_format.md#position-hashing
+    // See position hashing algorithm on world format documentation
+    // https://github.com/minetest/minetest/blob/master/doc/world_format.md#position-hashing
     private int getPosValue(int x, int y, int z) {
         return z * 16777216 + y * 4096 + x;
     }
@@ -134,8 +134,8 @@ public class MTVoxelWorld extends VoxelWorld {
         return p < 0 ? p + 16 : p;
     }
 
-    //See getContainerPos(s16 p, s16 d)
-    //https://github.com/minetest/minetest/blob/master/src/util/numeric.h#L45
+    // See getContainerPos(s16 p, s16 d)
+    // https://github.com/minetest/minetest/blob/master/src/util/numeric.h#L45
     private int getBlockPosition(int p) {
         return (p >= 0 ? p : p - 16 + 1) / 16;
     }

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/utils/Serializer.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/utils/Serializer.java
@@ -60,23 +60,23 @@ public class Serializer {
         stream.write(buffer);
     }
 
-    //See World Format Documentation for more information about block serialization
-    //https://github.com/minetest/minetest/blob/master/doc/world_format.md#node-timers
+    // See World Format Documentation for more information about block serialization
+    // https://github.com/minetest/minetest/blob/master/doc/world_format.md#node-timers
     private void generateNameIdMapping(OutputStream stream, Block block) throws IOException {
-        //u8 name-id-mapping version
+        // u8 name-id-mapping version
         write8Bits(stream, 0);
 
-        //u16 num_name_id_mappings
+        // u16 num_name_id_mappings
         write16Bits(stream, block.getNameIdMapping().size());
 
         for (Map.Entry<Integer, String> entry : block.getNameIdMapping().entrySet()) {
-            //u16 : id
+            // u16 : id
             write16Bits(stream, entry.getKey());
 
-            //u16 : name_len
+            // u16 : name_len
             write16Bits(stream, entry.getValue().length());
 
-            //u8[name_len]
+            // u8[name_len]
             stream.write(entry.getValue().getBytes());
         }
     }
@@ -92,22 +92,22 @@ public class Serializer {
     public byte[] serialize(Block block) throws IOException {
         ByteArrayOutputStream stream = new ByteArrayOutputStream(16384);
 
-        //u8 : map version number
+        // u8 : map version number
         write8Bits(stream, 28);
 
-        //u8 : flags
+        // u8 : flags
         write8Bits(stream, 0);
 
-        //u16 : lighting_complete
+        // u16 : lighting_complete
         write16Bits(stream, 0);
 
-        //u8 : content_width
+        // u8 : content_width
         write8Bits(stream, 2);
 
-        //u8 : params_width
+        // u8 : params_width
         write8Bits(stream, 2);
 
-        //Zlib Node data
+        // Zlib Node data
         DeflaterOutputStream nodeDataStream = new DeflaterOutputStream(stream, deflater);
 
         writeParam0IntoStream(nodeDataStream, block);
@@ -118,32 +118,32 @@ public class Serializer {
         nodeDataStream.finish();
         deflater.reset();
 
-        //Zlib Node metadata
+        // Zlib Node metadata
         DeflaterOutputStream nodeMetadataStream = new DeflaterOutputStream(stream, deflater);
 
-        //u8 : version
+        // u8 : version
         write16Bits(nodeMetadataStream, 2);
         write16Bits(nodeMetadataStream, 0);
         nodeMetadataStream.flush();
         nodeMetadataStream.finish();
         deflater.reset();
 
-        //u8 : static object version
+        // u8 : static object version
         write8Bits(stream, 0);
 
-        //u16 : static object count
+        // u16 : static object count
         write16Bits(stream, 0);
 
-        //u32 : timestamp
+        // u32 : timestamp
         write32Bits(stream, 0);
 
-        //name id mapping
+        // name id mapping
         generateNameIdMapping(stream, block);
 
-        //u8 : length of the data of a single time
+        // u8 : length of the data of a single time
         write8Bits(stream, 10);
 
-        //u16 : num_of_timers
+        // u16 : num_of_timers
         write16Bits(stream, 0);
 
         return stream.toByteArray();

--- a/src/main/java/com/ignfab/minalac/generator/parsing/ParamsParser.java
+++ b/src/main/java/com/ignfab/minalac/generator/parsing/ParamsParser.java
@@ -110,13 +110,14 @@ public class ParamsParser {
      */
     public VoxelWorld createVoxelWorld() {
         VoxelWorld world = FORMATS.get(rawParams.format).get();
-        world.getMetadata().setBbox(new WorldBBox3d(
+        WorldBBox3d maximumLimits = world.maxLimits();
+        world.setLimits(new WorldBBox3d(
             -rawParams.area.extendX / 2,
             -rawParams.area.extendY / 2,
-            0, // Not used for now but should be the minimum altitude
+            maximumLimits.getMinZ(),
             rawParams.area.extendX,
             rawParams.area.extendY,
-            1 // Not used for now but should be world z size
+            maximumLimits.getSizeZ()
         ));
         return world;
     }

--- a/src/main/java/com/ignfab/minalac/generator/parsing/ParamsParser.java
+++ b/src/main/java/com/ignfab/minalac/generator/parsing/ParamsParser.java
@@ -62,7 +62,7 @@ public class ParamsParser {
         if (!FORMATS.containsKey(rawParams.format))
             throw new ParseException("The provided format is not supported");
         try {
-            //TODO : If not provided its default value should be calculated by finding the appropriated projected CRS for the provided center point.
+            // TODO : If not provided its default value should be calculated by finding the appropriated projected CRS for the provided center point.
             // At the moment the default value is EPSG:2154
             targetCrs = CRS.decode(rawParams.crs == null ? "EPSG:2154" : rawParams.crs);
         } catch (FactoryException e) {

--- a/src/main/java/com/ignfab/minalac/generator/renderers/VectorRenderer.java
+++ b/src/main/java/com/ignfab/minalac/generator/renderers/VectorRenderer.java
@@ -7,7 +7,6 @@ import com.ignfab.minalac.generator.models.Rasterizable;
 import com.ignfab.minalac.generator.utils.world2d.chunk.IterableChunk2d;
 import com.ignfab.minalac.generator.utils.world2d.iterator.Chunk2dElement;
 import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
-import com.ignfab.minalac.generator.world.OutOfWorldException;
 import com.ignfab.minalac.generator.world.VoxelType;
 import com.ignfab.minalac.generator.world.VoxelTypeIgnore;
 
@@ -62,17 +61,14 @@ public class VectorRenderer {
                 WorldCoords2d c = element.getCoords();
                 // TODO: Make Iterator able to intersect with another box
                 // TODO: Have a world bbox rather
-                try {
-                    if (heightMap.bbox().contains(c)) {
-                        VoxelType vt = switch (element.getValue()) {
-                            case GeometryModel.INSIDE -> inside;
-                            case GeometryModel.BORDER -> edge;
-                            default -> IGNORE; // Should never get there
-                        };
-                        vt.place(c.x(), c.y(), heightMap.get(c) + 1);
-                    }
-                } catch (OutOfWorldException e) {
-                    // TODO: Would be much better to intersect feature and word bbox rather.
+                // TODO: Would be much better to intersect feature and word bbox rather.
+                if (heightMap.bbox().contains(c)) {
+                    VoxelType vt = switch (element.getValue()) {
+                        case GeometryModel.INSIDE -> inside;
+                        case GeometryModel.BORDER -> edge;
+                        default -> IGNORE; // Should never get there
+                    };
+                    vt.place(c.x(), c.y(), heightMap.get(c) + 1);
                 }
             }
         }

--- a/src/main/java/com/ignfab/minalac/generator/utils/world2d/WorldBBox2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world2d/WorldBBox2d.java
@@ -98,6 +98,16 @@ public class WorldBBox2d implements Iterable<WorldCoords2d> {
     }
 
     /**
+     * Returns {@code true} if the given bbox is in this bounding box.
+     *
+     * @param bbox the bbox to be checked.
+     * @return {@code true} if the provided bbox is in this bounding box.
+     */
+    public boolean contains(WorldBBox2d bbox) {
+        return contains(bbox.getMin()) && contains(bbox.getMax());
+    }
+
+    /**
      * Returns the size of the bounding box.
      *
      * @return the size of the bounding box as a {@code WorldSize2d}.

--- a/src/main/java/com/ignfab/minalac/generator/utils/world3d/WorldBBox3d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world3d/WorldBBox3d.java
@@ -107,6 +107,16 @@ public class WorldBBox3d implements Iterable<WorldCoords3d> {
     }
 
     /**
+     * Returns {@code true} if the given bbox is in this bounding box.
+     *
+     * @param bbox the bbox to be checked.
+     * @return {@code true} if the provided bbox is in this bounding box.
+     */
+    public boolean contains(WorldBBox3d bbox) {
+        return contains(bbox.getMin()) && contains(bbox.getMax());
+    }
+
+    /**
      * Returns the size of the bounding box.
      *
      * @return the size of the bounding box as a {@link WorldSize3d}.

--- a/src/main/java/com/ignfab/minalac/generator/world/OutOfWorldException.java
+++ b/src/main/java/com/ignfab/minalac/generator/world/OutOfWorldException.java
@@ -1,7 +1,0 @@
-package com.ignfab.minalac.generator.world;
-
-/**
- * Exception thrown when attempting to place a voxel outside the world limits.
- */
-public class OutOfWorldException extends Exception {
-}

--- a/src/main/java/com/ignfab/minalac/generator/world/VoxelType.java
+++ b/src/main/java/com/ignfab/minalac/generator/world/VoxelType.java
@@ -9,11 +9,11 @@ public interface VoxelType {
      * Places the voxel in its corresponding {@link VoxelWorld} at the given coordinates.
      * Coordinates are expressed using the system used in {@link com.ignfab.minalac.generator.utils.world3d.WorldCoords3d}.
      * In that system, the z-axis represents the altitude and increments correspond to the size of a voxel.
+     * If provided coordinates are outside the limits of the world, the voxel will not be placed.
      *
      * @param x the x-coordinate value
      * @param y the y-coordinate value
      * @param z the z-coordinate value
-     * @throws OutOfWorldException if the given coordinates are outside the world limits
      */
-    void place(int x, int y, int z) throws OutOfWorldException;
+    void place(int x, int y, int z);
 }

--- a/src/main/java/com/ignfab/minalac/generator/world/VoxelType.java
+++ b/src/main/java/com/ignfab/minalac/generator/world/VoxelType.java
@@ -4,7 +4,7 @@ package com.ignfab.minalac.generator.world;
  * The {@code VoxelType} interface represents a type of voxel that can be placed within a {@link VoxelWorld}.
  */
 public interface VoxelType {
-    //TODO : Since the javadoc was added, see if it is still relevant to keep the content of doc/legacy/QuickStart.md
+    // TODO : Since the javadoc was added, see if it is still relevant to keep the content of doc/legacy/QuickStart.md
     /**
      * Places the voxel in its corresponding {@link VoxelWorld} at the given coordinates.
      * Coordinates are expressed using the system used in {@link com.ignfab.minalac.generator.utils.world3d.WorldCoords3d}.

--- a/src/main/java/com/ignfab/minalac/generator/world/VoxelTypeFactory.java
+++ b/src/main/java/com/ignfab/minalac/generator/world/VoxelTypeFactory.java
@@ -11,6 +11,6 @@ public interface VoxelTypeFactory {
      * @return the corresponding {@link VoxelType}
      */
     VoxelType createVoxelType(SemanticType semanticType);
-    //TODO : implementation of a method that takes into account advanced voxel creation
-    //VoxelType createVoxelType(SemanticType semanticType, parameters);
+    // TODO : implementation of a method that takes into account advanced voxel creation
+    // VoxelType createVoxelType(SemanticType semanticType, parameters);
 }

--- a/src/main/java/com/ignfab/minalac/generator/world/VoxelTypeIgnore.java
+++ b/src/main/java/com/ignfab/minalac/generator/world/VoxelTypeIgnore.java
@@ -13,5 +13,5 @@ public class VoxelTypeIgnore implements VoxelType {
      * @param z z-coordinate where not to place voxel
      */
     @Override
-    public void place(int x, int y, int z) throws OutOfWorldException {}
+    public void place(int x, int y, int z) {}
 }

--- a/src/main/java/com/ignfab/minalac/generator/world/VoxelWorld.java
+++ b/src/main/java/com/ignfab/minalac/generator/world/VoxelWorld.java
@@ -1,27 +1,77 @@
 package com.ignfab.minalac.generator.world;
 
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+
 import java.io.File;
 
 /**
- * The {@code VoxelWorld} interface represents a three-dimensional world with voxels as the fundamental unit.
- * Implementations of this interface are primary meant to create playable world for voxel-based games such as Minecraft or Minetest.
+ * The {@code VoxelWorld} abstract class represents a three-dimensional world with voxels as the fundamental unit.
+ * Implementations of this abstract class are primary meant to create playable world for voxel-based games such as Minecraft or Minetest.
  *
  * @see VoxelType
  */
-public interface VoxelWorld {
+public abstract class VoxelWorld {
+    /**
+     * The limits of the world.
+     */
+    private WorldBBox3d limits;
+    /**
+     * The metadata of the world.
+     */
+    protected final VoxelWorldMetadata metadata;
+
+    protected VoxelWorld(VoxelWorldMetadata metadata) {
+        limits = new WorldBBox3d(0, 0, 0, 0, 0, 0);
+        this.metadata = metadata;
+    }
+
+    /**
+     * Sets the limits of this world.
+     * This operation can be only be done once.
+     *
+     * @param limits a bounding box representing the limits of the world
+     * @throws IllegalStateException if the limits have already been set
+     * @throws IllegalArgumentException if the specified exceed the maximum limits
+     */
+    public void setLimits(WorldBBox3d limits) {
+        if (!maxLimits().contains(limits))
+            throw new IllegalArgumentException("Provided limits exceed the maximum limits");
+        if (!this.limits.isEmpty())
+            throw new IllegalStateException("The limits have already been set");
+        this.limits = limits;
+    }
+
+    /**
+     * Return the limits of this world.
+     *
+     * @return the {@code WorldBBox3d} representing the limits of the world
+     */
+    public WorldBBox3d limits() {
+        return limits;
+    }
+
+    /**
+     * Return the maximum limits of the world.
+     *
+     * @return the {@code WorldBBox3d} representing the maximum limits of the world
+     */
+    public abstract WorldBBox3d maxLimits();
+
     /**
      * Returns the factory for creating its corresponding {@link VoxelType}.
      *
      * @return the factory for creating voxels
      */
-    VoxelTypeFactory getFactory();
+    public abstract VoxelTypeFactory getFactory();
 
     /**
      * Returns the metadata of this {@code VoxelWorld}.
      *
      * @return the {@link VoxelWorldMetadata}
      */
-    VoxelWorldMetadata getMetadata();
+    public VoxelWorldMetadata getMetadata() {
+        return metadata;
+    }
 
     // TODO: There is an inconsistency between the two implementations. When the folder does not exist MTVoxelWorld creates it whereas MCVoxelWorld throws a MapWriteException.
     /**
@@ -30,5 +80,5 @@ public interface VoxelWorld {
      * @param destination the {@link File} where the output will be saved. It must represent a directory.
      * @throws MapWriteException if an error occurs while writing to the specified destination.
      */
-    void save(File destination) throws MapWriteException;
+    public abstract void save(File destination) throws MapWriteException;
 }

--- a/src/main/java/com/ignfab/minalac/generator/world/VoxelWorldMetadata.java
+++ b/src/main/java/com/ignfab/minalac/generator/world/VoxelWorldMetadata.java
@@ -1,6 +1,5 @@
 package com.ignfab.minalac.generator.world;
 
-import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
 
 /**
@@ -15,11 +14,6 @@ public class VoxelWorldMetadata {
      * Name of the generated world.
      */
     protected String worldName;
-    /**
-     * Bounding box of the generated area.
-     * Can be used in some output format to restrict player's movements to the generated area only.
-     */
-    protected WorldBBox3d bbox;
 
     /**
      * Returns the initial position of the player.
@@ -55,23 +49,5 @@ public class VoxelWorldMetadata {
      */
     public void setWorldName(String worldName) {
         this.worldName = worldName;
-    }
-
-    /**
-     * Returns the {@link WorldBBox3d} of the world.
-     *
-     * @return the {@link WorldBBox3d} of the world
-     */
-    public WorldBBox3d getBbox() {
-        return bbox;
-    }
-
-    /**
-     * Sets the {@link WorldBBox3d} of the world.
-     *
-     * @param bbox the {@link WorldBBox3d} of the world
-     */
-    public void setBbox(WorldBBox3d bbox) {
-        this.bbox = bbox;
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelTypeTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelTypeTest.java
@@ -1,6 +1,7 @@
 package com.ignfab.minalac.generator.outputs.minecraft;
 
-import com.ignfab.minalac.generator.world.OutOfWorldException;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
 import net.querz.nbt.tag.CompoundTag;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,12 +17,13 @@ public class MCVoxelTypeTest {
     @BeforeEach
     public void setUp() {
         worldMock = new WorldMock();
+        worldMock.setLimits(new WorldBBox3d(new WorldCoords3d(-50, -10, 0), new WorldCoords3d(10, 0, 200)));
     }
 
     @Test
     public void testPlace() {
         MCVoxelType air = new MCVoxelType(worldMock, "minecraft:air");
-        assertDoesNotThrow(() -> air.place(3, -7, 64));
+        air.place(3, -7, 64);
         CompoundTag expectedAir = new CompoundTag();
         expectedAir.putString("Name", "minecraft:air");
         worldMock.assertBlockStateAt(3, 64, -7, expectedAir); // XYZ => XZY
@@ -32,7 +34,7 @@ public class MCVoxelTypeTest {
             "shape", "straight",
             "waterlogged", "false"
         ));
-        assertDoesNotThrow(() -> stairs.place(-43, 0, 192));
+        stairs.place(-43, 0, 192);
         CompoundTag expectedStairs = new CompoundTag();
         expectedStairs.putString("Name", "minecraft:oak_stairs");
         CompoundTag properties = new CompoundTag();
@@ -48,8 +50,8 @@ public class MCVoxelTypeTest {
         private final Map<String, CompoundTag> blockStates = new HashMap<>();
 
         @Override
-        void setBlockState(int blockX, int blockY, int blockZ, CompoundTag block) throws OutOfWorldException {
-            super.setBlockState(blockX, blockY, blockZ, block);
+        void setBlockState(int blockX, int blockY, int blockZ, CompoundTag block)  {
+            if (isOutOfLimits(blockX, blockY, blockZ)) return;
             blockStates.put(key(blockX, blockY, blockZ), block);
         }
 

--- a/src/test/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelWorldTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelWorldTest.java
@@ -2,7 +2,6 @@ package com.ignfab.minalac.generator.outputs.minecraft;
 
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
-import com.ignfab.minalac.generator.world.OutOfWorldException;
 import net.querz.nbt.tag.CompoundTag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -18,11 +17,13 @@ public class MCVoxelWorldTest {
     private File dir;
 
     @Test
-    public void testSave() throws OutOfWorldException {
+    public void testSave() {
         MCVoxelWorld world = new MCVoxelWorld();
+        world.setLimits(new WorldBBox3d(
+            new WorldCoords3d(-16, -16, 0),
+            new WorldCoords3d(15, 15, 255)));
         world.getMetadata().setWorldName("testSave");
         world.getMetadata().setSpawn(new WorldCoords3d(0, 64, 0));
-        world.getMetadata().setBbox(new WorldBBox3d(-16, 0, -16, 32, 255, 32));
         CompoundTag block = new CompoundTag();
         block.putString("Name", "minecraft:stone");
 
@@ -52,20 +53,21 @@ public class MCVoxelWorldTest {
     }
 
     @Test
-    @SuppressWarnings("checkstyle:ParenPad")
-    public void testCheckLimits() {
+    public void testIsOutOfLimits() {
         MCVoxelWorld world = new MCVoxelWorld();
+        world.setLimits(new WorldBBox3d(new WorldCoords3d(-10, -20, 0), new WorldCoords3d(20, 30, 40)));
 
-        assertDoesNotThrow(() -> world.checkLimits(-30_000_000, 0, -30_000_000));
-        assertDoesNotThrow(() -> world.checkLimits(30_000_000, 255, 30_000_000));
+        // Y -> Z
+        assertFalse(world.isOutOfLimits(-10, 0, -20));
+        assertFalse(world.isOutOfLimits(20, 40, 30));
 
-        assertDoesNotThrow(() -> world.checkLimits(0, 64, 0));
+        assertFalse(world.isOutOfLimits(5, 5, 20));
 
-        assertThrows(OutOfWorldException.class, () -> world.checkLimits(-30_000_001, 64,           0));
-        assertThrows(OutOfWorldException.class, () -> world.checkLimits(          0, -1,           0));
-        assertThrows(OutOfWorldException.class, () -> world.checkLimits(          0, 64, -30_000_001));
-        assertThrows(OutOfWorldException.class, () -> world.checkLimits(30_000_001,  64,          0));
-        assertThrows(OutOfWorldException.class, () -> world.checkLimits(         0, 256,          0));
-        assertThrows(OutOfWorldException.class, () -> world.checkLimits(         0,  64, 30_000_001));
+        assertTrue(world.isOutOfLimits(21, 40, 30));
+        assertTrue(world.isOutOfLimits(20, 41, 30));
+        assertTrue(world.isOutOfLimits(20, 40, 31));
+        assertTrue(world.isOutOfLimits(-11, 0, -20));
+        assertTrue(world.isOutOfLimits(-10, -1, -20));
+        assertTrue(world.isOutOfLimits(-10, 0, -21));
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/outputs/minetest/TestMTVoxelWorld.java
+++ b/src/test/java/com/ignfab/minalac/generator/outputs/minetest/TestMTVoxelWorld.java
@@ -1,5 +1,7 @@
 package com.ignfab.minalac.generator.outputs.minetest;
 
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.InvocationTargetException;
@@ -30,6 +32,10 @@ public class TestMTVoxelWorld {
     @Test
     public void testGetPosValue() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
         MTVoxelWorld world = new MTVoxelWorld();
+        world.setLimits(new WorldBBox3d(
+            new WorldCoords3d(-5, -5, -5),
+            new WorldCoords3d(5, 5, 5))
+        );
 
         assertEquals(0, getGetPosValueMethod().invoke(world, 0, 0, 0));
 
@@ -52,6 +58,10 @@ public class TestMTVoxelWorld {
     @Test
     public void testGetNodeRelativePosition() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
         MTVoxelWorld world = new MTVoxelWorld();
+        world.setLimits(new WorldBBox3d(
+            new WorldCoords3d(-5, -5, -5),
+            new WorldCoords3d(5, 5, 5))
+        );
 
         assertEquals(0, getGetNodeRelativePositionMethod().invoke(world, 0));
         assertEquals(10, getGetNodeRelativePositionMethod().invoke(world, 10));
@@ -73,6 +83,10 @@ public class TestMTVoxelWorld {
     @Test
     public void testGetBlockPosition() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
         MTVoxelWorld world = new MTVoxelWorld();
+        world.setLimits(new WorldBBox3d(
+            new WorldCoords3d(-5, -5, -5),
+            new WorldCoords3d(5, 5, 5))
+        );
 
         assertEquals(0, getGetBlockPositionMethod().invoke(world, 0));
         assertEquals(0, getGetBlockPositionMethod().invoke(world, 10));

--- a/src/test/java/com/ignfab/minalac/generator/outputs/testing/TestingVoxelType.java
+++ b/src/test/java/com/ignfab/minalac/generator/outputs/testing/TestingVoxelType.java
@@ -1,6 +1,5 @@
 package com.ignfab.minalac.generator.outputs.testing;
 
-import com.ignfab.minalac.generator.world.OutOfWorldException;
 import com.ignfab.minalac.generator.world.VoxelType;
 
 /**
@@ -37,7 +36,7 @@ public class TestingVoxelType implements VoxelType {
      * @param z z-coordinate where to place voxel
      */
     @Override
-    public void place(int x, int y, int z) throws OutOfWorldException {
+    public void place(int x, int y, int z) {
         this.world.set(x, y, z, this);
     }
 

--- a/src/test/java/com/ignfab/minalac/generator/outputs/testing/TestingVoxelWorld.java
+++ b/src/test/java/com/ignfab/minalac/generator/outputs/testing/TestingVoxelWorld.java
@@ -3,10 +3,9 @@ package com.ignfab.minalac.generator.outputs.testing;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
 import com.ignfab.minalac.generator.world.MapWriteException;
-import com.ignfab.minalac.generator.world.OutOfWorldException;
+
 import com.ignfab.minalac.generator.world.VoxelTypeFactory;
 import com.ignfab.minalac.generator.world.VoxelWorld;
-import com.ignfab.minalac.generator.world.VoxelWorldMetadata;
 
 import java.io.File;
 
@@ -19,11 +18,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
  * TestingVoxelWorld does not produce any file output. It is intended to be used in unit tests
  * as output world.
  */
-public class TestingVoxelWorld implements VoxelWorld {
+public class TestingVoxelWorld extends VoxelWorld {
     private VoxelTypeFactory factory;
-    private WorldBBox3d bbox;
+    private WorldBBox3d maxLimits;
     private String[] voxels;
-    private VoxelWorldMetadata metadata;
 
     /**
      * Constructs a new TestingVoxelWorld.
@@ -34,10 +32,16 @@ public class TestingVoxelWorld implements VoxelWorld {
      * Each voxel is stored in memory as a string, which could be very large.
      */
     public TestingVoxelWorld(WorldBBox3d bbox) {
-        this.bbox = bbox;
+        super(null);
         factory = new TestingVoxelTypeFactory(this);
+        maxLimits = bbox;
         voxels = new String[bbox.getSize().volume()];
-        metadata = new VoxelWorldMetadata();
+        setLimits(bbox);
+    }
+
+    @Override
+    public WorldBBox3d maxLimits() {
+        return maxLimits;
     }
 
     @Override
@@ -48,20 +52,14 @@ public class TestingVoxelWorld implements VoxelWorld {
     @Override
     public void save(File destination) throws MapWriteException {}
 
-    @Override
-    public VoxelWorldMetadata getMetadata() {
-        return metadata;
-    };
-
-    private int index(int x, int y, int z) throws OutOfWorldException {
-        if (!bbox.contains(x, y, z))
-            throw new OutOfWorldException();
-        return x - bbox.getMinX() + bbox.getSizeX()
-            * (y - bbox.getMinY() + bbox.getSizeY()
-            * (z - bbox.getMinZ()));
+    //This method should not be called with out of bounds coordinate
+    private int index(int x, int y, int z) {
+        return x - limits().getMinX() + limits().getSizeX()
+            * (y - limits().getMinY() + limits().getSizeY()
+            * (z - limits().getMinZ()));
     }
 
-    protected void set(int x, int y, int z, TestingVoxelType voxelType) throws OutOfWorldException {
+    protected void set(int x, int y, int z, TestingVoxelType voxelType) {
         set(x, y, z, voxelType.getType());
     }
 
@@ -73,8 +71,9 @@ public class TestingVoxelWorld implements VoxelWorld {
      * @param z Z-coordinates of position to set
      * @param value Voxel value to set at this position
      */
-    public void set(int x, int y, int z, String value) throws OutOfWorldException {
-        voxels[index(x, y, z)] = value;
+    public void set(int x, int y, int z, String value) {
+        if (limits().contains(x, y, z))
+            voxels[index(x, y, z)] = value;
     }
 
     /**
@@ -85,7 +84,9 @@ public class TestingVoxelWorld implements VoxelWorld {
      * @param z Z-coordinates of position to get
      * @return Voxel value at this position
      */
-    public String get(int x, int y, int z) throws OutOfWorldException {
+    public String get(int x, int y, int z) {
+        if (!limits().contains(x, y, z))
+            throw new IndexOutOfBoundsException("Specified coordinates (%d, %d, %d) are off limit".formatted(x, y, z));
         return voxels[index(x, y, z)];
     }
 
@@ -98,7 +99,7 @@ public class TestingVoxelWorld implements VoxelWorld {
      * @param z z-coordinate of tested voxel
      * @param message Message to be displayed in case of failure
      */
-    public void assertVoxel(String expected, int x, int y, int z, String message) throws OutOfWorldException {
+    public void assertVoxel(String expected, int x, int y, int z, String message) {
         assertEquals(expected, get(x, y, z), message);
     }
 
@@ -110,7 +111,7 @@ public class TestingVoxelWorld implements VoxelWorld {
      * @param y y-coordinate of tested voxel
      * @param z z-coordinate of tested voxel
      */
-    public void assertVoxel(String expected, int x, int y, int z) throws OutOfWorldException {
+    public void assertVoxel(String expected, int x, int y, int z) {
         assertVoxel(expected, x, y, z, "Voxel mismatch at (%d, %d, %d)".formatted(x, y, z));
     }
 
@@ -121,7 +122,7 @@ public class TestingVoxelWorld implements VoxelWorld {
      * @param pos Position of tested voxel
      * @param message Message to be displayed in case of failure
      */
-    public void assertVoxel(String expected, WorldCoords3d pos, String message) throws OutOfWorldException {
+    public void assertVoxel(String expected, WorldCoords3d pos, String message) {
         assertVoxel(expected, pos.x(), pos.y(), pos.z(), message);
     }
 
@@ -131,7 +132,7 @@ public class TestingVoxelWorld implements VoxelWorld {
      * @param expected Expected value
      * @param pos Position of tested voxel
      */
-    public void assertVoxel(String expected, WorldCoords3d pos) throws OutOfWorldException {
+    public void assertVoxel(String expected, WorldCoords3d pos) {
         assertVoxel(expected, pos.x(), pos.y(), pos.z());
     }
 
@@ -143,7 +144,7 @@ public class TestingVoxelWorld implements VoxelWorld {
      * @param z z-coordinate of tested voxel
      * @param message Message to be displayed in case of failure
      */
-    public void assertVoxelNull(int x, int y, int z, String message) throws OutOfWorldException {
+    public void assertVoxelNull(int x, int y, int z, String message) {
         assertNull(get(x, y, z), message);
     }
 
@@ -154,7 +155,7 @@ public class TestingVoxelWorld implements VoxelWorld {
      * @param y y-coordinate of tested voxel
      * @param z z-coordinate of tested voxel
      */
-    public void assertVoxelNull(int x, int y, int z) throws OutOfWorldException {
+    public void assertVoxelNull(int x, int y, int z) {
         assertVoxelNull(x, y, z, "Voxel mismatch at (%d, %d, %d)".formatted(x, y, z));
     }
 
@@ -164,7 +165,7 @@ public class TestingVoxelWorld implements VoxelWorld {
      * @param pos Position of tested voxel
      * @param message Message to be displayed in case of failure
      */
-    public void assertVoxelNull(WorldCoords3d pos, String message) throws OutOfWorldException {
+    public void assertVoxelNull(WorldCoords3d pos, String message) {
         assertVoxelNull(pos.x(), pos.y(), pos.z(), message);
     }
 
@@ -173,7 +174,7 @@ public class TestingVoxelWorld implements VoxelWorld {
      *
      * @param pos Position of tested voxel
      */
-    public void assertVoxelNull(WorldCoords3d pos) throws OutOfWorldException {
+    public void assertVoxelNull(WorldCoords3d pos) {
         assertVoxelNull(pos.x(), pos.y(), pos.z());
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/outputs/testing/TestingVoxelWorld.java
+++ b/src/test/java/com/ignfab/minalac/generator/outputs/testing/TestingVoxelWorld.java
@@ -52,7 +52,7 @@ public class TestingVoxelWorld extends VoxelWorld {
     @Override
     public void save(File destination) throws MapWriteException {}
 
-    //This method should not be called with out of bounds coordinate
+    // This method should not be called with out of bounds coordinate
     private int index(int x, int y, int z) {
         return x - limits().getMinX() + limits().getSizeX()
             * (y - limits().getMinY() + limits().getSizeY()

--- a/src/test/java/com/ignfab/minalac/generator/outputs/testing/TestingVoxelWorldTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/outputs/testing/TestingVoxelWorldTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.DisplayName;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
-import com.ignfab.minalac.generator.world.OutOfWorldException;
 import com.ignfab.minalac.generator.world.SemanticType;
 import com.ignfab.minalac.generator.world.VoxelType;
 
@@ -14,7 +13,7 @@ import java.io.File;
 public class TestingVoxelWorldTest {
     @Test
     @DisplayName("Ensure that everything that is stored in the world can be retreived")
-    public void testSetAndGet() throws OutOfWorldException {
+    public void testSetAndGet() {
         TestingVoxelWorld world = new TestingVoxelWorld(new WorldBBox3d(-1, -2, -3, 5, 4, 3));
         // Fill the world with unique values
         for (int x = -1; x <= 3; x++)
@@ -31,7 +30,7 @@ public class TestingVoxelWorldTest {
 
     @Test
     @DisplayName("Test setting in the world using voxel type can be retrieved")
-    public void testGetVoxelType() throws OutOfWorldException {
+    public void testGetVoxelType() {
         TestingVoxelWorld world = new TestingVoxelWorld(new WorldBBox3d(1, 2, 3, 4, 5, 6));
         VoxelType vt1 = world.getFactory().createVoxelType(SemanticType.STONE);
         VoxelType vt2 = world.getFactory().createVoxelType(SemanticType.DIRT);

--- a/src/test/java/com/ignfab/minalac/generator/parsing/ParamsParserTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parsing/ParamsParserTest.java
@@ -263,7 +263,7 @@ public class ParamsParserTest {
     public void testCreateVoxelWorld() {
         VoxelWorld world = assertDoesNotThrow(() -> new ParamsParser(WORKING_JSON).createVoxelWorld());
         assertNotNull(world);
-        assertEquals(500, world.getMetadata().getBbox().getSizeX());
-        assertEquals(2500, world.getMetadata().getBbox().getSizeY());
+        assertEquals(500, world.limits().getSizeX());
+        assertEquals(2500, world.limits().getSizeY());
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/renderers/VectorRendererTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/renderers/VectorRendererTest.java
@@ -9,7 +9,6 @@ import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
 import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
-import com.ignfab.minalac.generator.world.OutOfWorldException;
 import com.ignfab.minalac.generator.world.SemanticType;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -47,7 +46,7 @@ class VectorRendererTest {
 
     @Test
     @DisplayName("Test a simple rendering on flat height map")
-    public void testRenderFlat() throws OutOfWorldException {
+    public void testRenderFlat() {
         // Prepare a chunk smaller than the whole world
         WorldBBox2d modelBbox = new WorldBBox2d(0, -1, 2, 3);
 
@@ -66,7 +65,7 @@ class VectorRendererTest {
 
     @Test
     @DisplayName("Test rendering outside, inside and border")
-    public void testRenderOutsideInsideBorder() throws OutOfWorldException {
+    public void testRenderOutsideInsideBorder() {
         // Prepare a chunk with only three pixels, one per available value
         TestingIterableArrayChunk2d chunk = new TestingIterableArrayChunk2d(new WorldBBox2d(0, 0, 1, 3), GeometryModel.OUTSIDE);
         chunk.set(0, 1, GeometryModel.BORDER);
@@ -89,7 +88,7 @@ class VectorRendererTest {
 
     @Test
     @DisplayName("Test rendering on a non flat height map")
-    public void testRenderHeightMap() throws OutOfWorldException {
+    public void testRenderHeightMap() {
         // Prepare a non flat HeightMap
         for (WorldCoords2d pos : bbox.to2d())
             heightMap.set(pos, (pos.x() + pos.y()) / 2);
@@ -109,7 +108,7 @@ class VectorRendererTest {
 
     @Test
     @DisplayName("Test rendering with a height map over world vertical limits")
-    public void testRenderVerticalOverflow() throws OutOfWorldException {
+    public void testRenderVerticalOverflow() {
         // A heightmap overflowing under and over world limits
         for (WorldCoords2d pos : bbox.to2d())
             // At (2, 2), height will be 6, above max world z (i.e. 2)
@@ -131,7 +130,7 @@ class VectorRendererTest {
 
     @Test
     @DisplayName("Test rendering of a chunk larger than world horizontal limits")
-    public void testRenderHorizontalOverflow() throws OutOfWorldException {
+    public void testRenderHorizontalOverflow() {
         // Prepare a larger model bbox
         WorldBBox2d modelBbox = new WorldBBox2d(bbox.getMinX() - 1, bbox.getMinY() - 1, bbox.getSizeX() + 2, bbox.getSizeY() + 2);
 

--- a/src/test/java/com/ignfab/minalac/generator/utils/world2d/WorldBBox2dTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/world2d/WorldBBox2dTest.java
@@ -89,6 +89,27 @@ public class WorldBBox2dTest {
     }
 
     @Test
+    public void testContainsBBox() {
+        WorldBBox2d bboxA = new WorldBBox2d(new WorldCoords2d(-2, -3), new WorldCoords2d(6, 7));
+        WorldBBox2d bboxB = new WorldBBox2d(new WorldCoords2d(1, 0), new WorldCoords2d(3, 4));
+        WorldBBox2d bboxC = new WorldBBox2d(new WorldCoords2d(4, 5), new WorldCoords2d(8, 9));
+        WorldBBox2d bboxD = new WorldBBox2d(new WorldCoords2d(6, -3), new WorldCoords2d(14, 7));
+
+        assertTrue(bboxA.contains(bboxA), "BBOX contains itself");
+
+        assertTrue(bboxA.contains(bboxB), "BBOX A contains B: B is a strict subset of A");
+        assertFalse(bboxB.contains(bboxA), "BBOX B does not contain A: B is a strict subset of A");
+
+        assertFalse(bboxA.contains(bboxC), "BBOX A does not contains C: some elements of C, but not all, are in A");
+        assertFalse(bboxC.contains(bboxA), "BBOX C does not contains A: some elements of A, but not all, are in C");
+
+        assertFalse(bboxA.contains(bboxD), "BBOX A does not contains D: they share a line but are distinct");
+        assertFalse(bboxB.contains(bboxD), "BBOX B does not contains D: they are distinct");
+
+        // TODO: When EmptyBBOX is implemented, depending on the usage, decide whether or not it should be included in every BBOX
+    }
+
+    @Test
     @DisplayName("Test to3d() method")
     public void testTo3d() {
         WorldBBox2d box = new WorldBBox2d(-1, -2, 4, 5);

--- a/src/test/java/com/ignfab/minalac/generator/utils/world2d/WorldBBox2dTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/world2d/WorldBBox2dTest.java
@@ -50,41 +50,41 @@ public class WorldBBox2dTest {
     public void testContains() {
         WorldBBox2d box = new WorldBBox2d(-1, -2, 3, 4);
 
-        //four points bounding the box
+        // four points bounding the box
         assertTrue(box.contains(-1, -2));
         assertTrue(box.contains(1, -2));
         assertTrue(box.contains(1, 1));
         assertTrue(box.contains(-1, 1));
 
-        //Point inside
+        // Point inside
         assertTrue(box.contains(0, -1));
 
-        //Four points outside the box bounding it
+        // Four points outside the box bounding it
         assertFalse(box.contains(-2, -2));
         assertFalse(box.contains(2, -2));
         assertFalse(box.contains(1, 2));
         assertFalse(box.contains(-1, 2));
 
-        //Point outside
+        // Point outside
         assertFalse(box.contains(20, 10));
 
-        //Same with other version
+        // Same with other version
 
         assertTrue(box.contains(new WorldCoords2d(-1, -2)));
         assertTrue(box.contains(new WorldCoords2d(1, -2)));
         assertTrue(box.contains(new WorldCoords2d(1, 1)));
         assertTrue(box.contains(new WorldCoords2d(-1, 1)));
 
-        //Point inside
+        // Point inside
         assertTrue(box.contains(new WorldCoords2d(0, -1)));
 
-        //Four points outside the box bounding it
+        // Four points outside the box bounding it
         assertFalse(box.contains(new WorldCoords2d(-2, -2)));
         assertFalse(box.contains(new WorldCoords2d(2, -2)));
         assertFalse(box.contains(new WorldCoords2d(1, 2)));
         assertFalse(box.contains(new WorldCoords2d(-1, 2)));
 
-        //Point outside
+        // Point outside
         assertFalse(box.contains(new WorldCoords2d(20, 10)));
     }
 

--- a/src/test/java/com/ignfab/minalac/generator/utils/world2d/iterator/TestChunk2DIteratorAll.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/world2d/iterator/TestChunk2DIteratorAll.java
@@ -10,7 +10,7 @@ public class TestChunk2DIteratorAll {
     @Test
     public void testFullyFilledMapIterator() {
         ArrayChunk2d chunk = new ArrayChunk2d(1, 2, 3, 4, 1);
-        //Fill chunk with unique values
+        // Fill chunk with unique values
         for (int x = 1; x <= 3; x++)
             for (int y = 2; y <= 5; y++)
                 chunk.set(x, y, x + y * 3);

--- a/src/test/java/com/ignfab/minalac/generator/utils/world3d/WorldBBox3dTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/world3d/WorldBBox3dTest.java
@@ -77,6 +77,27 @@ public class WorldBBox3dTest {
     }
 
     @Test
+    public void testContainsBBox() {
+        WorldBBox3d bboxA = new WorldBBox3d(new WorldCoords3d(-2, -3, -4), new WorldCoords3d(6, 7, 8));
+        WorldBBox3d bboxB = new WorldBBox3d(new WorldCoords3d(1, 0, -1), new WorldCoords3d(3, 4, 5));
+        WorldBBox3d bboxC = new WorldBBox3d(new WorldCoords3d(4, 5, 6), new WorldCoords3d(8, 9, 10));
+        WorldBBox3d bboxD = new WorldBBox3d(new WorldCoords3d(6, -3, -4), new WorldCoords3d(14, 7, 8));
+
+        assertTrue(bboxA.contains(bboxA), "BBOX contains itself");
+
+        assertTrue(bboxA.contains(bboxB), "BBOX A contains B: B is a strict subset of A");
+        assertFalse(bboxB.contains(bboxA), "BBOX B does not contain A: B is a strict subset of A");
+
+        assertFalse(bboxA.contains(bboxC), "BBOX A does not contains C: some elements of C, but not all, are in A");
+        assertFalse(bboxC.contains(bboxA), "BBOX C does not contains A: some elements of A, but not all, are in C");
+
+        assertFalse(bboxA.contains(bboxD), "BBOX A does not contains D: they share a surface but are distinct");
+        assertFalse(bboxB.contains(bboxD), "BBOX B does not contains D: they are distinct");
+
+        // TODO: When EmptyBBOX is implemented, depending on the usage, decide whether or not it should be included in every BBOX
+    }
+
+    @Test
     @DisplayName("Test to2d() method")
     public void testTo2d() {
         WorldBBox3d box = new WorldBBox3d(-1, -2, -3, 4, 5, 6);

--- a/src/test/java/com/ignfab/minalac/generator/world/VoxelWorldTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/world/VoxelWorldTest.java
@@ -1,0 +1,62 @@
+package com.ignfab.minalac.generator.world;
+
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class VoxelWorldTest {
+    @Test
+    public void testSetLimits() {
+        VoxelWorld world = new VoxelWorldMock();
+        assertThrows(IllegalArgumentException.class, () -> {
+            world.setLimits(new WorldBBox3d(
+                    new WorldCoords3d(-21, -19, -18),
+                    new WorldCoords3d(21, 22, 23)
+            ));
+        });
+
+        assertDoesNotThrow(() -> {
+            world.setLimits(new WorldBBox3d(
+                new WorldCoords3d(-1, -2, -3),
+                new WorldCoords3d(4, 5, 6))
+            );
+        });
+
+        assertEquals(new WorldBBox3d(new WorldCoords3d(-1, -2, -3), new WorldCoords3d(4, 5, 6)), world.limits());
+
+        assertThrows(IllegalStateException.class, () -> {
+            world.setLimits(new WorldBBox3d(
+                new WorldCoords3d(-1, -2, -3),
+                new WorldCoords3d(7, 8, 9))
+            );
+        });
+
+    }
+    private static class VoxelWorldMock extends VoxelWorld {
+
+        protected VoxelWorldMock() {
+            super(null);
+        }
+
+        @Override
+        public WorldBBox3d maxLimits() {
+            return new WorldBBox3d(
+                new WorldCoords3d(-20, -19, -18),
+                new WorldCoords3d(21, 22, 23)
+            );
+        }
+
+        @Override
+        public VoxelTypeFactory getFactory() {
+            return null;
+        }
+
+        @Override
+        public void save(File destination) throws MapWriteException {}
+    }
+}


### PR DESCRIPTION
### Issue

**JIRA ticket**: [MINALAC-59](https://ignfab.atlassian.net/browse/MINALAC-59)

### Changes

This pull request aims to remove the `OutOfWorldException` class from the project. It also adds a BBOX representing the hard limits of the world.
#### Feature description

The method `place(int x, int y, int z)` no longer throws an exception when the provided  coordinates are out of bounds; instead, it simply does not place any voxel.

As for the BBOX representing the hard limits, I did not found it appropriate to add a new metadata to `VoxelWorldMetadata` class. To me, the metadata in the `VoxelWorldMetadata`, although useful and important, aren't crucial.
Hard limits, on the other hand, are essential, so, the method `getHardLimits()` was added to the interface `VoxelWorld`. Its implementation returns the `WorldBBox3d` representing the BBOX of the world. 

#### Showcase

Same as before !
### Reason

`OutOfWorldException`  was originally made to handle voxel placement beyond the world's hard limits. As explained on the JIRA ticket, it is no longer beneficial. It adds unnecessary exception handling and we now have others ways to manage these limits (`WorldBBox`).
Moreover, its removal will facilitate the [implementation](https://ignfab.atlassian.net/browse/MINALAC-52?atlOrigin=eyJpIjoiZDhmNzQwMDAxYzQ5NGI4MWE1YjliZTM5NWU0OGNmYjYiLCJwIjoiaiJ9) of `VoxelPattern` and rendering.

### TODOs
I have removed `shouldClipHeight_RemoveThisMethodWhenABetterSolutionIsImplemented(int y)` from `MCVoxelWorld` since it doesn't seem needed anymore.
I have added a new TODO `Check or intersection with hard limits BBOX when setting spawn and BBOX` on `VoxelWorldMetadata`. This is should probably be done when doing [MINALAC-56](https://ignfab.atlassian.net/browse/MINALAC-56?atlOrigin=eyJpIjoiYTFhYjE4ZDE1MDhjNDdiNDliZTMyNTM1Nzk5OGE4Y2MiLCJwIjoiaiJ9). (We might need a subclass of `WorldBBOX3d` which contains all coordinates in case we have a `VoxelWorld` which does not have hard limits)
I have left the TODOs `Replace by a better constraint management mechanism` present in `MCVoxelWorld` regarding the spawn metadata since it is related to the above TODO.
### Self-checks

- ~~The code has unit tests associated~~
- [x] The code has Javadoc Comments associated
- [x] Complex / Unexpected code is explained / justified with a small comment
- [x] Relevant documentation inside the `/docs` folder has been updated
- [x] All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [x] The texts have been proofread (documentation, error messages, logs, comments...)


[MINALAC-59]: https://ignfab.atlassian.net/browse/MINALAC-59?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MINALAC-56]: https://ignfab.atlassian.net/browse/MINALAC-56?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ