### PR TITLE
Implement rotation

### DIFF
--- a/docs/usage/GenerationParameters.md
+++ b/docs/usage/GenerationParameters.md
@@ -14,6 +14,7 @@ area:
     longitude: 2.425
   extendX: 1000
   extendY: 1000
+  rotation: 45
 verticalScale: 1.0
 horizontalScale: 1.0
 crs: EPSG:2154
@@ -27,7 +28,8 @@ Available fields:
  - `area`: Area to be rendered
    - `center`: `longitude` and `latitude` of the center point
    - `extendsX` and `extendsY`: Area extends in both horizontal directions (in voxels)
- - `verticalScale`: Vertical size of voxels (in map units, usually meters)
- - `horizontalScale`: Horizontal size of voxels (in map units, usually meters)
+   - `rotation` : Rotation angle around center (in degrees, optional, default 0)
+ - `verticalScale`: Vertical size of voxels (in map units, usually meters, optional, default 1.0)
+ - `horizontalScale`: Horizontal size of voxels (in map units, usually meters, optional, default 1.0)
  - `crs`: Coordinate Reference System to be used for projecting geographical data into voxel world
  - `format`: Output format (`minetest` or `minecraft`)

--- a/docs/usage/Run.md
+++ b/docs/usage/Run.md
@@ -8,7 +8,7 @@
 Run and compile from repository root:
 
 ```shell
-mvn -DskipTests=true clean package && java -jar target/Generator.jar -p examples/default.yaml $HOME/.minetest/worlds/minalac
+mvn -Dmaven.test.skip=true clean package && java -jar target/Generator.jar -p examples/default.yaml $HOME/.minetest/worlds/minalac
 ```
 
 Run jar only:
@@ -37,7 +37,7 @@ Output path and generation parameters has to be provided.
 
 If you have cloned the project repository, you can [build the JAR using Maven](../tools/Maven.md#create-an-executable-jar) and run it:
 ```shell
-mvn -DskipTests=true clean package && java -jar target/Generator.jar -p examples/default.yaml $HOME/.minetest/worlds/minalac
+mvn -Dmaven.test.skip=true clean package && java -jar target/Generator.jar -p examples/default.yaml $HOME/.minetest/worlds/minalac
 ```
 
 ## Download workflow artifact

--- a/src/main/java/com/ignfab/minalac/generator/generation/Generation.java
+++ b/src/main/java/com/ignfab/minalac/generator/generation/Generation.java
@@ -49,7 +49,9 @@ public class Generation {
      * @param extendY Generated world size (in voxels) along y-coordinates
      * @param horizontalScale Horizontal size of voxel in CRS units
      * @param verticalScale Vertical size of voxel in CRS units
+     * @param angle Rotation angle around center in radians
      */
+    @SuppressWarnings("checkstyle:ParameterNumber")
     public Generation(
         CoordinateReferenceSystem crs,
         double centerX,
@@ -57,11 +59,11 @@ public class Generation {
         int extendX,
         int extendY,
         double horizontalScale,
-        double verticalScale) {
+        double verticalScale,
+        double angle) {
 
         // For now:
         // - Center is in target CRS (should be lon/lat).
-        // - Rotation is not yet implemented (should be).
 
         this.crs = crs;
         this.verticalScale = verticalScale;
@@ -72,13 +74,13 @@ public class Generation {
         // CRS to Voxel transformation (basically, translates, rotates and scale)
         crsToVoxel = new AffineTransformation();
         crsToVoxel.translate(-centerX, -centerY);
-        // crsToVoxel.rotate(rotate * pi / 180.0, 0.0, 0.0);
         crsToVoxel.scale(1.0 / horizontalScale, 1.0 / horizontalScale);
+        crsToVoxel.rotate(-angle);
 
         // Voxel to CRS transformation (reverse of crsToVoxel transformation)
         voxelToCrs = new AffineTransformation();
+        voxelToCrs.rotate(angle);
         voxelToCrs.scale(horizontalScale, horizontalScale);
-        // VoxelToCrs.rotate(- rotate * pi / 180.0, 0.0, 0.0);
         voxelToCrs.translate(centerX, centerY);
     }
 

--- a/src/main/java/com/ignfab/minalac/generator/parsing/ParamsParser.java
+++ b/src/main/java/com/ignfab/minalac/generator/parsing/ParamsParser.java
@@ -93,7 +93,8 @@ public class ParamsParser {
             rawParams.area.extendX,
             rawParams.area.extendY,
             rawParams.horizontalScale,
-            rawParams.verticalScale
+            rawParams.verticalScale,
+            Math.toRadians(rawParams.area.rotation)
         );
 
         if (rawParams.heightMaps != null)

--- a/src/main/java/com/ignfab/minalac/generator/parsing/RawParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parsing/RawParams.java
@@ -127,6 +127,13 @@ public class RawParams {
         public int extendY;
 
         /**
+         * Rotation around center in degrees.
+         * Default 0.
+         */
+        @JsonSetter(nulls = Nulls.SKIP)
+        public int rotation = 0;
+
+        /**
          * Constructor used to ensure that the required fields are present during deserialization.
          *
          * @param center  the center of the area.

--- a/src/test/java/com/ignfab/minalac/generator/generation/TestGeneration.java
+++ b/src/test/java/com/ignfab/minalac/generator/generation/TestGeneration.java
@@ -33,7 +33,7 @@ public class TestGeneration {
 
     @BeforeEach
     public void init() {
-        generation = new Generation(crs2154, 601000.0, 6341000.0, 501, 501, 2.0, 3.0);
+        generation = new Generation(crs2154, 601000.0, 6341000.0, 501, 501, 2.0, 3.0, 0.0);
     }
 
     @AfterEach
@@ -43,7 +43,7 @@ public class TestGeneration {
 
     @Test
     public void testGeneration() throws FactoryException, TransformException {
-        Generation generation = new Generation(crs2154, 601000.0, 6341000.0, 501, 501, 2.0, 3.0);
+        Generation generation = new Generation(crs2154, 601000.0, 6341000.0, 501, 501, 2.0, 3.0, 0.0);
 
         WorldBBox2d box = generation.getWorldBBox2d();
         assertEquals(-250, box.getMinX());


### PR DESCRIPTION
### Type of modification

Types:
- Code
  - General
- Documentation
  - Markdown Files

#### Feature description

Allows Generator to perform azimuth rotation.
A `rotation` parameter is added to `area` section.

#### Technical changes

This is quite straightforward. `rotation` parameter is converted from degrees to radians and given to `Generation` constructor.
This constructor adds a rotation around center to both forward and reverse transformation matrix. The rest works out of the box.

#### Showcase

Use default example once, notice the trench orientation. Run another generation with `rotation: 300` and compare the result:
```yaml
heightMaps:
  - name: ground
    default: 0
verticalScale: 1.0
horizontalScale: 1.0
area:
  center:
    latitude: 48.845
    longitude: 2.425
  extendX: 1000
  extendY: 1000
  rotation: 300
crs: EPSG:2154
format: minetest

```
Not rotated:
![screenshot_20240826_172759](https://github.com/user-attachments/assets/ea80ce1e-27c4-47b1-b53d-17354bdfbaf5)

Rotated:
![screenshot_20240826_173032](https://github.com/user-attachments/assets/e577e479-e46e-4385-89c5-bee2f9bba630)

Notice the Yaw on top left indications.

### Reason

This was an existing feature in first version.

### TODO
Add some tests

### Self-checks

<!--
Check everything you did about your work in this PR.
The goal here is to save some precious time by self-checking common issues.

In case something is irrelevant to the subject, please remove the [ ] checkbox and ~~strike through~~ the text.
Example:
- [x] This task is done
- ~~This task does not apply to the work done in this PR~~
- [ ] This task still needs to be done
-->

- ~~The code has unit tests associated~~
- [x] The code has Javadoc Comments associated
- ~~Complex / Unexpected code is explained / justified with a small comment~~
- [x] Relevant documentation inside the `/docs` folder has been updated
- [x] All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- ~~The texts have been proofread (documentation, error messages, logs, comments...)~~
