### PR TITLE
Add data providing/processing system with basic implementation

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -213,9 +213,8 @@
 
     <!-- https://checkstyle.org/config_filters.html#SuppressionXpathFilter -->
     <module name="SuppressionXpathFilter">
-      <property name="file" value="${org.checkstyle.sun.suppressionxpathfilter.config}"
-                default="checkstyle-xpath-suppressions.xml" />
-      <property name="optional" value="true"/>
+      <property name="file" value="suppressions.xml"/>
+      <property name="optional" value="false"/>
     </module>
 
     <!-- Make the @SuppressWarnings annotations available to Checkstyle -->

--- a/examples/minecraft.yaml
+++ b/examples/minecraft.yaml
@@ -1,0 +1,13 @@
+heightmaps:
+  - name: ground
+    default: 0
+verticalScale: 1.0
+horizontalScale: 1.0
+area:
+  center:
+    latitude: 48.845
+    longitude: 2.425
+  extendX: 1000
+  extendY: 1000
+crs: EPSG:2154
+format: minecraft

--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,15 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>3.5.0</version>
+                <dependencies>
+                    <dependency>
+                        <!-- Overrides checkstyle version -->
+                        <groupId>com.puppycrawl.tools</groupId>
+                        <artifactId>checkstyle</artifactId>
+                        <version>10.18.1</version>
+                    </dependency>
+                </dependencies>
                 <executions>
                     <!-- Binds the checkstyle:check goal to the verify phase -->
                     <execution>

--- a/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
+++ b/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
@@ -1,13 +1,22 @@
 package com.ignfab.minalac.generator;
 
+import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
+import com.ignfab.minalac.generator.exceptions.IgnorableException;
+import com.ignfab.minalac.generator.exceptions.RetryableException;
 import com.ignfab.minalac.generator.generation.CoordsConverter;
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.generation.Heightmap;
+import com.ignfab.minalac.generator.inputs.Provider;
 import com.ignfab.minalac.generator.inputs.WFS1_1_GML3_1_DataProvider;
-import com.ignfab.minalac.generator.models.JTSGeometryModel;
+import com.ignfab.minalac.generator.models.Model;
 import com.ignfab.minalac.generator.models.ModelStore;
 import com.ignfab.minalac.generator.parsing.ParamsParser;
 import com.ignfab.minalac.generator.parsing.ParseException;
+import com.ignfab.minalac.generator.processors.GeoToolsVectorProcessor;
+import com.ignfab.minalac.generator.processors.Processor;
+import com.ignfab.minalac.generator.processors.post.MetadataCopyPostProcessor;
+import com.ignfab.minalac.generator.processors.post.MetadataParsePostProcessor;
+import com.ignfab.minalac.generator.processors.post.PostProcessor;
 import com.ignfab.minalac.generator.renderers.VectorRenderer;
 import com.ignfab.minalac.generator.utils.execution.Scheduler;
 import com.ignfab.minalac.generator.utils.execution.TaskFailedException;
@@ -19,17 +28,12 @@ import com.ignfab.minalac.generator.world.SemanticType;
 import com.ignfab.minalac.generator.world.VoxelType;
 import com.ignfab.minalac.generator.world.VoxelWorld;
 import com.ignfab.minalac.generator.world.VoxelWorldMetadata;
-import org.geotools.api.feature.simple.SimpleFeature;
 import org.geotools.api.referencing.FactoryException;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.api.referencing.operation.TransformException;
-import org.geotools.data.simple.SimpleFeatureIterator;
 import org.geotools.referencing.CRS;
 import org.locationtech.jts.geom.Envelope;
-import org.locationtech.jts.geom.Geometry;
-import org.xml.sax.SAXException;
 
-import javax.xml.parsers.ParserConfigurationException;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -37,7 +41,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.util.NoSuchElementException;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -94,15 +97,70 @@ public final class SampleImplementation {
 
         scheduler.schedule("models.buildings", () -> {
             log("Downloading buildings");
+            CoordsConverter converter; // This is supposed to be the layer CRS (actually the same for this demo)
             try {
-                downloadVectorFeatures(
-                    new WFS1_1_GML3_1_DataProvider("https://data.geopf.fr/wfs/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=BDTOPO_V3:batiment&STARTINDEX=0&COUNT=1000&SRSNAME=urn:ogc:def:crs:EPSG::2154&" + bboxURL + ",urn:ogc:def:crs:EPSG::2154&outputFormat=text%2Fxml%3B%20subtype%3Dgml%2F3.1.1"),
-                    generation.makeCoordsConverter(crs),  // This is supposed to be the layer CRS (actually the same for this demo)
-                    "building",
-                    store);
-            } catch (TransformException | IOException | ParserConfigurationException | SAXException | FactoryException e) {
+                converter = generation.makeCoordsConverter(crs);
+            } catch (FactoryException e) {
                 throw new RuntimeException(e);
             }
+            retrieveDataAndFillModelStore(store, "building",
+                new WFS1_1_GML3_1_DataProvider("https://data.geopf.fr/wfs/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=BDTOPO_V3:batiment&STARTINDEX=0&COUNT=1000&SRSNAME=urn:ogc:def:crs:EPSG::2154&" + bboxURL + ",urn:ogc:def:crs:EPSG::2154&outputFormat=text%2Fxml%3B%20subtype%3Dgml%2F3.1.1"),
+                new GeoToolsVectorProcessor(converter),
+                new MetadataCopyPostProcessor("hauteur", "height", false, false),
+                new MetadataParsePostProcessor<>(
+                    "height",
+                    Double.class,
+                    obj -> {
+                        if (obj instanceof Number number)
+                            return number.doubleValue();
+                        else if (obj instanceof String string)
+                            return Double.parseDouble(string);
+                        return null;
+                    },
+                    MetadataParsePostProcessor.ParsingFailurePolicy.REMOVE_METADATA,
+                    false,
+                    false
+                ),
+                // TODO Transform into something like "MetadataDefaultPostProcessor"
+                new PostProcessor<>() {
+                    @Override
+                    public Class<? super Model> acceptedModelType() {
+                        return Model.class;
+                    }
+
+                    @Override
+                    public Class<? extends Model> processedModelType(Class<? extends Model> inputModelType) {
+                        return inputModelType;
+                    }
+
+                    @Override
+                    public Model process(Model model) {
+                        if (!model.hasMetadata("height"))
+                            model.setMetadata("height", 20d);
+                        return model;
+                    }
+                },
+                // TODO Remove once the value is really used (currently useful to simulate value usage and failure in case of incorrect value)
+                new PostProcessor<>() {
+                    @Override
+                    public Class<? super Model> acceptedModelType() {
+                        return Model.class;
+                    }
+
+                    @Override
+                    public Class<? extends Model> processedModelType(Class<? extends Model> inputModelType) {
+                        return inputModelType;
+                    }
+
+                    @Override
+                    public Model process(Model model) throws GenerationFailedException {
+                        Object height = model.getMetadata("height");
+                        if (!(height instanceof Double))
+                            throw new GenerationFailedException("Illegal height value: " + (height == null ? "null" : (height + " (" + height.getClass() + ")")));
+                        return model;
+                    }
+                }
+            );
             log("Downloaded buildings");
         });
 
@@ -147,25 +205,41 @@ public final class SampleImplementation {
         System.out.printf("[%s] %s%n", Thread.currentThread().getName(), message);
     }
 
-    private static void downloadVectorFeatures(WFS1_1_GML3_1_DataProvider provider, CoordsConverter converter, String type, ModelStore store)
-            throws NoSuchElementException, TransformException, IOException, ParserConfigurationException, SAXException {
-        try (SimpleFeatureIterator iterator = provider.getFeatures().features()) {
-            while (iterator.hasNext()) {
-                SimpleFeature feature = iterator.next();
-                JTSGeometryModel model = new JTSGeometryModel((Geometry) feature.getDefaultGeometry(), converter);
-                Object height = feature.getAttribute("hauteur");
-
-                // TODO: Value 20 is a temporary value for building renderings.
-                model.setMetadata("height", 20.0);
-                if (height instanceof String s) {
-                    try {
-                        model.setMetadata("height", Double.valueOf(s));
-                    } catch (NumberFormatException e) {}
-                } else if (height instanceof Number n) {
-                    model.setMetadata("height", n);
+    private static <T> void retrieveDataAndFillModelStore(ModelStore store, String type, Provider<T> provider, Processor<? super T, ?> processor, PostProcessor<?, ?>... postProcessors) {
+        if (!processor.acceptedType().isAssignableFrom(provider.providedType()))
+            throw new IllegalArgumentException("Processor cannot treat provided type. Provided = %s, Accepted = %s".formatted(provider.providedType(), processor.acceptedType()));
+        Class<? extends Model> modelType = processor.modelType();
+        for (PostProcessor<?, ?> postProcessor : postProcessors) {
+            if (!postProcessor.acceptedModelType().isAssignableFrom(modelType))
+                throw new IllegalArgumentException("PostProcessor cannot treat model type. Current model type = %s, Accepted model type = %s".formatted(modelType, postProcessor.acceptedModelType()));
+            @SuppressWarnings("unchecked") // The model type has been validated above
+            PostProcessor<Model, ?> uncheckedPostProcessor = (PostProcessor<Model, ?>) postProcessor;
+            modelType = uncheckedPostProcessor.processedModelType(modelType);
+        }
+        try (Provider.Result<T> result = provider.provide()) {
+            for (T data : result) {
+                try {
+                    Model model = processor.process(data);
+                    for (PostProcessor<?, ?> postProcessor : postProcessors) {
+                        if (model == null)
+                            break;
+                        @SuppressWarnings("unchecked") // All model types have been validated above
+                        PostProcessor<Model, ?> uncheckedPostProcessor = (PostProcessor<Model, ?>) postProcessor;
+                        model = uncheckedPostProcessor.process(model);
+                    }
+                    if (model != null)
+                        store.add(type, model);
+                } catch (IgnorableException e) {
+                    // TODO Add an exception handling policy
+                    // To fail even on ignorable exceptions:
+                    // throw e;
                 }
-                store.add(type, model);
             }
+        } catch (RetryableException e) {
+            // TODO Implement a retry mechanism
+            throw new RuntimeException(e);
+        } catch (IOException | GenerationFailedException e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/com/ignfab/minalac/generator/exceptions/GenerationFailedException.java
+++ b/src/main/java/com/ignfab/minalac/generator/exceptions/GenerationFailedException.java
@@ -1,0 +1,32 @@
+package com.ignfab.minalac.generator.exceptions;
+
+/**
+ * Exception thrown when a fatal error occurs. This means that nothing can be
+ * done to recover from this situation, and the program should stop working.
+ */
+public class GenerationFailedException extends Exception {
+    /**
+     * Creates a new generation failure.
+     * @param message the error message
+     */
+    public GenerationFailedException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new generation failure.
+     * @param cause the cause of this error
+     */
+    public GenerationFailedException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Creates a new generation failure.
+     * @param message the error message
+     * @param cause the cause of this error
+     */
+    public GenerationFailedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/exceptions/IgnorableException.java
+++ b/src/main/java/com/ignfab/minalac/generator/exceptions/IgnorableException.java
@@ -1,0 +1,33 @@
+package com.ignfab.minalac.generator.exceptions;
+
+/**
+ * Exception thrown when something goes wrong with an element that can be ignored.
+ * The code receiving this error can decide to continue without the problematic
+ * element, or completely abort and cause a fatal error.
+ */
+public class IgnorableException extends Exception {
+    /**
+     * Creates a new ignorable exception.
+     * @param message the error message
+     */
+    public IgnorableException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new ignorable exception.
+     * @param cause the cause of this error
+     */
+    public IgnorableException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Creates a new ignorable exception.
+     * @param message the error message
+     * @param cause the cause of this error
+     */
+    public IgnorableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/exceptions/RetryableException.java
+++ b/src/main/java/com/ignfab/minalac/generator/exceptions/RetryableException.java
@@ -1,0 +1,38 @@
+package com.ignfab.minalac.generator.exceptions;
+
+/**
+ * Exception thrown when something goes wrong but retrying may solve the problem.
+ * The code receiving this error can decide to retry the current action,
+ * or completely abort and cause a fatal error (e.g. after a set number of tries).
+ * It is up to the receiver whether to wait before trying again.
+ * <p>
+ * An example of when this issue could happen is when fetching remote content,
+ * such as data from an HTTP server. If the network goes down for a moment,
+ * the operation would fail, but can succeed on the second try.
+ */
+public class RetryableException extends Exception {
+    /**
+     * Creates a new retryable exception.
+     * @param message the error message
+     */
+    public RetryableException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new retryable exception.
+     * @param cause the cause of this error
+     */
+    public RetryableException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Creates a new retryable exception.
+     * @param message the error message
+     * @param cause the cause of this error
+     */
+    public RetryableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/inputs/Provider.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/Provider.java
@@ -1,0 +1,56 @@
+package com.ignfab.minalac.generator.inputs;
+
+import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
+import com.ignfab.minalac.generator.exceptions.RetryableException;
+
+import java.io.Closeable;
+
+/**
+ * A provider is responsible for acquiring data.
+ * <p>
+ * Its main method is {@link #provide()}, which should return a
+ * {@link Result}. A result is both iterable and closable, which
+ * means it must be closed at the end of iteration, or in case
+ * an error occurs and no other element will be consumed.
+ * <p>
+ * The type of elements provided is defined by the generic type
+ * {@code T} (compile-time check) and must also be returned by
+ * the {@link #providedType()} method to allow runtime check.
+ *
+ * @param <T> The type of provided elements
+ */
+public interface Provider<T> {
+    /**
+     * Returns the type of provided elements.
+     *
+     * @return the type of provided elements
+     */
+    Class<T> providedType();
+
+    /**
+     * Provides elements. The returned result can be iterated over
+     * and then closed at the end. A typical usage may be:
+     * <pre>{@code
+     *  Provider<Elem> provider = ...;
+     *  try (Provider.Result<Elem> result = provider.provide()) {
+     *      for (Elem element : result) {
+     *          // Code using element here...
+     *      }
+     *  }
+     * }</pre>
+     *
+     * @return A result wrapping elements and close method
+     * @throws GenerationFailedException If a fatal error occurs while fetching data
+     * @throws RetryableException If an error occurs but retrying may solve the issue
+     */
+    Result<T> provide() throws GenerationFailedException, RetryableException;
+
+    /**
+     * A result wraps elements and a close method.
+     * Once the close method has been invoked, the underlying
+     * resources can be freed, and no new element will be available.
+     *
+     * @param <T> The type of wrapped elements
+     */
+    interface Result<T> extends Iterable<T>, Closeable {}
+}

--- a/src/main/java/com/ignfab/minalac/generator/inputs/WFS1_1_GML3_1_DataProvider.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/WFS1_1_GML3_1_DataProvider.java
@@ -1,6 +1,9 @@
 package com.ignfab.minalac.generator.inputs;
 
-import org.geotools.data.simple.SimpleFeatureCollection;
+import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
+import com.ignfab.minalac.generator.exceptions.RetryableException;
+import org.geotools.api.feature.simple.SimpleFeature;
+import org.geotools.data.simple.SimpleFeatureIterator;
 import org.geotools.wfs.GML;
 import org.xml.sax.SAXException;
 
@@ -8,13 +11,15 @@ import javax.xml.parsers.ParserConfigurationException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Iterator;
 
 /**
  * Data provider using WFS 1.1 and GML 3.1.
  */
 @SuppressWarnings("checkstyle:TypeName") // Underscore character used to better identify "WFS 1.1" and "GML 3.1"
-public class WFS1_1_GML3_1_DataProvider {
+public class WFS1_1_GML3_1_DataProvider implements Provider<SimpleFeature> {
     private final String baseURL;
 
     /**
@@ -26,27 +31,63 @@ public class WFS1_1_GML3_1_DataProvider {
         this.baseURL = baseURL;
     }
 
+    @Override
+    public Class<SimpleFeature> providedType() {
+        return SimpleFeature.class;
+    }
 
-    /**
-     * Retrieves a collection of features from the data provider.
-     *
-     * @return a collection of features
-     */
-    public SimpleFeatureCollection getFeatures() throws IOException, ParserConfigurationException, SAXException {
+    @Override
+    public Result<SimpleFeature> provide() throws GenerationFailedException, RetryableException {
         GML gml = new GML(GML.Version.GML3);
 
-        URL url = new URL(baseURL);
+        URL url;
+        try {
+            url = new URL(baseURL);
+        } catch (MalformedURLException e) {
+            throw new GenerationFailedException("Malformed data source URL", e);
+        }
 
-        InputStream stream = url.openStream();
+        try {
+            InputStream stream = url.openStream(); // TODO Replace with an HTTP requesting tool to allow unit testing and snapshots
 
-        // Invalidate schema declaration because GML version 3.1 is not used in this schema (version is unspecified, defaulting to 3.2)
-        // This code is temporary and no attention is given to its (bad) performance
-        // TODO: Improve that!
-        byte[] bytes = stream.readAllBytes();
-        stream.close();
-        String string = new String(bytes).replace("http://BDTOPO_V3", "explicitly-invalid");
-        InputStream replacedStream = new ByteArrayInputStream(string.getBytes());
+            // Invalidate schema declaration because GML version 3.1 is not used in this schema (version is unspecified, defaulting to 3.2)
+            // This code is temporary and no attention is given to its (bad) performance
+            // TODO: Improve that!
+            byte[] bytes = stream.readAllBytes();
+            stream.close();
+            String string = new String(bytes).replace("http://BDTOPO_V3", "explicitly-invalid");
+            InputStream replacedStream = new ByteArrayInputStream(string.getBytes());
 
-        return gml.decodeFeatureCollection(replacedStream);
-   }
+            return new FeaturesResult(gml.decodeFeatureCollection(replacedStream).features(), replacedStream);
+        } catch (IOException e) {
+            throw new RetryableException(e);
+        } catch (ParserConfigurationException | SAXException e) {
+            throw new GenerationFailedException("Unable to decode features", e);
+        }
+    }
+
+    private record FeaturesResult(SimpleFeatureIterator features, InputStream stream) implements Result<SimpleFeature> {
+        @Override
+        public Iterator<SimpleFeature> iterator() {
+            return new Iter();
+        }
+
+        @Override
+        public void close() throws IOException {
+            features.close();
+            stream.close();
+        }
+
+        private final class Iter implements Iterator<SimpleFeature> {
+            @Override
+            public boolean hasNext() {
+                return features.hasNext();
+            }
+
+            @Override
+            public SimpleFeature next() {
+                return features.next();
+            }
+        }
+    }
 }

--- a/src/main/java/com/ignfab/minalac/generator/processors/GeoToolsVectorProcessor.java
+++ b/src/main/java/com/ignfab/minalac/generator/processors/GeoToolsVectorProcessor.java
@@ -1,0 +1,50 @@
+package com.ignfab.minalac.generator.processors;
+
+import com.ignfab.minalac.generator.exceptions.IgnorableException;
+import com.ignfab.minalac.generator.generation.CoordsConverter;
+import com.ignfab.minalac.generator.models.JTSGeometryModel;
+import org.geotools.api.feature.Property;
+import org.geotools.api.feature.simple.SimpleFeature;
+import org.geotools.api.referencing.operation.TransformException;
+import org.locationtech.jts.geom.Geometry;
+
+/**
+ * Processor transforming {@link SimpleFeature} GeoTools object
+ * into {@link JTSGeometryModel}.
+ * It also copies feature's properties inside model's metadata.
+ * <p>
+ * This processor pairs well with {@link com.ignfab.minalac.generator.inputs.WFS1_1_GML3_1_DataProvider}.
+ */
+public class GeoToolsVectorProcessor implements Processor<SimpleFeature, JTSGeometryModel> {
+    private final CoordsConverter converter;
+
+    /**
+     * Creates a new processor using the given converter to for the {@link JTSGeometryModel}.
+     * @param converter the converter to pass to the geometry model
+     */
+    public GeoToolsVectorProcessor(CoordsConverter converter) {
+        this.converter = converter;
+    }
+
+    @Override
+    public Class<SimpleFeature> acceptedType() {
+        return SimpleFeature.class;
+    }
+
+    @Override
+    public Class<JTSGeometryModel> modelType() {
+        return JTSGeometryModel.class;
+    }
+
+    @Override
+    public JTSGeometryModel process(SimpleFeature feature) throws IgnorableException {
+        try {
+            JTSGeometryModel model = new JTSGeometryModel((Geometry) feature.getDefaultGeometry(), converter);
+            for (Property property : feature.getProperties())
+                model.setMetadata(property.getName().getLocalPart(), property.getValue());
+            return model;
+        } catch (TransformException e) {
+            throw new IgnorableException("Unable to create model: Failed to transform JTS geometry", e);
+        }
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/processors/Processor.java
+++ b/src/main/java/com/ignfab/minalac/generator/processors/Processor.java
@@ -1,0 +1,47 @@
+package com.ignfab.minalac.generator.processors;
+
+import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
+import com.ignfab.minalac.generator.exceptions.IgnorableException;
+import com.ignfab.minalac.generator.models.Model;
+
+/**
+ * A processor is responsible for transforming elements coming from
+ * a {@link com.ignfab.minalac.generator.inputs.Provider provider}
+ * into a model.
+ * <p>
+ * Its main method is {@link #process(Object)}, which take one
+ * element and return the corresponding model.
+ * <p>
+ * The type of processable elements and models returned are defined
+ * by the generic types {@code T} and {@code M} (compile-time check)
+ * and must also be returned by the {@link #acceptedType()} and
+ * {@link #modelType()} methods to allow runtime check.
+ *
+ * @param <T> The type of processable elements
+ * @param <M> The type of created models
+ */
+public interface Processor<T, M extends Model> {
+    /**
+     * Returns the type of processable elements.
+     *
+     * @return the type of processable elements
+     */
+    Class<T> acceptedType();
+
+    /**
+     * Returns the type of created models.
+     *
+     * @return the type of created models
+     */
+    Class<M> modelType();
+
+    /**
+     * Processes an element and creates a corresponding model.
+     *
+     * @param object The element to process
+     * @return The created model
+     * @throws GenerationFailedException If a fatal error occurs while processing data
+     * @throws IgnorableException If an error occurs but the element may be ignored
+     */
+    M process(T object) throws GenerationFailedException, IgnorableException;
+}

--- a/src/main/java/com/ignfab/minalac/generator/processors/post/MetadataCopyPostProcessor.java
+++ b/src/main/java/com/ignfab/minalac/generator/processors/post/MetadataCopyPostProcessor.java
@@ -1,0 +1,53 @@
+package com.ignfab.minalac.generator.processors.post;
+
+import com.ignfab.minalac.generator.models.Model;
+
+/**
+ * Post-processor copying a metadata into another, effectively
+ * adding a new one with a new name and the same value.
+ * This operation can be seen as renaming a metadata, with
+ * the side effect of leaving the original one in place.
+ * <p>
+ * The model same model object is returned after post-processing.
+ */
+public class MetadataCopyPostProcessor implements PostProcessor<Model, Model> {
+    private final String from;
+    private final String to;
+    private final boolean abortIfFromIsAbsent;
+    private final boolean doNotOverwriteExistingTo;
+
+    /**
+     * Creates a new post-processor copying {@code from} into {@code to}.
+     * @param from the original name of the metadata to copy
+     * @param to the destination name to store the copied metadata
+     * @param abortIfFromIsAbsent whether to abort if metadata is absent
+     * @param doNotOverwriteExistingTo whether to abort if copy would overwrite existing metadata
+     */
+    public MetadataCopyPostProcessor(String from, String to, boolean abortIfFromIsAbsent, boolean doNotOverwriteExistingTo) {
+        this.from = from;
+        this.to = to;
+        this.abortIfFromIsAbsent = abortIfFromIsAbsent;
+        this.doNotOverwriteExistingTo = doNotOverwriteExistingTo;
+    }
+
+    @Override
+    public Class<? super Model> acceptedModelType() {
+        return Model.class;
+    }
+
+    @Override
+    public Class<? extends Model> processedModelType(Class<? extends Model> inputModelType) {
+        return inputModelType;
+    }
+
+    @Override
+    public Model process(Model model) {
+        if (doNotOverwriteExistingTo && model.hasMetadata(to))
+            return model;
+        if (model.hasMetadata(from))
+            model.setMetadata(to, model.getMetadata(from));
+        else if (!abortIfFromIsAbsent)
+            model.setMetadata(to, null);
+        return model;
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/processors/post/MetadataParsePostProcessor.java
+++ b/src/main/java/com/ignfab/minalac/generator/processors/post/MetadataParsePostProcessor.java
@@ -1,0 +1,106 @@
+package com.ignfab.minalac.generator.processors.post;
+
+import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
+import com.ignfab.minalac.generator.exceptions.IgnorableException;
+import com.ignfab.minalac.generator.models.Model;
+
+import java.util.function.Function;
+
+/**
+ * Post-processor parsing a metadata value in-place.
+ * @param <T> type of parsed value
+ */
+public class MetadataParsePostProcessor<T> implements PostProcessor<Model, Model> {
+    private final String name;
+    private final Class<T> type;
+    private final Function<Object, ? extends T> parser;
+    private final ParsingFailurePolicy failurePolicy;
+    private final boolean failWhenMissingMetadata;
+    private final boolean failWhenParserReturnNull;
+
+    /**
+     * Creates a new post-processor parsing {@code name} as a {@code type}.
+     * @param name the name of the metadata to parse
+     * @param type the type of parsed value
+     * @param parser the parsing function to use
+     * @param failurePolicy what to do in case of failure (e.g. exception in {@code parser})
+     * @param failWhenMissingMetadata whether the absence of metadata is a failure
+     * @param failWhenParserReturnNull whether {@code null} return value from {@code parser} is a failure
+     */
+    public MetadataParsePostProcessor(
+        String name,
+        Class<T> type,
+        Function<Object, ? extends T> parser,
+        ParsingFailurePolicy failurePolicy,
+        boolean failWhenMissingMetadata,
+        boolean failWhenParserReturnNull
+    ) {
+        this.name = name;
+        this.type = type;
+        this.parser = parser;
+        this.failurePolicy = failurePolicy;
+        this.failWhenMissingMetadata = failWhenMissingMetadata;
+        this.failWhenParserReturnNull = failWhenParserReturnNull;
+    }
+
+    @Override
+    public Class<? super Model> acceptedModelType() {
+        return Model.class;
+    }
+
+    @Override
+    public Class<? extends Model> processedModelType(Class<? extends Model> inputModelType) {
+        return inputModelType;
+    }
+
+    @Override
+    public Model process(Model model) throws GenerationFailedException, IgnorableException {
+        if (model.hasMetadata(name)) {
+            Object value = model.getMetadata(name);
+            if (type.isAssignableFrom(value.getClass()))
+                return model;
+            try {
+                T parsed = parser.apply(value);
+                if (parsed == null && failWhenParserReturnNull)
+                    throw new Exception("Parsing function returned null");
+                model.setMetadata(name, parsed);
+            } catch (Throwable e) {
+                switch (failurePolicy) {
+                    case IGNORE -> {}
+                    case REMOVE_METADATA -> model.setMetadata(name, null);
+                    case SKIP_MODEL -> throw new IgnorableException("Failed to parse metadata: " + name, e);
+                    case ERROR -> throw new GenerationFailedException("Failed to parse metadata: " + name, e);
+                }
+            }
+        } else if (failWhenMissingMetadata) {
+            switch (failurePolicy) {
+                case IGNORE, REMOVE_METADATA -> {}
+                case SKIP_MODEL -> throw new IgnorableException("Missing metadata: " + name);
+                case ERROR -> throw new GenerationFailedException("Missing metadata: " + name);
+            }
+        }
+        return model;
+    }
+
+    /**
+     * Policies about how to handle parsing failure.
+     */
+    public enum ParsingFailurePolicy {
+        /**
+         * Ignores the failure, leaving everything untouched.
+         */
+        IGNORE,
+        /**
+         * Removes the metadata that caused the failure.
+         */
+        REMOVE_METADATA,
+        /**
+         * Throws an {@link IgnorableException} to skip the model.
+         */
+        SKIP_MODEL,
+        /**
+         * Throws an {@link GenerationFailedException} causing a fatal error.
+         */
+        ERROR
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/processors/post/PostProcessor.java
+++ b/src/main/java/com/ignfab/minalac/generator/processors/post/PostProcessor.java
@@ -1,0 +1,48 @@
+package com.ignfab.minalac.generator.processors.post;
+
+import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
+import com.ignfab.minalac.generator.exceptions.IgnorableException;
+import com.ignfab.minalac.generator.models.Model;
+
+/**
+ * A post-processor is responsible for altering models
+ * so they can comply with renderers' requirements.
+ * <p>
+ * Its main method is {@link #process(Model)}, which take a
+ * model and return the altered model.
+ * <p>
+ * The type of processable models and models returned are defined
+ * by the generic types {@code M1} and {@code M2} (compile-time check)
+ * and must also be returned by the {@link #acceptedModelType()} and
+ * {@link #processedModelType(Class)} methods to allow runtime check.
+ *
+ * @param <M1> The type of processable models
+ * @param <M2> The type of altered models
+ */
+public interface PostProcessor<M1 extends Model, M2 extends Model> {
+    /**
+     * Returns the type of processable models.
+     *
+     * @return the type of processable models
+     */
+    Class<? super M1> acceptedModelType();
+
+    /**
+     * Returns the type of altered models.
+     * It may vary depending on the model type received as an input.
+     *
+     * @param inputModelType the input model type
+     * @return the type of altered models
+     */
+    Class<? extends M2> processedModelType(Class<? extends M1> inputModelType);
+
+    /**
+     * Post-processes a model and returns an altered model.
+     *
+     * @param model The model to post-process
+     * @return The altered model (which may or may not be the input model)
+     * @throws GenerationFailedException If a fatal error occurs while post-processing data
+     * @throws IgnorableException If an error occurs but the model may be ignored
+     */
+    M2 process(M1 model) throws GenerationFailedException, IgnorableException;
+}

--- a/src/test/java/com/ignfab/minalac/generator/processors/GeoToolsVectorProcessorTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/processors/GeoToolsVectorProcessorTest.java
@@ -1,0 +1,54 @@
+package com.ignfab.minalac.generator.processors;
+
+import com.ignfab.minalac.generator.generation.CoordsConverter;
+import com.ignfab.minalac.generator.models.JTSGeometryModel;
+import com.ignfab.minalac.generator.utils.iterator.Iterables;
+import com.ignfab.minalac.generator.utils.world2d.Positioned2d;
+import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
+import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
+import org.geotools.api.feature.simple.SimpleFeature;
+import org.geotools.api.feature.simple.SimpleFeatureType;
+import org.geotools.data.DataUtilities;
+import org.geotools.feature.SchemaException;
+import org.geotools.referencing.operation.transform.IdentityTransform;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.util.AffineTransformation;
+
+import java.util.List;
+
+import static com.ignfab.minalac.generator.utils.iterator.IteratorTester.assertBrowsesAllOnce;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class GeoToolsVectorProcessorTest {
+    private static final CoordsConverter IDENTITY_CONVERTER = new CoordsConverter(IdentityTransform.create(2), new AffineTransformation());
+
+    @Test
+    public void test() throws SchemaException {
+        GeoToolsVectorProcessor processor = new GeoToolsVectorProcessor(IDENTITY_CONVERTER);
+
+        // Validate capabilities of processor
+        assertTrue(processor.acceptedType().isAssignableFrom(SimpleFeature.class), "processor accepts SimpleFeature");
+        assertTrue(JTSGeometryModel.class.isAssignableFrom(processor.modelType()), "processor produces JTSGeometryModel");
+
+        // Construct dummy feature
+        SimpleFeatureType featureType = DataUtilities.createType("FLAG", "id:Integer,name:String,*geom:Geometry:4326");
+        SimpleFeature feature = DataUtilities.createFeature(featureType, "1|Dummy feature|POINT (1 2)");
+
+        // Validate processing
+        JTSGeometryModel model = assertDoesNotThrow(() -> processor.process(feature));
+
+        // Validate metadata
+        assertEquals(1, (int) model.getMetadata("id"));
+        assertEquals("Dummy feature", model.getMetadata("name"));
+        assertTrue(model.hasMetadata("geom"));
+
+        // Validate geometry
+        assertBrowsesAllOnce(
+            List.of(new WorldCoords2d(1, 2)),
+            Iterables.remap(
+                model.voxelize2d(new WorldBBox2d(0, 0, 5, 5)),
+                Positioned2d::coords
+            )
+        );
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/processors/post/MetadataCopyPostProcessorTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/processors/post/MetadataCopyPostProcessorTest.java
@@ -1,0 +1,70 @@
+package com.ignfab.minalac.generator.processors.post;
+
+import com.ignfab.minalac.generator.models.Model;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MetadataCopyPostProcessorTest {
+    private Model model;
+
+    @BeforeEach
+    public void setUp() {
+        model = new TestingModel(Map.of(
+            "a", 1,
+            "b", 2,
+            "c", 3
+        ));
+    }
+
+    @Test
+    public void testCapabilities() {
+        MetadataCopyPostProcessor postProcessor = new MetadataCopyPostProcessor("a", "d", false, false);
+        assertTrue(postProcessor.acceptedModelType().isAssignableFrom(TestingModel.class), "post-processor accepts any model type");
+        assertTrue(TestingModel.class.isAssignableFrom(postProcessor.processedModelType(TestingModel.class)), "post-processor produces same model type");
+    }
+
+    private TestingModel getProcessed(MetadataCopyPostProcessor postProcessor) {
+        Model processedModel = assertDoesNotThrow(() -> postProcessor.process(model));
+        return assertInstanceOf(TestingModel.class, processedModel);
+    }
+
+    @Test
+    public void testSimpleCopy() {
+        TestingModel processed = getProcessed(new MetadataCopyPostProcessor("a", "d", false, false));
+        processed.assertMetadata("a", 1, "Original metadata untouched");
+        processed.assertMetadata("b", 2, "Unrelated metadata untouched");
+        processed.assertMetadata("d", 1, "Destination metadata copied");
+    }
+
+    @Test
+    public void testAbsentCopyAllowed() {
+        TestingModel processed = getProcessed(new MetadataCopyPostProcessor("d", "c", false, false));
+        processed.assertMetadataAbsent("d", "Original metadata still absent");
+        processed.assertMetadataAbsent("c", "Destination metadata cleared");
+    }
+
+    @Test
+    public void testAbsentCopyForbidden() {
+        TestingModel processed = getProcessed(new MetadataCopyPostProcessor("d", "c", true, false));
+        processed.assertMetadataAbsent("d", "Original metadata still absent");
+        processed.assertMetadata("c", 3, "Destination metadata NOT cleared");
+    }
+
+    @Test
+    public void testOverwriteCopyAllowed() {
+        TestingModel processed = getProcessed(new MetadataCopyPostProcessor("a", "c", false, false));
+        processed.assertMetadata("a", 1, "Original metadata untouched");
+        processed.assertMetadata("c", 1, "Destination metadata overwritten");
+    }
+
+    @Test
+    public void testOverwriteCopyForbidden() {
+        TestingModel processed = getProcessed(new MetadataCopyPostProcessor("a", "c", false, true));
+        processed.assertMetadata("a", 1, "Original metadata untouched");
+        processed.assertMetadata("c", 3, "Destination metadata NOT overwritten");
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/processors/post/MetadataParsePostProcessorTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/processors/post/MetadataParsePostProcessorTest.java
@@ -1,0 +1,181 @@
+package com.ignfab.minalac.generator.processors.post;
+
+import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
+import com.ignfab.minalac.generator.exceptions.IgnorableException;
+import com.ignfab.minalac.generator.models.Model;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MetadataParsePostProcessorTest {
+    private Model model;
+
+    @BeforeEach
+    public void setUp() {
+        model = new TestingModel(Map.of(
+            "string", "value",
+            "int", 7
+        ));
+    }
+
+    @Test
+    public void testCapabilities() {
+        MetadataParsePostProcessor<?> postProcessor = new MetadataParsePostProcessor<>(
+            "name",
+            Object.class,
+            Function.identity(),
+            MetadataParsePostProcessor.ParsingFailurePolicy.IGNORE,
+            false,
+            false
+        );
+        assertTrue(postProcessor.acceptedModelType().isAssignableFrom(TestingModel.class), "post-processor accepts any model type");
+        assertTrue(TestingModel.class.isAssignableFrom(postProcessor.processedModelType(TestingModel.class)), "post-processor produces same model type");
+    }
+
+    private TestingModel getProcessed(MetadataParsePostProcessor<?> postProcessor) {
+        Model processedModel = assertDoesNotThrow(() -> postProcessor.process(model));
+        return assertInstanceOf(TestingModel.class, processedModel);
+    }
+
+    @Test
+    public void testSimpleParse() {
+        TestingModel processed = getProcessed(new MetadataParsePostProcessor<>(
+            "int",
+            String.class,
+            Objects::toString,
+            // Failure policy is irrelevant for this test as there is no failure
+            MetadataParsePostProcessor.ParsingFailurePolicy.ERROR,
+            false,
+            false
+        ));
+        processed.assertMetadata("int", "7");
+        processed.assertMetadata("string", "value", "Unrelated metadata untouched");
+    }
+
+    @Test
+    public void testParsingError() {
+        assertThrows(GenerationFailedException.class, () -> new MetadataParsePostProcessor<>(
+            "int",
+            String.class,
+            obj -> {
+                throw new RuntimeException();
+            },
+            MetadataParsePostProcessor.ParsingFailurePolicy.ERROR,
+            false,
+            false
+        ).process(model));
+    }
+
+    @Test
+    public void testMissingAllowed() {
+        TestingModel processed = getProcessed(new MetadataParsePostProcessor<>(
+            "missing",
+            String.class,
+            Objects::toString,
+            MetadataParsePostProcessor.ParsingFailurePolicy.ERROR,
+            false,
+            false
+        ));
+        processed.assertMetadataAbsent("missing", "Metadata still absent");
+    }
+
+    @Test
+    public void testMissingForbidden() {
+        assertThrows(GenerationFailedException.class, () -> new MetadataParsePostProcessor<>(
+            "missing",
+            String.class,
+            Objects::toString,
+            MetadataParsePostProcessor.ParsingFailurePolicy.ERROR,
+            true,
+            false
+        ).process(model));
+    }
+
+    @Test
+    public void testNullAllowed() {
+        TestingModel processed = getProcessed(new MetadataParsePostProcessor<>(
+            "int",
+            String.class,
+            obj -> null,
+            MetadataParsePostProcessor.ParsingFailurePolicy.ERROR,
+            false,
+            false
+        ));
+        processed.assertMetadataAbsent("int", "Metadata removed");
+    }
+
+    @Test
+    public void testNullForbidden() {
+        assertThrows(GenerationFailedException.class, () -> new MetadataParsePostProcessor<>(
+            "int",
+            String.class,
+            obj -> null,
+            MetadataParsePostProcessor.ParsingFailurePolicy.ERROR,
+            false,
+            true
+        ).process(model));
+    }
+
+    @Test
+    public void testFailurePolicyIgnore() {
+        TestingModel processed = getProcessed(new MetadataParsePostProcessor<>(
+            "int",
+            String.class,
+            obj -> {
+                throw new RuntimeException();
+            },
+            MetadataParsePostProcessor.ParsingFailurePolicy.IGNORE,
+            false,
+            false
+        ));
+        processed.assertMetadata("int", 7, "Original value kept");
+    }
+
+    @Test
+    public void testFailurePolicyRemove() {
+        TestingModel processed = getProcessed(new MetadataParsePostProcessor<>(
+            "int",
+            String.class,
+            obj -> {
+                throw new RuntimeException();
+            },
+            MetadataParsePostProcessor.ParsingFailurePolicy.REMOVE_METADATA,
+            false,
+            false
+        ));
+        processed.assertMetadataAbsent("int", "Original value cleared");
+    }
+
+    @Test
+    public void testFailurePolicySkip() {
+        assertThrows(IgnorableException.class, () -> new MetadataParsePostProcessor<>(
+            "int",
+            String.class,
+            obj -> {
+                throw new RuntimeException();
+            },
+            MetadataParsePostProcessor.ParsingFailurePolicy.SKIP_MODEL,
+            false,
+            false
+        ).process(model));
+    }
+
+    @Test
+    public void testFailurePolicyError() {
+        assertThrows(GenerationFailedException.class, () -> new MetadataParsePostProcessor<>(
+            "int",
+            String.class,
+            obj -> {
+                throw new RuntimeException();
+            },
+            MetadataParsePostProcessor.ParsingFailurePolicy.ERROR,
+            false,
+            false
+        ).process(model));
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/processors/post/TestingModel.java
+++ b/src/test/java/com/ignfab/minalac/generator/processors/post/TestingModel.java
@@ -1,0 +1,35 @@
+package com.ignfab.minalac.generator.processors.post;
+
+import com.ignfab.minalac.generator.models.Model;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestingModel extends Model {
+    public TestingModel() {}
+
+    public TestingModel(Map<String, Object> metadata) {
+        metadata.forEach(this::setMetadata);
+    }
+
+    private static String prefix(String message) {
+        return message == null ? "" : message + " ===> ";
+    }
+
+    public void assertMetadata(String name, Object value) {
+        assertMetadata(name, value, null);
+    }
+
+    public void assertMetadata(String name, Object value, String message) {
+        assertEquals(getMetadata(name), value, prefix(message) + "Metadata mismatch with name: " + name);
+    }
+
+    public void assertMetadataAbsent(String name) {
+        assertMetadataAbsent(name, null);
+    }
+
+    public void assertMetadataAbsent(String name, String message) {
+        assertFalse(hasMetadata(name), prefix(message) + "Unexpected metadata with name: " + name);
+    }
+}

--- a/suppressions.xml
+++ b/suppressions.xml
@@ -1,11 +1,18 @@
 <?xml version="1.0"?>
 
 <!DOCTYPE suppressions PUBLIC
-    "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
-    "https://checkstyle.org/dtds/suppressions_1_2.dtd">
+    "-//Checkstyle//DTD SuppressionXpathFilter Experimental Configuration 1.2//EN"
+    "https://checkstyle.org/dtds/suppressions_1_2_xpath_experimental.dtd">
 
 <suppressions>
     <suppress checks="MissingJavadocMethod" files=".*[\\/]src[\\/]test[\\/]"/>
     <suppress checks="MissingJavadocType" files=".*[\\/]src[\\/]test[\\/]"/>
+
+    <!--
+    Disable WhitespaceAround check for empty block inside switch expression
+    See https://github.com/checkstyle/checkstyle/issues/9540 for more info
+    -->
+    <suppress-xpath checks="WhitespaceAround" query="//LITERAL_SWITCH//SLIST"/>
+    <suppress-xpath checks="WhitespaceAround" query="//LITERAL_SWITCH//RCURLY"/>
 </suppressions>
 


### PR DESCRIPTION
### Type of modification

Types:
- Code
  - Inputs: Provider, (Post)Processor
  - Exceptions

### Changes

Adds data providing/processing system with basic implementation.

#### Feature description

The goal of this system is to separate responsibilities amongst simple classes to achieve the "complex" task of importing data from various data sources.

The structure is the following:
- The `Provider` reads data from the source and returns an iterable of intermediate objects
- The `Processor` transforms each intermediate object into a `Model`
- Each `PostProcessor` alters the model (metadata, geometry, ...) to "standardize" it and make data from different sources uniform

To illustrate how it works, the current data import process have been adapted to fit into this system:
- The `WFS1_1_GML3_1_DataProvider` now implements `Provider` and returns `SimpleFeature`s
- The `SampleImplementation#downloadVectorFeature` method is now split in:
  - `GeoToolsVectorProcessor` which implements `Processor` and transforms `SimpleFeature` into `JTSGeometryModel`
  - `MetadataCopyPostProcessor` which implements `PostProcessor` and copies a metadata into another (effectively changing its name)
  - `MetadataParsePostProcessor` which implements `PostProcessor` and parses a metadata into a given type
  - An anonymous `PostProcessor` which sets a default value to a metadata, and needs to be generalized into something like `MetadataDefaultPostProcessor`

The whole import pipeline is managed by the `SampleImplementation#retrieveDataAndFillModelStore` method, which illustrate how the process works, but will need to be moved into a dedicated class later.

This PR also includes new exceptions:
- `MinalacException`: a fatal error that prevent further execution of the program
- `IgnorableException`: an error that occurred on an element that could be ignored
  - `ModelException`: an `IgnorableException` about a model
- `RetryableException`: an error that occurred during a task that could be retried

Ignorables and retryables exceptions are used as hints about how to handle the exception, but simple exception handling policy can decide to treat them all as fatal errors.

#### Technical changes

Checkstyle is currently missing a configuration option about empty switch cases, and a special suppression had been added to handle this until this issue gets resolved:
https://github.com/checkstyle/checkstyle/issues/9540

Update: The issue may gets resolved soon, with the addition of a new option `allowEmptySwitchCase` in the `WhitespaceAround` check, in version 10.18.2 (next version).

#### Showcase

As often, everything should work the same, as no new data source had been implemented yet.

### Reason

Having very small tasks like this allows to write simple code and achieve the complex goal of importing heterogeneous data sources.

The post-processors can be configured independently for each data source, and the ability to reuse them (because they are generic) avoid large code duplication.

### TODOs

Added: (5)
- `WFS1_1_GML3_1_DataProvider`: The provider currently uses an hard-coded call to `URL#openStream`, which limits our ability to write tests and other systems (such as snapshots). We should replace this by a dedicated object, i.e. "HTTP Requester", given in constructor.
- `SampleImplementation`: (4)
  - Two metadata post-processors have been created (copy and parse) to illustrate how it works. Another one (default) should be created by extracting and generalizing the inline anonymous post-processor. This is an opportunity for a simple task to discover the system.
  - Because the metadata resulting from the post-processors is currently unused (it will be in an upcoming PR), an extra anonymous post-processor have been added to fail if the value is incorrect. Other than revealing potential mistake in current pipeline, it is completely useless and needs to be removed once #24 is merged.
  - Currently, any `IgnorableException` occurring in the process is silently ignored. This behavior should be made customizable using an exception handling policy defining the action to do on such error (log, ignore, fail, ...).
  - Similarly, `RetryableException` are not handled properly, as no retry mechanism had been implemented yet. They are treated like `MinalacException`, as fatal errors.

### Self-checks

- [x] The code has unit tests associated
- [x] The code has Javadoc Comments associated
- [x] Complex / Unexpected code is explained / justified with a small comment
- [x] Relevant documentation inside the `/docs` folder has been updated
- ~~All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)~~
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [x] The texts have been proofread (documentation, error messages, logs, comments...)
