### PR TITLE
Proposition renommage/split MultiIterator

### DIFF
--- a/src/main/java/com/ignfab/minalac/generator/utils/iterator/UnionIterator.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/iterator/UnionIterator.java
@@ -1,0 +1,45 @@
+package com.ignfab.minalac.generator.utils.iterator;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * Iterator concatenating different iterators.
+ *
+ * @param <T> Type of iterable items
+ */
+public class UnionIterator<T> implements Iterator<T> {
+    private final Iterator<? extends Iterator<? extends T>> iterators;
+    private Iterator<? extends T> current;
+
+    /**
+     * Creates an UnionIterator from varable number of iterators.
+     *
+     * @param iterators Iterators to be concatenated
+     */
+    @SafeVarargs
+    public UnionIterator(Iterator<? extends T>... iterators) {
+        this.iterators = Arrays.asList(iterators).iterator();
+        moveOn();
+    }
+
+    private void moveOn() {
+        while ((current == null || !current.hasNext()) && iterators.hasNext())
+            current = iterators.next();
+    }
+
+    @Override
+    public boolean hasNext() {
+        return current != null && current.hasNext();
+    }
+
+    @Override
+    public T next() {
+        if (current == null || !current.hasNext())
+            throw new NoSuchElementException();
+        T element = current.next();
+        moveOn();
+        return element;
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/utils/iterator/UnwrapIterator.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/iterator/UnwrapIterator.java
@@ -1,0 +1,52 @@
+package com.ignfab.minalac.generator.utils.iterator;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * Unwraps an iterable/iterator of Iterable<T> into an Iterator<T>.
+ *
+ * @param <T> Type of iterable items
+ */
+public class UnwrapIterator<T> implements Iterator<T> {
+    private final Iterator<? extends Iterable<? extends T>> iterables;
+    private Iterator<? extends T> current;
+
+    /**
+     * Creates an UnwrapIterator from an iterable over iterables.
+     *
+     * @param iterables iterable to unwrap
+     */
+    public UnwrapIterator(Iterable<? extends Iterable<? extends T>> iterables) {
+        this(iterables.iterator());
+    }
+
+    /**
+     * Creates an UnwrapIterator from an iterator over iterables.
+     *
+     * @param iterables iterator to unwrap
+     */
+    public UnwrapIterator(Iterator<? extends Iterable<? extends T>> iterables) {
+        this.iterables = iterables;
+        moveOn();
+    }
+
+    private void moveOn() {
+        while ((current == null || !current.hasNext()) && iterables.hasNext())
+            current = iterables.next().iterator();
+    }
+
+    @Override
+    public boolean hasNext() {
+        return current != null && current.hasNext();
+    }
+
+    @Override
+    public T next() {
+        if (current == null || !current.hasNext())
+            throw new NoSuchElementException();
+        T element = current.next();
+        moveOn();
+        return element;
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/utils/shape2d/PolyLine2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/shape2d/PolyLine2d.java
@@ -1,6 +1,6 @@
 package com.ignfab.minalac.generator.utils.shape2d;
 
-import com.ignfab.minalac.generator.utils.iterator.MultiIterator;
+import com.ignfab.minalac.generator.utils.iterator.UnwrapIterator;
 import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
 import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
 import com.ignfab.minalac.generator.voxelization.IndexedVoxel2d;
@@ -46,7 +46,7 @@ public record PolyLine2d(List<Line2d> lines) implements Iterable<IndexedVoxel2d>
      */
     @Override
     public Iterator<IndexedVoxel2d> iterator() {
-        return new MultiIterator<>(lines);
+        return new UnwrapIterator<>(lines);
     }
 
     /**

--- a/src/main/java/com/ignfab/minalac/generator/utils/shape2d/Polygon2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/shape2d/Polygon2d.java
@@ -1,9 +1,11 @@
 package com.ignfab.minalac.generator.utils.shape2d;
 
-import com.ignfab.minalac.generator.utils.iterator.MultiIterator;
+import com.ignfab.minalac.generator.utils.iterator.UnionIterator;
+import com.ignfab.minalac.generator.utils.iterator.UnwrapIterator;
 import com.ignfab.minalac.generator.utils.iterator.RemapIterator;
 import com.ignfab.minalac.generator.utils.shape2d.iterator.Polygon2dIterator;
 import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
+import com.ignfab.minalac.generator.voxelization.IndexedVoxel2d;
 import com.ignfab.minalac.generator.voxelization.Voxel2d;
 
 import java.util.ArrayList;
@@ -60,8 +62,10 @@ public class Polygon2d implements Iterable<Voxel2d> {
      *
      * @return the border iterable of this polygon.
      */
-    public Iterable<Line2d> borders() {
-        return () -> MultiIterator.concat(shell.lines(), () -> new MultiIterator<>(new RemapIterator<>(holes, PolyLine2d::lines)));
+    public Iterable<IndexedVoxel2d> borders() {
+        return () -> new UnionIterator<>(
+            shell.iterator(),
+            new UnwrapIterator<>(holes));
     }
 
     /**
@@ -84,6 +88,16 @@ public class Polygon2d implements Iterable<Voxel2d> {
     }
 
     /**
+     * Returns a new iterable over all lines (shell and holes) of this polygon.
+     *
+     * @return iterator over lines
+     */
+    public Iterable<Line2d> lines() {
+        return () -> new UnionIterator<>(
+            new UnwrapIterator<>(new RemapIterator<>(holes, PolyLine2d::lines)),
+            shell.lines().iterator());
+    }
+    /**
      * Lists intersections of this polygon at a given y.
      * Very useful for voxelization purpose.
      * <p>
@@ -98,7 +112,7 @@ public class Polygon2d implements Iterable<Voxel2d> {
             return Collections.emptyList();
 
         List<Line2d.Intersection> intersections = new ArrayList<>();
-        for (Line2d line : borders()) {
+        for (Line2d line : lines()) {
             Line2d.Intersection inter = line.intersection(y);
             if (inter != null)
                 intersections.add(inter);

--- a/src/main/java/com/ignfab/minalac/generator/utils/shape2d/ShapesVoxelizer2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/shape2d/ShapesVoxelizer2d.java
@@ -1,7 +1,8 @@
 package com.ignfab.minalac.generator.utils.shape2d;
 
-import com.ignfab.minalac.generator.utils.iterator.MultiIterator;
 import com.ignfab.minalac.generator.utils.iterator.RemapIterator;
+import com.ignfab.minalac.generator.utils.iterator.UnionIterator;
+import com.ignfab.minalac.generator.utils.iterator.UnwrapIterator;
 import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
 import com.ignfab.minalac.generator.utils.world2d.iterator.BoundedIterator2d;
 import com.ignfab.minalac.generator.voxelization.IndexedVoxel2d;
@@ -64,11 +65,13 @@ public class ShapesVoxelizer2d implements Voxelizer2d {
      */
     @Override
     public Iterator<Voxel2d> iterator() {
-        return new BoundedIterator2d<>(MultiIterator.concat(
-            () -> new MultiIterator<>(points),
-            () -> new MultiIterator<>(lines),
-            () -> new MultiIterator<>(polygons)
-        ), bbox);
+        return new BoundedIterator2d<>(
+            new UnionIterator<Voxel2d>(
+                new UnwrapIterator<>(points),
+                new UnwrapIterator<>(lines),
+                new UnwrapIterator<>(polygons)
+            ),
+        bbox);
     }
 
     /**
@@ -79,11 +82,16 @@ public class ShapesVoxelizer2d implements Voxelizer2d {
      */
     @Override
     public Iterable<IndexedVoxel2d> borders() {
-        return () -> new BoundedIterator2d<>(MultiIterator.concat(
-            () -> new MultiIterator<>(points),
-            () -> new MultiIterator<>(lines),
-            () -> new MultiIterator<>(new MultiIterator<>(new RemapIterator<>(polygons, Polygon2d::borders)))
-        ), bbox);
+        return () -> new BoundedIterator2d<>(
+            new UnionIterator<>(
+                new UnwrapIterator<>(points),
+                new UnwrapIterator<>(lines),
+                new UnwrapIterator<>(
+                    new RemapIterator<>(polygons, Polygon2d::borders)
+                )
+            ),
+            bbox
+        );
     }
 
     /**
@@ -94,6 +102,11 @@ public class ShapesVoxelizer2d implements Voxelizer2d {
      */
     @Override
     public Iterable<Voxel2d> inside() {
-        return () -> new BoundedIterator2d<>(new MultiIterator<>(new RemapIterator<>(polygons, Polygon2d::inside)), bbox);
+        return () -> new BoundedIterator2d<>(
+            new UnwrapIterator<>(
+                new RemapIterator<>(polygons, Polygon2d::inside)
+            ),
+            bbox
+        );
     }
 }


### PR DESCRIPTION
Ce qui me gênait c'est que le MultiIterateur fait deux chose:
- Unifier des iterateurs (avec `concat`)
- Et débaler d'autres itérateurs (`Iterator<Iterable<T>>` -> `Iterator<T>`)

Proposition: séparer les deux fonctionnalités en deux iterateurs : `UnionIterator` pour la première, `UnwrapIterator` pour la seconde.

La modif n'est faite que sur la 2D mais serait à transposer en 3D.

Autre modif à faire qui serait intéressante: inverser l'ordre du BoundedIterator pour avoir la BBox en premier. Ça devrait améliorer la lisibilité.