### PR TITLE
fix(minecraft): In-Game Z axis is inverted

### DIFF
--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCBlockEntityVoxelType.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCBlockEntityVoxelType.java
@@ -42,11 +42,11 @@ public abstract class MCBlockEntityVoxelType extends MCVoxelType {
         CompoundTag block = new CompoundTag();
         block.putString("id", type);
         block.putBoolean("keepPacked", false);
-        // XYZ => XZY
+        // X/Y/Z => X/Z/-Y
         block.putInt("x", x);
         block.putInt("y", z);
-        block.putInt("z", y);
+        block.putInt("z", -y);
         serialize(block);
-        world.addBlockEntity(x, z, y, block); // XYZ => XZY
+        world.addBlockEntity(x, z, -y, block); // X/Y/Z => X/Z/-Y
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelType.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelType.java
@@ -59,6 +59,6 @@ public class MCVoxelType implements VoxelType {
             properties.forEach(state::putString);
             block.put("Properties", state);
         }
-        world.setBlockState(x, z, y, block); // XYZ => XZY
+        world.setBlockState(x, z, -y, block); // X/Y/Z => X/Z/-Y
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelWorld.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelWorld.java
@@ -294,12 +294,12 @@ public class MCVoxelWorld extends VoxelWorld {
 
                     ListTag<DoubleTag> pos = new ListTag<>(DoubleTag.class);
                     {
-                        // XYZ => XZY
+                        // X/Y/Z => X/Z/-Y
                         pos.addDouble(metadata.getSpawn().x() + 0.5);
                         // TODO Replace by a better constraint management mechanism
                         // pos.addDouble(metadata.getSpawn().z());
                         pos.addDouble(Math.min(Math.max(limits().minZ(), metadata.getSpawn().z()), limits().maxZ()));
-                        pos.addDouble(metadata.getSpawn().y() + 0.5);
+                        pos.addDouble(-metadata.getSpawn().y() + 0.5);
                     }
                     player.put("Pos", pos);
 
@@ -360,12 +360,12 @@ public class MCVoxelWorld extends VoxelWorld {
 
                 data.putLong("SizeOnDisk", 0); // Unused
 
-                // XYZ => XZY
+                // X/Y/Z => X/Z/-Y
                 data.putInt("SpawnX", metadata.getSpawn().x());
                 // TODO Replace by a better constraint management mechanism
                 // data.putInt("SpawnY", metadata.getSpawn().z());
                 data.putInt("SpawnY", Math.min(Math.max(limits().minZ(), metadata.getSpawn().z()), limits().maxZ()));
-                data.putInt("SpawnZ", metadata.getSpawn().y());
+                data.putInt("SpawnZ", -metadata.getSpawn().y());
 
                 data.putBoolean("thundering", false);
                 data.putInt("thunderTime", 0x7FFFFFFF);
@@ -509,7 +509,7 @@ public class MCVoxelWorld extends VoxelWorld {
 
     // In-Game coords
     /* package-private */ boolean isOutOfLimits(int blockX, int blockY, int blockZ) {
-        // (In-Game coords to world coords) XZY => XYZ
-        return !limits().contains(blockX, blockZ, blockY);
+        // (In-Game coords to world coords) X/Z/-Y => X/Y/Z
+        return !limits().contains(blockX, -blockZ, blockY);
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelTypeTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelTypeTest.java
@@ -26,7 +26,7 @@ public class MCVoxelTypeTest {
         air.place(3, -7, 64);
         CompoundTag expectedAir = new CompoundTag();
         expectedAir.putString("Name", "minecraft:air");
-        worldMock.assertBlockStateAt(3, 64, -7, expectedAir); // XYZ => XZY
+        worldMock.assertBlockStateAt(3, 64, 7, expectedAir); // X/Y/Z => X/Z/-Y
 
         MCVoxelType stairs = new MCVoxelType(worldMock, "minecraft:oak_stairs", Map.of(
             "facing", "north",
@@ -43,7 +43,7 @@ public class MCVoxelTypeTest {
         properties.putString("shape", "straight");
         properties.putString("waterlogged", "false");
         expectedStairs.put("Properties", properties);
-        worldMock.assertBlockStateAt(-43, 192, 0, expectedStairs); // XYZ => XZY
+        worldMock.assertBlockStateAt(-43, 192, 0, expectedStairs); // X/Y/Z => X/Z/-Y
     }
 
     private static final class WorldMock extends MCVoxelWorld {

--- a/src/test/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelWorldTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelWorldTest.java
@@ -57,17 +57,17 @@ public class MCVoxelWorldTest {
         MCVoxelWorld world = new MCVoxelWorld();
         world.setLimits(new WorldBBox3d(new WorldCoords3d(-10, -20, 0), new WorldCoords3d(20, 30, 40)));
 
-        // Y -> Z
-        assertFalse(world.isOutOfLimits(-10, 0, -20));
-        assertFalse(world.isOutOfLimits(20, 40, 30));
+        // X/Y/Z => X/Z/-Y
+        assertFalse(world.isOutOfLimits(-10, 0, 20));
+        assertFalse(world.isOutOfLimits(20, 40, -30));
 
-        assertFalse(world.isOutOfLimits(5, 5, 20));
+        assertFalse(world.isOutOfLimits(5, 5, -20));
 
-        assertTrue(world.isOutOfLimits(21, 40, 30));
-        assertTrue(world.isOutOfLimits(20, 41, 30));
-        assertTrue(world.isOutOfLimits(20, 40, 31));
-        assertTrue(world.isOutOfLimits(-11, 0, -20));
-        assertTrue(world.isOutOfLimits(-10, -1, -20));
-        assertTrue(world.isOutOfLimits(-10, 0, -21));
+        assertTrue(world.isOutOfLimits(21, 40, -30));
+        assertTrue(world.isOutOfLimits(20, 41, -30));
+        assertTrue(world.isOutOfLimits(20, 40, -31));
+        assertTrue(world.isOutOfLimits(-11, 0, 20));
+        assertTrue(world.isOutOfLimits(-10, -1, 20));
+        assertTrue(world.isOutOfLimits(-10, 0, 21));
     }
 }


### PR DESCRIPTION
### Type of modification

- Code
  - Outputs: Minecraft output format

### Changes

Inverts the Z axis for Minecraft output format.

#### Feature description

The PR replaces all coordinates conversions related to "Generator <=> Minecraft" from "X/Y/Z <=> X/Z/Y" to "X/Y/Z <=> X/Z/-Y".

All generated maps are now correctly oriented (IRL north and IG north pointing in the same direction, instead of opposed direction).

Maybe we should consider adding a dedicated coords converter to the world objects, so these operations are centralized. However, for performance reasons, it seems preferable to keep the hard-coded conversion inside the `VoxelType#place(x, y, z)` method, as it is called very very frequently, and we should avoid creating useless object (such as a `WorldCoords3d` or any equivalent) here.

#### Showcase

IRL:
![image](https://github.com/user-attachments/assets/e6f3ce39-fff8-49df-b3d8-39c80ef83f36)

Before this PR:
![image](https://github.com/user-attachments/assets/da5a4661-5a17-4a10-bf02-de1f56a695dd)

After this PR:
![image](https://github.com/user-attachments/assets/63d83361-25b8-4912-aba7-57f88d910f0f)
*Please disregard any changes in materials, as they come from another already merged commit that was rebased between the two screenshots*

The player was looking in the direction of the IG north in both screenshot.

### Reason

The In-Game Z axis is inverted in comparison to the generator's coordinates system. The north and south were flipped.

### Self-checks

- ~~The code has unit tests associated~~
- ~~The code has Javadoc Comments associated~~
- [x] Complex / Unexpected code is explained / justified with a small comment
- ~~Relevant documentation inside the `/docs` folder has been updated~~
- [x] All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [x] The texts have been proofread (documentation, error messages, logs, comments...)
