### PR TITLE
feat(scheduler): Name thread and use names instead of log prefix

### DIFF
--- a/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
+++ b/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
@@ -85,17 +85,17 @@ public final class SampleImplementation {
 
         // Downloads
         scheduler.schedule("heightmaps.ground", () -> {
-            log("heightmaps.ground", "Downloading height map");
+            log("Downloading height map");
             try {
                 fillGroundHeightmap("https://data.geopf.fr/wms-r/wms?LAYERS=RGEALTI-MNT_PYR-ZIP_FXX_LAMB93_WMS&FORMAT=image/x-bil;bits=32&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&STYLES=&CRS=" + crsName + "&" + bboxURL, groundHeightmap, generation.getVerticalScale());
             } catch (MalformedURLException e) {
                 throw new RuntimeException(e);
             }
-            log("heightmaps.ground", "Downloaded height map");
+            log("Downloaded height map");
         });
 
         scheduler.schedule("models.buildings", () -> {
-            log("models.buildings", "Downloading buildings");
+            log("Downloading buildings");
             try {
                 downloadVectorFeatures(
                     new WFS1_1_GML3_1_DataProvider("https://data.geopf.fr/wfs/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=BDTOPO_V3:batiment&STARTINDEX=0&COUNT=1000&SRSNAME=urn:ogc:def:crs:EPSG::2154&" + bboxURL + ",urn:ogc:def:crs:EPSG::2154&outputFormat=text%2Fxml%3B%20subtype%3Dgml%2F3.1.1"),
@@ -106,25 +106,25 @@ public final class SampleImplementation {
             } catch (TransformException | IOException | ParserConfigurationException | SAXException | FactoryException e) {
                 throw new RuntimeException(e);
             }
-            log("models.buildings", "Downloaded buildings");
+            log("Downloaded buildings");
         });
 
         // Rendering
         scheduler.schedule("renderers.ground", () -> {
-            log("renderers.ground", "Placing ground");
+            log("Placing ground");
             placeVoxelFromHeightmap(groundHeightmap, world);
-            log("renderers.ground", "Placed ground");
+            log("Placed ground");
         }, "heightmaps.ground");
 
         scheduler.schedule("renderers.buildings", () -> {
-            log("renderers.buildings", "Placing buildings");
+            log("Placing buildings");
             new VectorRenderer(
                 groundHeightmap,
                 store.getByType("building"),
                 world.getFactory().createVoxelType(SemanticType.COBBLE),
                 world.getFactory().createVoxelType(SemanticType.BRICK)
             ).render();
-            log("renderers.buildings", "Placed buildings");
+            log("Placed buildings");
         }, "heightmaps.ground", "models.buildings");
 
         scheduler.start();
@@ -146,8 +146,8 @@ public final class SampleImplementation {
         System.out.println("Execution time: " + (end - start) / 1000 + "s");
     }
 
-    private static void log(String prefix, String message) {
-        System.out.printf("[%s] (%s) %s%n", Thread.currentThread().getName(), prefix, message);
+    private static void log(String message) {
+        System.out.printf("[%s] %s%n", Thread.currentThread().getName(), message);
     }
 
     private static void downloadVectorFeatures(WFS1_1_GML3_1_DataProvider provider, CoordsConverter converter,

--- a/src/main/java/com/ignfab/minalac/generator/utils/execution/Scheduler.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/execution/Scheduler.java
@@ -70,6 +70,8 @@ public class Scheduler {
         // The .execute() method asks for execution but real execution can be delayed if no thread is currently available
         executor.execute(() -> {
             try {
+                // Name current thread according to task id
+                Thread.currentThread().setName(task.getId());
                 task.setState(ScheduledTaskState.RUNNING);
                 task.run();
                 task.setState(ScheduledTaskState.FINISHED);


### PR DESCRIPTION
### Type of modification

Types:
- Code

### Changes

Name Scheduler threads with running task id.

#### Feature description

Use task id as thread name instead of default.
Get rid of `prefix` argument in `log` function.

### Reason

Having to set a functional prefix to each log call was inconvenient, repetitive and subject to mistakes.

### Self-checks

- ~~The code has unit tests associated~~
- ~~The code has Javadoc Comments associated~~
- ~~Complex / Unexpected code is explained / justified with a small comment~~
- ~~Relevant documentation inside the `/docs` folder has been updated~~
- [x] All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- ~~The texts have been proofread (documentation, error messages, logs, comments...)~~
