### PR TITLE
refactor(bbox): Rename `WorldBBox2d` and `WorldBBox3d` getters

### DIFF
--- a/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
+++ b/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
@@ -193,8 +193,8 @@ public final class SampleImplementation {
     }
 
     private static void fillGroundHeightmap(String partialUrl, Heightmap heightmap, double verticalScale) throws MalformedURLException {
-        int width = heightmap.bbox().getSizeX();
-        int height = heightmap.bbox().getSizeY();
+        int width = heightmap.bbox().sizeX();
+        int height = heightmap.bbox().sizeY();
         URL url = new URL(partialUrl + "&WIDTH=" + width + "&HEIGHT=" + height);
 
         byte[] data;
@@ -212,8 +212,8 @@ public final class SampleImplementation {
 
         float[] mntArray = byteArrayToFloatArray(data);
 
-        int xMin = heightmap.bbox().getMinX();
-        int yMin = heightmap.bbox().getMinY();
+        int xMin = heightmap.bbox().minX();
+        int yMin = heightmap.bbox().minY();
 
         int index = 0;
 

--- a/src/main/java/com/ignfab/minalac/generator/generation/Generation.java
+++ b/src/main/java/com/ignfab/minalac/generator/generation/Generation.java
@@ -93,11 +93,11 @@ public class Generation {
         MathTransform crsTransform = CRS.findMathTransform(this.crs, crs);
 
         Coordinate[] corners = {
-            new Coordinate(worldBBox.getMinX(), worldBBox.getMinY()),
-            new Coordinate(worldBBox.getMaxX(), worldBBox.getMinY()),
-            new Coordinate(worldBBox.getMaxX(), worldBBox.getMaxY()),
-            new Coordinate(worldBBox.getMinX(), worldBBox.getMaxY()),
-            new Coordinate(worldBBox.getMinX(), worldBBox.getMinY())
+            new Coordinate(worldBBox.minX(), worldBBox.minY()),
+            new Coordinate(worldBBox.maxX(), worldBBox.minY()),
+            new Coordinate(worldBBox.maxX(), worldBBox.maxY()),
+            new Coordinate(worldBBox.minX(), worldBBox.maxY()),
+            new Coordinate(worldBBox.minX(), worldBBox.minY())
         };
 
         Geometry geom = voxelToCrs.transform(new GeometryFactory().createLinearRing(corners));

--- a/src/main/java/com/ignfab/minalac/generator/models/BufferedImageChunk.java
+++ b/src/main/java/com/ignfab/minalac/generator/models/BufferedImageChunk.java
@@ -34,7 +34,7 @@ public class BufferedImageChunk implements IterableChunk2d, WritableChunk2d {
         // TYPE_BYTE_GRAY color model is the closest to what we need for now (store a few different values).
         // To get rid of this hack, we should have a look on how to develop a specific
         // color model to store integers (I guess this could be lot of useless work).
-        image = new BufferedImage(bbox.getSize().x(), bbox.getSize().y(), BufferedImage.TYPE_BYTE_GRAY);
+        image = new BufferedImage(bbox.sizeX(), bbox.sizeY(), BufferedImage.TYPE_BYTE_GRAY);
         Arrays.fill(((DataBufferByte) image.getRaster().getDataBuffer()).getData(), (byte) 0);
     }
 
@@ -52,7 +52,7 @@ public class BufferedImageChunk implements IterableChunk2d, WritableChunk2d {
     @Override
     public int get(int x, int y) {
         if (!bbox.contains(x, y)) throw new IndexOutOfBoundsException();
-        return image.getRaster().getSample(x - bbox.getMin().x(), y - bbox.getMin().y(), 0);
+        return image.getRaster().getSample(x - bbox.minX(), y - bbox.minY(), 0);
     }
 
     /**
@@ -69,7 +69,7 @@ public class BufferedImageChunk implements IterableChunk2d, WritableChunk2d {
     @Override
     public void set(int x, int y, int value) {
         if (!bbox.contains(x, y)) throw new IndexOutOfBoundsException();
-        image.getRaster().setSample(x - bbox.getMin().x(), y - bbox.getMin().y(), 0, value);
+        image.getRaster().setSample(x - bbox.minX(), y - bbox.minY(), 0, value);
     }
 
     /**

--- a/src/main/java/com/ignfab/minalac/generator/models/GeometryModel.java
+++ b/src/main/java/com/ignfab/minalac/generator/models/GeometryModel.java
@@ -98,7 +98,7 @@ public class GeometryModel extends Model implements Rasterizable {
         Graphics2D graphics = chunk.createGraphics();
 
         // Draw geometry translated into bounding box relative coordinates (i.e. BufferedImage coordinates)
-        Geometry geom = AffineTransformation.translationInstance(-bbox.getMinX(), -bbox.getMinY()).transform(this.geom);
+        Geometry geom = AffineTransformation.translationInstance(-bbox.minX(), -bbox.minY()).transform(this.geom);
         draw(graphics, geom);
 
         graphics.dispose();

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelWorld.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelWorld.java
@@ -98,10 +98,10 @@ public class MCVoxelWorld extends VoxelWorld {
             {
                 data.putBoolean("allowCommands", true);
                 WorldBBox3d bbox = limits();
-                WorldSize3d size = limits().getSize();
+                WorldSize3d size = limits().size();
                 double minSize = Math.max(size.x(), size.y());
-                data.putDouble("BorderCenterX", (bbox.getMinX() + bbox.getMaxX()) / 2d);
-                data.putDouble("BorderCenterZ", (bbox.getMinY() + bbox.getMaxY()) / 2d); // Y => Z
+                data.putDouble("BorderCenterX", (bbox.minX() + bbox.maxX()) / 2d);
+                data.putDouble("BorderCenterZ", (bbox.minY() + bbox.maxY()) / 2d); // Y => Z
                 data.putDouble("BorderDamagePerBlock", 0.2);
                 data.putDouble("BorderSafeZone", 5);
                 data.putDouble("BorderSize", minSize);
@@ -298,7 +298,7 @@ public class MCVoxelWorld extends VoxelWorld {
                         pos.addDouble(metadata.getSpawn().x() + 0.5);
                         // TODO Replace by a better constraint management mechanism
                         // pos.addDouble(metadata.getSpawn().z());
-                        pos.addDouble(Math.min(Math.max(limits().getMinZ(), metadata.getSpawn().z()), limits().getMaxZ()));
+                        pos.addDouble(Math.min(Math.max(limits().minZ(), metadata.getSpawn().z()), limits().maxZ()));
                         pos.addDouble(metadata.getSpawn().y() + 0.5);
                     }
                     player.put("Pos", pos);
@@ -364,7 +364,7 @@ public class MCVoxelWorld extends VoxelWorld {
                 data.putInt("SpawnX", metadata.getSpawn().x());
                 // TODO Replace by a better constraint management mechanism
                 // data.putInt("SpawnY", metadata.getSpawn().z());
-                data.putInt("SpawnY", Math.min(Math.max(limits().getMinZ(), metadata.getSpawn().z()), limits().getMaxZ()));
+                data.putInt("SpawnY", Math.min(Math.max(limits().minZ(), metadata.getSpawn().z()), limits().maxZ()));
                 data.putInt("SpawnZ", metadata.getSpawn().y());
 
                 data.putBoolean("thundering", false);

--- a/src/main/java/com/ignfab/minalac/generator/parsing/ParamsParser.java
+++ b/src/main/java/com/ignfab/minalac/generator/parsing/ParamsParser.java
@@ -114,10 +114,10 @@ public class ParamsParser {
         world.setLimits(new WorldBBox3d(
             -rawParams.area.extendX / 2,
             -rawParams.area.extendY / 2,
-            maximumLimits.getMinZ(),
+            maximumLimits.minZ(),
             rawParams.area.extendX,
             rawParams.area.extendY,
-            maximumLimits.getSizeZ()
+            maximumLimits.sizeZ()
         ));
         return world;
     }

--- a/src/main/java/com/ignfab/minalac/generator/utils/world2d/WorldBBox2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world2d/WorldBBox2d.java
@@ -73,7 +73,7 @@ public class WorldBBox2d implements Iterable<WorldCoords2d> {
      * @param bbox an existing {@link WorldBBox3d} object
      */
     public WorldBBox2d(WorldBBox3d bbox) {
-        this(bbox.getMin().to2d(), bbox.getSize().to2d());
+        this(bbox.min().to2d(), bbox.size().to2d());
     }
 
     /**
@@ -104,7 +104,7 @@ public class WorldBBox2d implements Iterable<WorldCoords2d> {
      * @return {@code true} if the provided bbox is in this bounding box.
      */
     public boolean contains(WorldBBox2d bbox) {
-        return contains(bbox.getMin()) && contains(bbox.getMax());
+        return contains(bbox.min()) && contains(bbox.max());
     }
 
     /**
@@ -112,7 +112,7 @@ public class WorldBBox2d implements Iterable<WorldCoords2d> {
      *
      * @return the size of the bounding box as a {@code WorldSize2d}.
      */
-    public WorldSize2d getSize() {
+    public WorldSize2d size() {
         return size;
     }
 
@@ -121,7 +121,7 @@ public class WorldBBox2d implements Iterable<WorldCoords2d> {
      *
      * @return the bounding box size along the x-axis.
      */
-    public int getSizeX() {
+    public int sizeX() {
         return size.x();
     }
 
@@ -130,7 +130,7 @@ public class WorldBBox2d implements Iterable<WorldCoords2d> {
      *
      * @return the bounding box size along the y-axis.
      */
-    public int getSizeY() {
+    public int sizeY() {
         return size.y();
     }
 
@@ -139,7 +139,7 @@ public class WorldBBox2d implements Iterable<WorldCoords2d> {
      *
      * @return the {@code WorldCoords2d} of the minimum point.
      */
-    public WorldCoords2d getMin() {
+    public WorldCoords2d min() {
         return min;
     }
 
@@ -148,7 +148,7 @@ public class WorldBBox2d implements Iterable<WorldCoords2d> {
      *
      * @return the x-coordinate of the minimum point.
      */
-    public int getMinX() {
+    public int minX() {
         return min.x();
     }
 
@@ -157,7 +157,7 @@ public class WorldBBox2d implements Iterable<WorldCoords2d> {
      *
      * @return the y-coordinate of the minimum point.
      */
-    public int getMinY() {
+    public int minY() {
         return min.y();
     }
 
@@ -166,7 +166,7 @@ public class WorldBBox2d implements Iterable<WorldCoords2d> {
      *
      * @return the {@code WorldCoords2d} of the maximum point.
      */
-    public WorldCoords2d getMax() {
+    public WorldCoords2d max() {
         return max;
     }
 
@@ -175,7 +175,7 @@ public class WorldBBox2d implements Iterable<WorldCoords2d> {
      *
      * @return the x-coordinate of the maximum point.
      */
-    public int getMaxX() {
+    public int maxX() {
         return max.x();
     }
 
@@ -184,7 +184,7 @@ public class WorldBBox2d implements Iterable<WorldCoords2d> {
      *
      * @return the y-coordinate of the maximum point.
      */
-    public int getMaxY() {
+    public int maxY() {
         return max.y();
     }
 
@@ -235,10 +235,10 @@ public class WorldBBox2d implements Iterable<WorldCoords2d> {
      * @return A new bounding box representing the intersection (may be empty)
      */
     public WorldBBox2d intersection(WorldBBox2d box) {
-        int minX = Math.max(min.x(), box.getMinX());
-        int minY = Math.max(min.y(), box.getMinY());
-        int maxX = Math.min(max.x(), box.getMaxX());
-        int maxY = Math.min(max.y(), box.getMaxY());
+        int minX = Math.max(min.x(), box.minX());
+        int minY = Math.max(min.y(), box.minY());
+        int maxX = Math.min(max.x(), box.maxX());
+        int maxY = Math.min(max.y(), box.maxY());
         return new WorldBBox2d(minX, minY, Math.max(0, maxX - minX + 1), Math.max(0, maxY - minY + 1));
     }
 

--- a/src/main/java/com/ignfab/minalac/generator/utils/world2d/chunk/ArrayChunk2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world2d/chunk/ArrayChunk2d.java
@@ -28,7 +28,7 @@ public class ArrayChunk2d implements ReadableChunk2d, WritableChunk2d {
      */
     public ArrayChunk2d(WorldBBox2d bbox, int defaultValue) {
         this.bbox = bbox;
-        values = new int[bbox.getSize().x() * bbox.getSize().y()];
+        values = new int[bbox.sizeX() * bbox.sizeY()];
         if (defaultValue != 0)
             Arrays.fill(values, defaultValue);
     }
@@ -61,7 +61,7 @@ public class ArrayChunk2d implements ReadableChunk2d, WritableChunk2d {
     private int index(int x, int y) {
         if (!bbox.contains(x, y))
             throw new IndexOutOfBoundsException(String.format("%s: Index out of range at (x=%d, y=%d)", getClass().getSimpleName(), x, y));
-        return (x - bbox.getMin().x()) * bbox.getSize().y() + (y - bbox.getMin().y());
+        return (x - bbox.minX()) * bbox.size().y() + (y - bbox.minY());
     }
 
     @Override

--- a/src/main/java/com/ignfab/minalac/generator/utils/world2d/iterator/WorldBBox2dIterator.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world2d/iterator/WorldBBox2dIterator.java
@@ -25,18 +25,18 @@ public class WorldBBox2dIterator implements Iterator<WorldCoords2d> {
         if (bbox.isEmpty()) {
             hasNext = false;
         } else {
-            x = bbox.getMin().x();
-            y = bbox.getMin().y();
+            x = bbox.minX();
+            y = bbox.minY();
             hasNext = true;
         }
     }
 
     private void moveOn() {
         x++;
-        if (x > bbox.getMax().x()) {
-            x = bbox.getMin().x();
+        if (x > bbox.maxX()) {
+            x = bbox.minX();
             y++;
-            if (y > bbox.getMax().y())
+            if (y > bbox.maxY())
                 hasNext = false;
         }
     }

--- a/src/main/java/com/ignfab/minalac/generator/utils/world3d/WorldBBox3d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world3d/WorldBBox3d.java
@@ -81,7 +81,7 @@ public class WorldBBox3d implements Iterable<WorldCoords3d> {
      * @param sizeZ the size along the z-axis
      */
     public WorldBBox3d(WorldBBox2d bbox, int originZ, int sizeZ) {
-        this(bbox.getMin().to3d(originZ), bbox.getSize().to3d(sizeZ));
+        this(bbox.min().to3d(originZ), bbox.size().to3d(sizeZ));
     }
 
     /**
@@ -113,7 +113,7 @@ public class WorldBBox3d implements Iterable<WorldCoords3d> {
      * @return {@code true} if the provided bbox is in this bounding box.
      */
     public boolean contains(WorldBBox3d bbox) {
-        return contains(bbox.getMin()) && contains(bbox.getMax());
+        return contains(bbox.min()) && contains(bbox.max());
     }
 
     /**
@@ -121,7 +121,7 @@ public class WorldBBox3d implements Iterable<WorldCoords3d> {
      *
      * @return the size of the bounding box as a {@link WorldSize3d}.
      */
-    public WorldSize3d getSize() {
+    public WorldSize3d size() {
         return size;
     }
 
@@ -130,7 +130,7 @@ public class WorldBBox3d implements Iterable<WorldCoords3d> {
      *
      * @return the bounding box size along the x-axis.
      */
-    public int getSizeX() {
+    public int sizeX() {
         return size.x();
     }
 
@@ -139,7 +139,7 @@ public class WorldBBox3d implements Iterable<WorldCoords3d> {
      *
      * @return the bounding box size along the y-axis.
      */
-    public int getSizeY() {
+    public int sizeY() {
         return size.y();
     }
 
@@ -148,7 +148,7 @@ public class WorldBBox3d implements Iterable<WorldCoords3d> {
      *
      * @return the bounding box size along the z-axis.
      */
-    public int getSizeZ() {
+    public int sizeZ() {
         return size.z();
     }
 
@@ -157,7 +157,7 @@ public class WorldBBox3d implements Iterable<WorldCoords3d> {
      *
      * @return the {@link WorldCoords3d} of the minimum point.
      */
-    public WorldCoords3d getMin() {
+    public WorldCoords3d min() {
         return min;
     }
 
@@ -166,7 +166,7 @@ public class WorldBBox3d implements Iterable<WorldCoords3d> {
      *
      * @return the x-coordinate of the minimum point.
      */
-    public int getMinX() {
+    public int minX() {
         return min.x();
     }
 
@@ -175,7 +175,7 @@ public class WorldBBox3d implements Iterable<WorldCoords3d> {
      *
      * @return the y-coordinate of the minimum point.
      */
-    public int getMinY() {
+    public int minY() {
         return min.y();
     }
 
@@ -184,7 +184,7 @@ public class WorldBBox3d implements Iterable<WorldCoords3d> {
      *
      * @return the z-coordinate of the minimum point.
      */
-    public int getMinZ() {
+    public int minZ() {
         return min.z();
     }
 
@@ -193,7 +193,7 @@ public class WorldBBox3d implements Iterable<WorldCoords3d> {
      *
      * @return the {@link WorldCoords3d} of the maximum point.
      */
-    public WorldCoords3d getMax() {
+    public WorldCoords3d max() {
         return max;
     }
 
@@ -202,7 +202,7 @@ public class WorldBBox3d implements Iterable<WorldCoords3d> {
      *
      * @return the x-coordinate of the maximum point.
      */
-    public int getMaxX() {
+    public int maxX() {
         return max.x();
     }
 
@@ -211,7 +211,7 @@ public class WorldBBox3d implements Iterable<WorldCoords3d> {
      *
      * @return the y-coordinate of the maximum point.
      */
-    public int getMaxY() {
+    public int maxY() {
         return max.y();
     }
 
@@ -220,7 +220,7 @@ public class WorldBBox3d implements Iterable<WorldCoords3d> {
      *
      * @return the z-coordinate of the maximum point.
      */
-    public int getMaxZ() {
+    public int maxZ() {
         return max.z();
     }
 
@@ -270,12 +270,12 @@ public class WorldBBox3d implements Iterable<WorldCoords3d> {
      * @return A new bounding box representing the intersection (may be empty)
      */
     public WorldBBox3d intersection(WorldBBox3d box) {
-        int minX = Math.max(min.x(), box.getMinX());
-        int minY = Math.max(min.y(), box.getMinY());
-        int minZ = Math.max(min.z(), box.getMinZ());
-        int maxX = Math.min(max.x(), box.getMaxX());
-        int maxY = Math.min(max.y(), box.getMaxY());
-        int maxZ = Math.min(max.z(), box.getMaxZ());
+        int minX = Math.max(min.x(), box.minX());
+        int minY = Math.max(min.y(), box.minY());
+        int minZ = Math.max(min.z(), box.minZ());
+        int maxX = Math.min(max.x(), box.maxX());
+        int maxY = Math.min(max.y(), box.maxY());
+        int maxZ = Math.min(max.z(), box.maxZ());
         return new WorldBBox3d(minX, minY, minZ, Math.max(0, maxX - minX + 1), Math.max(0, maxY - minY + 1), Math.max(0, maxZ - minZ + 1));
     }
 

--- a/src/main/java/com/ignfab/minalac/generator/utils/world3d/iterator/WorldBBox3dIterator.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world3d/iterator/WorldBBox3dIterator.java
@@ -26,22 +26,22 @@ public class WorldBBox3dIterator implements Iterator<WorldCoords3d> {
         if (bbox.isEmpty()) {
             hasNext = false;
         } else {
-            x = bbox.getMin().x();
-            y = bbox.getMin().y();
-            z = bbox.getMin().z();
+            x = bbox.minX();
+            y = bbox.minY();
+            z = bbox.minZ();
             hasNext = true;
         }
     }
 
     private void moveOn() {
         x++;
-        if (x > bbox.getMax().x()) {
-            x = bbox.getMin().x();
+        if (x > bbox.maxX()) {
+            x = bbox.minX();
             y++;
-            if (y > bbox.getMax().y()) {
-                y = bbox.getMin().y();
+            if (y > bbox.maxY()) {
+                y = bbox.minY();
                 z++;
-                if (z > bbox.getMax().z())
+                if (z > bbox.maxZ())
                     hasNext = false;
             }
         }

--- a/src/test/java/com/ignfab/minalac/generator/generation/TestGeneration.java
+++ b/src/test/java/com/ignfab/minalac/generator/generation/TestGeneration.java
@@ -46,10 +46,10 @@ public class TestGeneration {
         Generation generation = new Generation(crs2154, 601000.0, 6341000.0, 501, 501, 2.0, 3.0);
 
         WorldBBox2d box = generation.getWorldBBox2d();
-        assertEquals(-250, box.getMinX());
-        assertEquals(-250, box.getMinY());
-        assertEquals(250, box.getMaxX());
-        assertEquals(250, box.getMaxY());
+        assertEquals(-250, box.minX());
+        assertEquals(-250, box.minY());
+        assertEquals(250, box.maxX());
+        assertEquals(250, box.maxY());
 
         // We should have an envelope +/- 500 around center (250 voxel * 2.0 meters/voxels = 500m)
         Envelope envelope = generation.getEnvelopeForCRS(crs2154);

--- a/src/test/java/com/ignfab/minalac/generator/models/GeometryModelTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/models/GeometryModelTest.java
@@ -26,10 +26,10 @@ public class GeometryModelTest {
         GeometryModel model = new GeometryModel(FACTORY.createPoint(new Coordinate(10.0, -20.0)), CONVERTER, LARGEBOX);
         ReadableChunk2d chunk = model.getChunk();
 
-        assertEquals(chunk.bbox().getSize().x(),  1, "x-size");
-        assertEquals(chunk.bbox().getSize().y(),  1, "y-size");
-        assertEquals(chunk.bbox().getMin().x(),  10, "x-min");
-        assertEquals(chunk.bbox().getMin().y(), -20, "y-min");
+        assertEquals(chunk.bbox().sizeX(),  1, "x-size");
+        assertEquals(chunk.bbox().sizeY(),  1, "y-size");
+        assertEquals(chunk.bbox().minX(),  10, "x-min");
+        assertEquals(chunk.bbox().minY(), -20, "y-min");
     }
 
     @Test
@@ -49,10 +49,10 @@ public class GeometryModelTest {
         // B B B B
 
         // Bbox check
-        assertEquals(chunk.bbox().getSize().x(), 4, "x-size");
-        assertEquals(chunk.bbox().getSize().y(), 3, "y-size");
-        assertEquals(chunk.bbox().getMin().x(), -1, "x-min");
-        assertEquals(chunk.bbox().getMin().y(), -1, "y-min");
+        assertEquals(chunk.bbox().sizeX(), 4, "x-size");
+        assertEquals(chunk.bbox().sizeY(), 3, "y-size");
+        assertEquals(chunk.bbox().minX(), -1, "x-min");
+        assertEquals(chunk.bbox().minY(), -1, "y-min");
 
         // Pixel check
         assertEquals(chunk.get(-1, -1), GeometryModel.BORDER,  "(-1, -1)");
@@ -88,10 +88,10 @@ public class GeometryModelTest {
         // 0 0 0 0 1
 
         // Bbox check
-        assertEquals(chunk.bbox().getSize().x(), 5, "x-size");
-        assertEquals(chunk.bbox().getSize().y(), 5, "y-size");
-        assertEquals(chunk.bbox().getMin().x(), -2, "x-min");
-        assertEquals(chunk.bbox().getMin().y(), -2, "y-min");
+        assertEquals(chunk.bbox().sizeX(), 5, "x-size");
+        assertEquals(chunk.bbox().sizeY(), 5, "y-size");
+        assertEquals(chunk.bbox().minX(), -2, "x-min");
+        assertEquals(chunk.bbox().minY(), -2, "y-min");
 
         // Pixel check
         assertEquals(chunk.get(-2, -2), GeometryModel.BORDER,  "(-2,-2)");
@@ -156,10 +156,10 @@ public class GeometryModelTest {
         // 1 1 1 1 1
 
         // Bbox check
-        assertEquals(chunk.bbox().getSize().x(), 5, "x-size");
-        assertEquals(chunk.bbox().getSize().y(), 5, "y-size");
-        assertEquals(chunk.bbox().getMin().x(), -2, "x-min");
-        assertEquals(chunk.bbox().getMin().y(), -2, "y-min");
+        assertEquals(chunk.bbox().sizeX(), 5, "x-size");
+        assertEquals(chunk.bbox().sizeY(), 5, "y-size");
+        assertEquals(chunk.bbox().minX(), -2, "x-min");
+        assertEquals(chunk.bbox().minY(), -2, "y-min");
 
         // Pixel check
         assertEquals(chunk.get(-2, -2), GeometryModel.BORDER,  "(-2,-2)");
@@ -221,10 +221,10 @@ public class GeometryModelTest {
         //  -5           X
 
         // Bbox check
-        assertEquals( 3, chunk.bbox().getSize().x(), "x-size"); // Intersection only
-        assertEquals( 4, chunk.bbox().getSize().y(), "y-size");
-        assertEquals(-3, chunk.bbox().getMin().x(),  "x-min");
-        assertEquals(-3, chunk.bbox().getMin().y(),  "y-min");
+        assertEquals( 3, chunk.bbox().sizeX(), "x-size"); // Intersection only
+        assertEquals( 4, chunk.bbox().sizeY(), "y-size");
+        assertEquals(-3, chunk.bbox().minX(),  "x-min");
+        assertEquals(-3, chunk.bbox().minY(),  "y-min");
 
         // Pixel check
         assertEquals(GeometryModel.OUTSIDE, chunk.get(-3,  0), "(-3, 0)");

--- a/src/test/java/com/ignfab/minalac/generator/models/TestBufferedImageChunk.java
+++ b/src/test/java/com/ignfab/minalac/generator/models/TestBufferedImageChunk.java
@@ -31,13 +31,13 @@ public class TestBufferedImageChunk {
 
         // Set a different value on each chunk cell
         v = 0;
-        for (int y = bbox.getMin().y(); y <= bbox.getMax().y(); y++)
-            for (int x = bbox.getMin().x(); x <= bbox.getMax().x(); x++)
+        for (int y = bbox.minY(); y <= bbox.maxY(); y++)
+            for (int x = bbox.minX(); x <= bbox.maxX(); x++)
                 chunk.set(x, y, v++);
 
         v = 0;
-        for (int y = bbox.getMin().y(); y <= bbox.getMax().y(); y++)
-            for (int x = bbox.getMin().x(); x <= bbox.getMax().x(); x++)
+        for (int y = bbox.minY(); y <= bbox.maxY(); y++)
+            for (int x = bbox.minX(); x <= bbox.maxX(); x++)
                 assertEquals(chunk.get(x, y), v++, "(%d, %d)".formatted(x, y));
     }
 

--- a/src/test/java/com/ignfab/minalac/generator/outputs/testing/TestingVoxelWorld.java
+++ b/src/test/java/com/ignfab/minalac/generator/outputs/testing/TestingVoxelWorld.java
@@ -35,7 +35,7 @@ public class TestingVoxelWorld extends VoxelWorld {
         super(null);
         factory = new TestingVoxelTypeFactory(this);
         maxLimits = bbox;
-        voxels = new String[bbox.getSize().volume()];
+        voxels = new String[bbox.size().volume()];
         setLimits(bbox);
     }
 
@@ -54,9 +54,9 @@ public class TestingVoxelWorld extends VoxelWorld {
 
     // This method should not be called with out of bounds coordinate
     private int index(int x, int y, int z) {
-        return x - limits().getMinX() + limits().getSizeX()
-            * (y - limits().getMinY() + limits().getSizeY()
-            * (z - limits().getMinZ()));
+        return x - limits().minX() + limits().sizeX()
+            * (y - limits().minY() + limits().sizeY()
+            * (z - limits().minZ()));
     }
 
     protected void set(int x, int y, int z, TestingVoxelType voxelType) {

--- a/src/test/java/com/ignfab/minalac/generator/parsing/ParamsParserTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parsing/ParamsParserTest.java
@@ -248,8 +248,8 @@ public class ParamsParserTest {
         Generation generation = assertDoesNotThrow(() -> new ParamsParser(WORKING_JSON).createGeneration());
 
         assertNotNull(generation);
-        assertEquals(500, generation.getWorldBBox2d().getSize().x());
-        assertEquals(2500, generation.getWorldBBox2d().getSize().y());
+        assertEquals(500, generation.getWorldBBox2d().sizeX());
+        assertEquals(2500, generation.getWorldBBox2d().sizeY());
         assertEquals(3.0, generation.getVerticalScale(), 0.001);
 
         Heightmap ground = assertDoesNotThrow(() -> generation.getHeightmap("ground"));
@@ -263,7 +263,7 @@ public class ParamsParserTest {
     public void testCreateVoxelWorld() {
         VoxelWorld world = assertDoesNotThrow(() -> new ParamsParser(WORKING_JSON).createVoxelWorld());
         assertNotNull(world);
-        assertEquals(500, world.limits().getSizeX());
-        assertEquals(2500, world.limits().getSizeY());
+        assertEquals(500, world.limits().sizeX());
+        assertEquals(2500, world.limits().sizeY());
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/renderers/VectorRendererTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/renderers/VectorRendererTest.java
@@ -132,7 +132,7 @@ class VectorRendererTest {
     @DisplayName("Test rendering of a chunk larger than world horizontal limits")
     public void testRenderHorizontalOverflow() {
         // Prepare a larger model bbox
-        WorldBBox2d modelBbox = new WorldBBox2d(bbox.getMinX() - 1, bbox.getMinY() - 1, bbox.getSizeX() + 2, bbox.getSizeY() + 2);
+        WorldBBox2d modelBbox = new WorldBBox2d(bbox.minX() - 1, bbox.minY() - 1, bbox.sizeX() + 2, bbox.sizeY() + 2);
 
         models.add(new TestingRasterizableModel(new TestingIterableArrayChunk2d(modelBbox, GeometryModel.INSIDE)));
 

--- a/src/test/java/com/ignfab/minalac/generator/utils/world2d/WorldBBox2dTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/world2d/WorldBBox2dTest.java
@@ -12,9 +12,9 @@ public class WorldBBox2dTest {
     public void testConstructorOriginSizeInt() {
         // Instantiating a new bounding box
         WorldBBox2d box = assertDoesNotThrow(() -> new WorldBBox2d(1, 2, 3, 4));
-        assertEquals(new WorldCoords2d(1, 2), box.getMin());
-        assertEquals(new WorldCoords2d(3, 5), box.getMax());
-        assertEquals(new WorldSize2d(3, 4), box.getSize());
+        assertEquals(new WorldCoords2d(1, 2), box.min());
+        assertEquals(new WorldCoords2d(3, 5), box.max());
+        assertEquals(new WorldSize2d(3, 4), box.size());
 
         // Instantiating a 0 sized bounding box
         assertDoesNotThrow(() -> new WorldBBox2d(0, 0, 0, 0));
@@ -30,9 +30,9 @@ public class WorldBBox2dTest {
         box = assertDoesNotThrow(() -> new WorldBBox2d(
             new WorldCoords2d(2, 3)
         ));
-        assertEquals(new WorldCoords2d(2, 3), box.getMin());
-        assertEquals(new WorldCoords2d(2, 3), box.getMax());
-        assertEquals(new WorldSize2d(1, 1), box.getSize());
+        assertEquals(new WorldCoords2d(2, 3), box.min());
+        assertEquals(new WorldCoords2d(2, 3), box.max());
+        assertEquals(new WorldSize2d(1, 1), box.size());
 
         box = assertDoesNotThrow(() -> new WorldBBox2d(
             new WorldCoords2d(1, -2),
@@ -40,9 +40,9 @@ public class WorldBBox2dTest {
             new WorldCoords2d(-5, 0)
         ));
 
-        assertEquals(new WorldCoords2d(-5, -2), box.getMin());
-        assertEquals(new WorldCoords2d(1, 3), box.getMax());
-        assertEquals(new WorldSize2d(7, 6), box.getSize());
+        assertEquals(new WorldCoords2d(-5, -2), box.min());
+        assertEquals(new WorldCoords2d(1, 3), box.max());
+        assertEquals(new WorldSize2d(7, 6), box.size());
     }
 
     @Test

--- a/src/test/java/com/ignfab/minalac/generator/utils/world3d/WorldBBox3dTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/world3d/WorldBBox3dTest.java
@@ -12,9 +12,9 @@ public class WorldBBox3dTest {
     public void testConstructorOriginSizeInt() {
         // Instantiating a new bounding box
         WorldBBox3d box = assertDoesNotThrow(() -> new WorldBBox3d(1, 2, 3, 4, 5, 6));
-        assertEquals(new WorldCoords3d(1, 2, 3), box.getMin());
-        assertEquals(new WorldCoords3d(4, 6, 8), box.getMax());
-        assertEquals(new WorldSize3d(4, 5, 6), box.getSize());
+        assertEquals(new WorldCoords3d(1, 2, 3), box.min());
+        assertEquals(new WorldCoords3d(4, 6, 8), box.max());
+        assertEquals(new WorldSize3d(4, 5, 6), box.size());
 
         // Instantiating a 0 sized bounding box
         assertDoesNotThrow(() -> new WorldBBox3d(0, 0, 0, 0, 0, 0));
@@ -30,9 +30,9 @@ public class WorldBBox3dTest {
         box = assertDoesNotThrow(() -> new WorldBBox3d(
             new WorldCoords3d(1, 2, 3)
         ));
-        assertEquals(new WorldCoords3d(1, 2, 3), box.getMin());
-        assertEquals(new WorldCoords3d(1, 2, 3), box.getMax());
-        assertEquals(new WorldSize3d(1, 1, 1), box.getSize());
+        assertEquals(new WorldCoords3d(1, 2, 3), box.min());
+        assertEquals(new WorldCoords3d(1, 2, 3), box.max());
+        assertEquals(new WorldSize3d(1, 1, 1), box.size());
 
         box = assertDoesNotThrow(() -> new WorldBBox3d(
             new WorldCoords3d(1, -2, 3),
@@ -40,9 +40,9 @@ public class WorldBBox3dTest {
             new WorldCoords3d(-6, 0, 0)
         ));
 
-        assertEquals(new WorldCoords3d(-6, -2, -5), box.getMin());
-        assertEquals(new WorldCoords3d(1, 4, 3), box.getMax());
-        assertEquals(new WorldSize3d(8, 7, 9), box.getSize());
+        assertEquals(new WorldCoords3d(-6, -2, -5), box.min());
+        assertEquals(new WorldCoords3d(1, 4, 3), box.max());
+        assertEquals(new WorldSize3d(8, 7, 9), box.size());
     }
 
     @Test


### PR DESCRIPTION
### Changes

Rename `WorldBBox2d` and `WorldBBox3d` getters using the same convention for `WoordCoords` (Removing the get prefix)

### Self-checks

- ~~[ ] The code has unit tests associated~~
- ~~[ ] The code has Javadoc Comments associated~~
- ~~[ ] Complex / Unexpected code is explained / justified with a small comment~~
- ~~[ ] Relevant documentation inside the `/docs` folder has been updated~~
- ~~[ ] All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)~~
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- ~~[ ] The texts have been proofread (documentation, error messages, logs, comments...)
