### PR TITLE
fix(minecraft): Thread-safety issue with Minecraft format

### DIFF
--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelWorld.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelWorld.java
@@ -472,7 +472,14 @@ public class MCVoxelWorld extends VoxelWorld {
     }
 
     // In-Game coords
-    /* package-private */ void setBlockState(int blockX, int blockY, int blockZ, CompoundTag block) {
+    /* package-private */ synchronized void setBlockState(int blockX, int blockY, int blockZ, CompoundTag block) {
+        // This method is synchronized as a workaround because the Querz library is not thread-safe.
+        // This is a performance-killer!
+        // The only part that really needs synchronization is inside nbt.querz.mca.Section:
+        // During a palette update (adjustBlockStateBits), it should block, until operation
+        // is complete, any other thread trying to add a block to the palette (addToPalette,
+        // after the check for existing block inside palette).
+
         if (isOutOfLimits(blockX, blockY, blockZ)) return;
         getOrCreateRegion(blockX, blockZ).file().setBlockStateAt(blockX, blockY, blockZ, block, false);
     }


### PR DESCRIPTION
### Type of modification

- Code
  - Outputs: Minecraft output format

### Issue

MINALAC-66

### Changes

Fixes an issue related to thread-safety when writing data in Minecraft output format.

#### Feature description

The block placement method is now synchronized. While this affects deeply performances (~8s => ~13s on my computer for the same generation), this is unavoidable as long as we keep the current Minecraft world writing library, which is not thread-safe itself.

The issue and a way it could be patched within the library is explained in a comment is the code.

### Reason

The generation was just crashing randomly, and it began to happen more and more frequently as we adds more and more features in the generation (aka, as we place more voxels, at different places, from different threads...), and it reached a point where almost 1 out of 5 generation crashed because of this. The performance tradeoff, while being relatively consequent, is acceptable for now.

### Self-checks

- ~~The code has unit tests associated~~
- ~~The code has Javadoc Comments associated~~
- [x] Complex / Unexpected code is explained / justified with a small comment
- ~~Relevant documentation inside the `/docs` folder has been updated~~
- ~~All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)~~
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [x] The texts have been proofread (documentation, error messages, logs, comments...)
