### PR TITLE
Everything in Yaml

### DIFF
--- a/docs/usage/GenerationParameters.md
+++ b/docs/usage/GenerationParameters.md
@@ -8,8 +8,19 @@ These parameters generate a map of 1000x1000 voxels around IGN building at Saint
 heightmaps:
   ground:
     default: 0
+sources:
+  bati:
+    modelType: building
+    provider:
+      type: wfs
+      url: https://data.geopf.fr/wfs/wfs
+      features: BDTOPO_V3:batiment
+    processor:
+      type: geoToolsVector
 renderers:
   building:
+    after:
+      - source:bati
     type: vector
     modelType: building
     heightmap: ground
@@ -27,12 +38,24 @@ crs: EPSG:2154
 format: minetest
 ```
 
-Available fields:
+## Fields description
+
 - `heightmaps`: Heightmaps available for the generation
-  - _`<name>`_: Name of the heightmap
+  - _`<name>`_: Unique name of the heightmap
       - `default` (int or str): Default value for all heightmap cells (integer or one of `minimal`, `min`, `maximal` or `max`)
+- `sources`: Sources providing models to render
+  - _`<name>`_: Unique name of the source
+    - `after` (optional list): List of [dependancies](#dependancies)
+    - `modelType`: the type of models to create
+    - `provider`: Definition of the data provider to use
+        - `type`: Type of data provider
+        - Additional parameters specific to the given [type](#provider-parameters)
+    - `processor`: Definition of the data processor to use
+        - `type`: Type of data processor
+        - Additional parameters specific to the given [type](#processor-parameters)
 - `renderers`: Renderers used to generate the map
-  - _`<name>`_: Name of the renderer
+  - _`<name>`_: Unique name of the renderer
+    - `after` (list): List of [dependencies](#dependencies)
     - `type` (str): Type of the renderer
     - Additional parameters specific to the given [type](#renderer-parameters)
 - `area`: Area to be rendered
@@ -46,11 +69,103 @@ Available fields:
 - `crs`: Coordinate Reference System to be used for projecting geographical data into voxel world
 - `format`: Output format (`minetest` or `minecraft`)
 
-# Renderer parameters
+## Dependencies
+
+Dependencies allow to manage execution order of sources and renderers. Optional `after` fields contains a list of every source or renderer that should run before the source or renderer it belongs to.
+
+In `after` list, `source:<name>` refers to sources and `renderer:<name>` refers to renderers (`<name>` being the unique name given to source or renderer in its definition).
+
+For example, if we want `buildings` renderer to run after `buildings` source and `altitude` renderer, we write:
+```yaml
+renderers:
+  buildings:
+    after:
+      - source:buildings
+      - renderer:altitude
+    ...
+```
+
+**BEWARE** : For now, `after` values are not checked. Generator will get stuck waiting in case of dependency loop or if a value refers to nonexistant source or renderer.
+
+## Providers parameters
+
+A provider fetches data from a source and provides it as-is to a processor. Provider type is identified by `type` field.
+
+### Web Feature Service
+A provider capable of fetching vector data from a [Web Feature Service](https://en.wikipedia.org/wiki/Web_Feature_Service) source. Source must support WFS 1.1 and GML 3.1 versions.
+
+**Type**: `wfs`
+
+**Extra parameters**:
+- `url` (required): Base URL, including protocol and path, excluding request arguments (example: `https://data.geopf.fr/wfs/wfs`)
+- `features` (required): Name of WFS feature type to fetch
+- `crs` (optional): Wanted CRS for these features (defaults to target CRS)
+
+**Suitable processors**: `geoToolsVector`
+
+### Web Map Service with floating point values
+A provider capable of fetching **float** data from a [Web Map Service](https://en.wikipedia.org/wiki/Web_Map_Service) source. Source must be able to provide `x-bil` format.
+
+**Type**: `wmsFloat`
+
+**Extra parameters**:
+- `url` (required): Base URL, including protocol and path, excluding request arguments (example: `https://data.geopf.fr/wms-r/wms`)
+- `layer` (required): Name of layer to fetch
+- `crs` (optional): Wanted CRS for this layer (defaults to target CRS)
+
+**Suitable processors**: `floatMatrix`
+
+## Processor parameters
+
+A processor converts data from a provider into models. Processor type is identified by `type` field.
+
+### GeoTools vector processor
+
+This processor is able to take vector features and turn them into models, using GeoTools library.
+
+**Type**: `geoToolsVector`
+
+**Extra parameters**: None
+
+**Suitable providers**: `wfs`
+
+### Float matrix vector processor
+
+Processor translating a float data matrix to a model.
+
+**type**: `floatMatrix`
+
+**Extra parameters**: None
+
+**Suitable providers**: `wmsFloat`
+
+## Renderer parameters
 
 Each renderer has a field `type` which is used to identify it.
 
-## Vector renderer
+
+### Ground renderer
+
+This renderer places a column of voxels under a heightmap.
+
+**Type**: ground
+
+**Extra parameters**:
+- `heightmap`: Name of the heightmap to use
+- `voxels`: Voxels to place as a pair of semantic type and thickness.
+
+Example:
+```yaml
+type: ground
+heightmap: altitude
+voxels:
+  GRASS: 1
+  DIRT: 3
+  STONE: 10
+```
+This will put a grass voxel at heightmap altitude, three dirt voxels underneath and then ten stone voxels (fourteen voxels in total under the heightmap's level).
+
+### Vector renderer
 
 ```yaml
 type: vector
@@ -67,7 +182,7 @@ Fields:
 - `inside`: the semantic type of the voxel used for the inside
 - `edge`: the semantic type of the voxel used for the edges
 
-## Heightmap Renderer
+### Heightmap renderer
 
 ```yaml
 type: heightmap

--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -1,12 +1,43 @@
 heightmaps:
   ground:
     default: 0
+sources:
+  mnt:
+    modelType: mnt
+    provider:
+      type: wmsFloat
+      url: https://data.geopf.fr/wms-r/wms
+      layer: RGEALTI-MNT_PYR-ZIP_FXX_LAMB93_WMS
+    processor:
+      type: floatMatrix
+  bati:
+    modelType: building
+    provider:
+      type: wfs
+      url: https://data.geopf.fr/wfs/wfs
+      features: BDTOPO_V3:batiment
+    processor:
+      type: geoToolsVector
 renderers:
-  heightmap-ground:
+  altitude:
+    after:
+      - source:mnt
     type: heightmap
     modelType: mnt
     heightmap: ground
+  ground:
+    after:
+      - renderer:altitude
+    type: ground
+    heightmap: ground
+    voxels:
+      GRASS: 1
+      DIRT: 3
+      STONE: 10
   building:
+    after:
+      - renderer:altitude
+      - source:bati
     type: vector
     modelType: building
     heightmap: ground

--- a/examples/minecraft.yaml
+++ b/examples/minecraft.yaml
@@ -1,12 +1,43 @@
 heightmaps:
   ground:
     default: 0
+sources:
+  mnt:
+    modelType: mnt
+    provider:
+      type: wmsFloat
+      url: https://data.geopf.fr/wms-r/wms
+      layer: RGEALTI-MNT_PYR-ZIP_FXX_LAMB93_WMS
+    processor:
+      type: floatMatrix
+  bati:
+    modelType: building
+    provider:
+      type: wfs
+      url: https://data.geopf.fr/wfs/wfs
+      features: BDTOPO_V3:batiment
+    processor:
+      type: geoToolsVector
 renderers:
-  heightmap-ground:
+  altitude:
+    after:
+      - source:mnt
     type: heightmap
     modelType: mnt
     heightmap: ground
+  ground:
+    after:
+      - renderer:altitude
+    type: ground
+    heightmap: ground
+    voxels:
+      GRASS: 1
+      DIRT: 3
+      STONE: 10
   building:
+    after:
+      - renderer:altitude
+      - source:bati
     type: vector
     modelType: building
     heightmap: ground

--- a/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
+++ b/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
@@ -1,44 +1,25 @@
 package com.ignfab.minalac.generator;
 
-import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
-import com.ignfab.minalac.generator.exceptions.IgnorableException;
-import com.ignfab.minalac.generator.exceptions.RetryableException;
 import com.ignfab.minalac.generator.exceptions.TransformException;
 import com.ignfab.minalac.generator.generation.Generation;
-import com.ignfab.minalac.generator.inputs.Provider;
-import com.ignfab.minalac.generator.inputs.WFS1_1_GML3_1_DataProvider;
-import com.ignfab.minalac.generator.inputs.WMSFloatBilDataProvider;
-import com.ignfab.minalac.generator.models.Model;
-import com.ignfab.minalac.generator.models.ModelStore;
 import com.ignfab.minalac.generator.parameters.ParamsParser;
 import com.ignfab.minalac.generator.parameters.ParseException;
+import com.ignfab.minalac.generator.parameters.processors.FloatMatrixProcessorParams;
+import com.ignfab.minalac.generator.parameters.processors.GeoToolsVectorProcessorParams;
+import com.ignfab.minalac.generator.parameters.providers.WFSProviderParams;
+import com.ignfab.minalac.generator.parameters.providers.WMSFloatBilProviderParams;
+import com.ignfab.minalac.generator.parameters.renderers.GroundRendererParams;
 import com.ignfab.minalac.generator.parameters.renderers.HeightmapRendererParams;
 import com.ignfab.minalac.generator.parameters.renderers.VectorRendererParams;
-import com.ignfab.minalac.generator.processors.FloatMatrixProcessor;
-import com.ignfab.minalac.generator.processors.GeoToolsVectorProcessor;
-import com.ignfab.minalac.generator.processors.Processor;
-import com.ignfab.minalac.generator.processors.post.MetadataCopyPostProcessor;
-import com.ignfab.minalac.generator.processors.post.MetadataParsePostProcessor;
-import com.ignfab.minalac.generator.processors.post.PostProcessor;
-import com.ignfab.minalac.generator.renderers.GroundRenderer;
-import com.ignfab.minalac.generator.utils.coordinates.MapToWorldConverter;
-import com.ignfab.minalac.generator.utils.execution.Scheduler;
 import com.ignfab.minalac.generator.utils.execution.TaskFailedException;
 import com.ignfab.minalac.generator.utils.network.HttpTrustAllSSL;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
-import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.world.MapWriteException;
-import com.ignfab.minalac.generator.world.SemanticType;
-import com.ignfab.minalac.generator.world.SimpleVoxelPattern;
-import com.ignfab.minalac.generator.world.VoxelWorld;
 import com.ignfab.minalac.generator.world.VoxelWorldMetadata;
+
 import org.geotools.api.referencing.FactoryException;
-import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
-import org.geotools.referencing.CRS;
-import org.locationtech.jts.geom.Envelope;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -55,7 +36,6 @@ public final class SampleImplementation {
      *
      * @param args command line arguments
      */
-    @SuppressWarnings("MethodLength")
     public static void main(String[] args) throws FactoryException, InterruptedException, MapWriteException, ParseException, TaskFailedException, TransformException {
         long start = System.currentTimeMillis();
         HttpTrustAllSSL.applyGlobally();
@@ -66,204 +46,45 @@ public final class SampleImplementation {
 
         // Generation parsing
         ParamsParser parser = new ParamsParser();
+
         // TODO: Static method that provides a ParamsParser with all default renderers
         // If those name values are modified, update the documentation accordingly
-        parser.registerRenderer("vector", VectorRendererParams.class);
-        parser.registerRenderer("heightmap", HeightmapRendererParams.class);
+        parser.registerParams("heightmap", HeightmapRendererParams.class);
+        parser.registerParams("ground", GroundRendererParams.class);
+        parser.registerParams("vector", VectorRendererParams.class);
+
+        parser.registerParams("wfs", WFSProviderParams.class);
+        parser.registerParams("wmsFloat", WMSFloatBilProviderParams.class);
+
+        parser.registerParams("floatMatrix", FloatMatrixProcessorParams.class);
+        parser.registerParams("geoToolsVector", GeoToolsVectorProcessorParams.class);
+
         Generation generation = parser.parse(cli.readParameters()).create();
 
         System.out.println("Creation of the map.");
+        generation.scheduler().start();
 
-        String crsName = "EPSG:2154";
-        CoordinateReferenceSystem crs = CRS.decode(crsName);
-        Envelope envelope = generation.getEnvelopeForCRS(crs);
-        String bboxURL = "BBOX=" + envelope.getMinX() + "," + envelope.getMinY() + "," + envelope.getMaxX() + "," + envelope.getMaxY();
-
-        Scheduler scheduler = new Scheduler();
-
-        // Downloads
-
-        scheduler.schedule("models.ground", () -> {
-            log("Downloading height map");
-            MapToWorldConverter converter;
-            try {
-                converter = generation.makeCoordsConverter(crs);
-            } catch (FactoryException e) {
-                throw new RuntimeException(e);
-            }
-            retrieveDataAndFillModelStore(generation.models(), "mnt",
-                new WMSFloatBilDataProvider("https://data.geopf.fr/wms-r/wms?LAYERS=RGEALTI-MNT_PYR-ZIP_FXX_LAMB93_WMS", crs, envelope),
-                new FloatMatrixProcessor(converter)
-            );
-            log("Downloaded heightmap");
-        });
-
-        scheduler.schedule("models.buildings", () -> {
-            log("Downloading buildings");
-            MapToWorldConverter converter; // This is supposed to be the layer CRS (actually the same for this demo)
-            try {
-                converter = generation.makeCoordsConverter(crs);
-            } catch (FactoryException e) {
-                throw new RuntimeException(e);
-            }
-            retrieveDataAndFillModelStore(generation.models(), "building",
-                new WFS1_1_GML3_1_DataProvider("https://data.geopf.fr/wfs/wfs?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=BDTOPO_V3:batiment&STARTINDEX=0&COUNT=1000&SRSNAME=urn:ogc:def:crs:EPSG::2154&" + bboxURL + ",urn:ogc:def:crs:EPSG::2154&outputFormat=text%2Fxml%3B%20subtype%3Dgml%2F3.1.1"),
-                new GeoToolsVectorProcessor(converter),
-                new MetadataCopyPostProcessor("hauteur", "height", false, false),
-                new MetadataParsePostProcessor<>(
-                    "height",
-                    Double.class,
-                    obj -> {
-                        if (obj instanceof Number number)
-                            return number.doubleValue();
-                        else if (obj instanceof String string)
-                            return Double.parseDouble(string);
-                        return null;
-                    },
-                    MetadataParsePostProcessor.ParsingFailurePolicy.REMOVE_METADATA,
-                    false,
-                    false
-                ),
-                // TODO Transform into something like "MetadataDefaultPostProcessor"
-                new PostProcessor<>() {
-                    @Override
-                    public Class<? super Model> acceptedModelType() {
-                        return Model.class;
-                    }
-
-                    @Override
-                    public Class<? extends Model> processedModelType(Class<? extends Model> inputModelType) {
-                        return inputModelType;
-                    }
-
-                    @Override
-                    public Model process(Model model) {
-                        if (!model.hasMetadata("height"))
-                            model.setMetadata("height", 20d);
-                        return model;
-                    }
-                },
-                // TODO Remove once the value is really used (currently useful to simulate value usage and failure in case of incorrect value)
-                new PostProcessor<>() {
-                    @Override
-                    public Class<? super Model> acceptedModelType() {
-                        return Model.class;
-                    }
-
-                    @Override
-                    public Class<? extends Model> processedModelType(Class<? extends Model> inputModelType) {
-                        return inputModelType;
-                    }
-
-                    @Override
-                    public Model process(Model model) throws GenerationFailedException {
-                        Object height = model.getMetadata("height");
-                        if (!(height instanceof Double))
-                            throw new GenerationFailedException("Illegal height value: " + (height == null ? "null" : (height + " (" + height.getClass() + ")")));
-                        return model;
-                    }
-                }
-            );
-            log("Downloaded buildings");
-        });
-
-        // Rendering
-
-        SimpleVoxelPattern soilPattern = new SimpleVoxelPattern();
-        soilPattern.set(0, 0, 0, generation.world().getFactory().createVoxelType(SemanticType.GRASS));
-        soilPattern.set(new WorldBBox3d(0, 0, -3, 1, 1, 3), generation.world().getFactory().createVoxelType(SemanticType.DIRT));
-        soilPattern.set(new WorldBBox3d(0, 0, -23, 1, 1, 20), generation.world().getFactory().createVoxelType(SemanticType.STONE));
-
-        scheduler.schedule("renderers.heightmap", () -> {
-            log("Filling altitude heightmap");
-            generation.renderers().get("heightmap-ground").render(generation.world().limits());
-            log("Altitude heightmap filled");
-        }, "models.ground");
-
-        // TODO: Create GroundRendererParams when VoxelPattern deserialization is implemented
-        scheduler.schedule("renderers.ground", () -> {
-            log("Rendering ground");
-            new GroundRenderer(
-                generation.heightmaps().get("ground"),
-                soilPattern
-            ).render(generation.world().limits());
-            log("Ground rendered");
-        }, "renderers.heightmap");
-
-        scheduler.schedule("renderers.buildings", () -> {
-            log("Placing buildings");
-            generation.renderers().get("building").render(generation.world().limits());
-            log("Placed buildings");
-        }, "renderers.heightmap", "models.buildings");
-        // Get work done!
-
-        scheduler.start();
         try {
-            scheduler.waitUntilAllTasksFinished(5, TimeUnit.MINUTES);
+            generation.scheduler().waitUntilAllTasksFinished(5, TimeUnit.MINUTES);
         } finally {
-            scheduler.shutdown();
+            generation.scheduler().shutdown();
         }
 
         System.out.println("Saving world");
         VoxelWorldMetadata metadata = generation.world().getMetadata();
         metadata.setSpawn(new WorldCoords3d(0, 0, generation.heightmaps().get("ground").get(0, 0) + 1));
         metadata.setWorldName("Minalac");
-        save(cli.getOutputPath().toFile(), generation.world());
 
+        File directory = cli.getOutputPath().toFile();
+        deleteDirectory(directory);
+        if (!directory.mkdirs())
+            throw new MapWriteException("Cannot generate the map because the folder " + directory.getAbsolutePath() + " cannot be created");
+
+        generation.world().save(directory);
         System.out.println("Done");
 
         long end = System.currentTimeMillis();
         System.out.println("Execution time: " + (end - start) / 1000 + "s");
-    }
-
-    private static void log(String message) {
-        System.out.printf("[%s] %s%n", Thread.currentThread().getName(), message);
-    }
-
-    private static <T> void retrieveDataAndFillModelStore(ModelStore store, String type, Provider<T> provider, Processor<? super T, ?> processor, PostProcessor<?, ?>... postProcessors) {
-        if (!processor.acceptedType().isAssignableFrom(provider.providedType()))
-            throw new IllegalArgumentException("Processor cannot treat provided type. Provided = %s, Accepted = %s".formatted(provider.providedType(), processor.acceptedType()));
-        Class<? extends Model> modelType = processor.modelType();
-        for (PostProcessor<?, ?> postProcessor : postProcessors) {
-            if (!postProcessor.acceptedModelType().isAssignableFrom(modelType))
-                throw new IllegalArgumentException("PostProcessor cannot treat model type. Current model type = %s, Accepted model type = %s".formatted(modelType, postProcessor.acceptedModelType()));
-            @SuppressWarnings("unchecked") // The model type has been validated above
-            PostProcessor<Model, ?> uncheckedPostProcessor = (PostProcessor<Model, ?>) postProcessor;
-            modelType = uncheckedPostProcessor.processedModelType(modelType);
-        }
-        try (Provider.Result<T> result = provider.provide()) {
-            for (T data : result) {
-                try {
-                    Model model = processor.process(data);
-                    for (PostProcessor<?, ?> postProcessor : postProcessors) {
-                        if (model == null)
-                            break;
-                        @SuppressWarnings("unchecked") // All model types have been validated above
-                        PostProcessor<Model, ?> uncheckedPostProcessor = (PostProcessor<Model, ?>) postProcessor;
-                        model = uncheckedPostProcessor.process(model);
-                    }
-                    if (model != null)
-                        store.add(type, model);
-                } catch (IgnorableException e) {
-                    // TODO Add an exception handling policy
-                    // To fail even on ignorable exceptions:
-                    // throw e;
-                }
-            }
-        } catch (RetryableException e) {
-            // TODO Implement a retry mechanism
-            throw new RuntimeException(e);
-        } catch (IOException | GenerationFailedException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private static void save(File directory, VoxelWorld world) throws MapWriteException {
-        deleteDirectory(directory);
-        if (directory.mkdirs())
-            world.save(directory);
-        else
-            throw new MapWriteException("Cannot generate the map because the folder " + directory.getAbsolutePath() + " cannot be created");
     }
 
     private static void deleteDirectory(File directoryToBeDeleted) {

--- a/src/main/java/com/ignfab/minalac/generator/generation/DataSource.java
+++ b/src/main/java/com/ignfab/minalac/generator/generation/DataSource.java
@@ -1,0 +1,94 @@
+package com.ignfab.minalac.generator.generation;
+
+import java.io.IOException;
+
+import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
+import com.ignfab.minalac.generator.exceptions.IgnorableException;
+import com.ignfab.minalac.generator.exceptions.RetryableException;
+import com.ignfab.minalac.generator.inputs.Provider;
+import com.ignfab.minalac.generator.models.Model;
+import com.ignfab.minalac.generator.models.ModelStore;
+import com.ignfab.minalac.generator.processors.Processor;
+import com.ignfab.minalac.generator.processors.post.PostProcessor;
+
+/**
+ * A data source with a provider, a processor and some (or no) post-processors.
+ */
+public class DataSource {
+    private final ModelStore modelStore;
+    private final String modelType;
+    private final Provider<?> provider;
+    private final Processor<Object, ?> processor;
+    private final PostProcessor<Model, ?>[] postProcessors;
+
+    /**
+     * Creates a new data source.
+     *
+     * @param modelStore where resulting models shoud be stored
+     * @param modelType name of type to be associated with them
+     * @param provider data provider
+     * @param processor processor converting provided data to models
+     * @param postProcessors eventual post-processor to run on created models
+     */
+
+    public DataSource(
+        ModelStore modelStore,
+        String modelType,
+        Provider<?> provider,
+        Processor<?, ? extends Model> processor,
+        PostProcessor<?, ?>[] postProcessors
+    ) {
+        Class<? extends Model> modelClass = processor.modelType();
+
+        if (!processor.acceptedType().isAssignableFrom(provider.providedType()))
+            throw new IllegalArgumentException("Processor cannot treat provided type. Provided = %s, Accepted = %s".formatted(provider.providedType(), processor.acceptedType()));
+
+        for (PostProcessor<?, ?> postProcessor : postProcessors) {
+            if (!postProcessor.acceptedModelType().isAssignableFrom(modelClass))
+                throw new IllegalArgumentException("PostProcessor cannot treat model type. Current model type = %s, Accepted model type = %s".formatted(modelType, postProcessor.acceptedModelType()));
+            @SuppressWarnings("unchecked") // The model type has been validated above
+            PostProcessor<Model, ?> uncheckedPostProcessor = (PostProcessor<Model, ?>) postProcessor;
+            modelClass = uncheckedPostProcessor.processedModelType(modelClass);
+        }
+
+        @SuppressWarnings("unchecked")
+        Processor<Object, ?> uncheckedProcessor = (Processor<Object, ?>) processor;
+        @SuppressWarnings("unchecked")
+        PostProcessor<Model, ?>[] uncheckedPostProcessors = (PostProcessor<Model, ?>[]) postProcessors;
+
+        this.modelStore = modelStore;
+        this.modelType = modelType;
+        this.provider = provider;
+        this.processor = uncheckedProcessor;
+        this.postProcessors = uncheckedPostProcessors;
+    }
+
+    /**
+     * Fetches data from provider, and create and process models.
+     */
+    public void fetch() {
+        try (Provider.Result<?> result = provider.provide()) {
+            for (Object data : result) {
+                try {
+                    Model model = processor.process(data);
+                    for (PostProcessor<Model, ?> postProcessor : postProcessors) {
+                        if (model == null)
+                            break;
+                        model = postProcessor.process(model);
+                    }
+                    if (model != null)
+                        modelStore.add(modelType, model);
+                } catch (IgnorableException e) {
+                    // TODO Add an exception handling policy
+                    // To fail even on ignorable exceptions:
+                    // throw e;
+                }
+            }
+        } catch (RetryableException e) {
+            // TODO Implement a retry mechanism
+            throw new RuntimeException(e);
+        } catch (IOException | GenerationFailedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/generation/Generation.java
+++ b/src/main/java/com/ignfab/minalac/generator/generation/Generation.java
@@ -2,25 +2,26 @@ package com.ignfab.minalac.generator.generation;
 
 import com.ignfab.minalac.generator.exceptions.TransformException;
 import com.ignfab.minalac.generator.models.ModelStore;
-import com.ignfab.minalac.generator.renderers.Renderer;
 import com.ignfab.minalac.generator.utils.coordinates.MapToWorldConverter;
 import com.ignfab.minalac.generator.utils.coordinates.WorldToMapConverter;
+import com.ignfab.minalac.generator.utils.execution.Scheduler;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.world.VoxelWorld;
 import com.ignfab.minalac.generator.utils.random.Seed;
+
 import org.geotools.api.referencing.FactoryException;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.CRS;
 
 import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.util.AffineTransformation;
 
 /**
  * This {@code Generation} class contains information about the ongoing generation
- * such as the voxel world, the renderers or the heightmaps.
+ * such as the voxel world, the scheduler or the heightmaps.
  */
 public class Generation {
     // Main generation seed for random number generation
@@ -39,7 +40,8 @@ public class Generation {
     private final VoxelWorld world;
     private final ModelStore models = new ModelStore();
     private final Store<Heightmap> heightmaps = new Store<>();
-    private final Store<Renderer> renderers = new Store<>();
+
+    private final Scheduler scheduler = new Scheduler();
 
     /**
      * Constructs a new generation context.
@@ -124,11 +126,11 @@ public class Generation {
     }
 
     /**
-     * Returns the {@link Store} for the renderers.
-     * @return the renderers.
+     * Returns the generation scheduler.
+     * @return the scheduler.
      */
-    public Store<Renderer> renderers() {
-        return renderers;
+    public Scheduler scheduler() {
+        return scheduler;
     }
 
     /**
@@ -136,9 +138,9 @@ public class Generation {
      * in a given CRS.
      *
      * @param crs Coordinate reference system to get envelope for.
-     * @return Envelope covering generated world in CRS.
+     * @return ReferencedEnvelope covering generated world in CRS.
      */
-    public Envelope getEnvelopeForCRS(CoordinateReferenceSystem crs) throws FactoryException, TransformException {
+    public ReferencedEnvelope getEnvelopeForCRS(CoordinateReferenceSystem crs) throws FactoryException, TransformException {
         WorldToMapConverter converter = makeCoordsConverter(crs).inverse();
 
         Geometry geom = new GeometryFactory().createLinearRing(new Coordinate[] {
@@ -149,7 +151,7 @@ public class Generation {
             new Coordinate(world.limits().minX(), world.limits().minY())
         });
 
-        return converter.convert(geom).getEnvelopeInternal();
+        return new ReferencedEnvelope(converter.convert(geom).getEnvelopeInternal(), crs);
     }
 
     /**
@@ -181,4 +183,14 @@ public class Generation {
     public Seed seed() {
         return seed;
     }
+
+    /**
+     * Returns target CRS.
+     *
+     * @return CRS used for world rendering
+     */
+    public CoordinateReferenceSystem crs() {
+        return crs;
+    }
+
 }

--- a/src/main/java/com/ignfab/minalac/generator/inputs/Provider.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/Provider.java
@@ -5,6 +5,8 @@ import com.ignfab.minalac.generator.exceptions.RetryableException;
 
 import java.io.Closeable;
 
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+
 /**
  * A provider is responsible for acquiring data.
  * <p>
@@ -20,6 +22,13 @@ import java.io.Closeable;
  * @param <T> The type of provided elements
  */
 public interface Provider<T> {
+    /**
+     * Returns the coordinate reference system of provided data.
+     *
+     * @return CRS of provided data
+     */
+    CoordinateReferenceSystem crs();
+
     /**
      * Returns the type of provided elements.
      *

--- a/src/main/java/com/ignfab/minalac/generator/inputs/URLBuilder.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/URLBuilder.java
@@ -1,0 +1,59 @@
+package com.ignfab.minalac.generator.inputs;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * A URL builder out of base URL and query parameters.
+ */
+public class URLBuilder {
+    private String url;
+    private String params;
+
+    /**
+     * Creates a new URLBuilder.
+     *
+     * @param baseURL base URL including protocol and path but excluding query parameters
+     */
+    public URLBuilder(String baseURL) {
+        url = baseURL;
+        params = "";
+    }
+
+    /**
+     * Adds String typed query parameter to the URL being built.
+     *
+     * @param name Name of the query parameter
+     * @param value Value of that parameter
+     */
+    public void addQueryParameter(String name, String value) {
+        if (params == "")
+            params = "?";
+        else
+            params += "&";
+        params += URLEncoder.encode(name, StandardCharsets.UTF_8) + "=" + URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Adds int typed query parameter to the URL being built.
+     *
+     * @param name Name of the query parameter
+     * @param value Value of that parameter
+     */
+    public void addQueryParameter(String name, int value) {
+        addQueryParameter(name, String.valueOf(value));
+    }
+
+    /**
+     * Actually builds URL into a {@code java.net.URL} object.
+     *
+     * @return built URL
+     *
+     * @throws MalformedURLException if build URL is invalid (most likely due to incorrect base URL)
+     */
+    public URL toURL() throws MalformedURLException {
+        return new URL(url + params);
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/inputs/WFS1_1_GML3_1_DataProvider.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/WFS1_1_GML3_1_DataProvider.java
@@ -3,7 +3,10 @@ package com.ignfab.minalac.generator.inputs;
 import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
 import com.ignfab.minalac.generator.exceptions.RetryableException;
 import org.geotools.api.feature.simple.SimpleFeature;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.data.simple.SimpleFeatureIterator;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.CRS;
 import org.geotools.wfs.GML;
 import org.xml.sax.SAXException;
 
@@ -12,7 +15,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.Iterator;
 
 /**
@@ -20,15 +22,24 @@ import java.util.Iterator;
  */
 @SuppressWarnings("checkstyle:TypeName") // Underscore character used to better identify "WFS 1.1" and "GML 3.1"
 public class WFS1_1_GML3_1_DataProvider implements Provider<SimpleFeature> {
+    private static final String SERVICE = "WFS";
+    private static final String VERSION = "2.0.0";
+
     private final String baseURL;
+    private final String type;
+    private final ReferencedEnvelope envelope;
 
     /**
      * Constructs a new {@code WFS1_1_GML3_1_DataProvider}.
      *
-     * @param baseURL the base URL.
+     * @param baseURL the base URL
+     * @param type Name of the WFS feature type to query
+     * @param envelope Limit of area to fetch
      */
-    public WFS1_1_GML3_1_DataProvider(String baseURL) {
+    public WFS1_1_GML3_1_DataProvider(String baseURL, String type, ReferencedEnvelope envelope) {
         this.baseURL = baseURL;
+        this.type = type;
+        this.envelope = envelope;
     }
 
     @Override
@@ -38,29 +49,49 @@ public class WFS1_1_GML3_1_DataProvider implements Provider<SimpleFeature> {
 
     @Override
     public Result<SimpleFeature> provide() throws GenerationFailedException, RetryableException {
-        GML gml = new GML(GML.Version.GML3);
 
-        URL url;
+        String srsname = CRS.toSRS(envelope.getCoordinateReferenceSystem());
+        if (srsname == null)
+            throw new GenerationFailedException("Could not retrieve SRS name for layer");
+
+        URLBuilder url = new URLBuilder(baseURL);
+        url.addQueryParameter("SERVICE", SERVICE);
+        url.addQueryParameter("VERSION", VERSION);
+        url.addQueryParameter("REQUEST", "GetFeature");
+        url.addQueryParameter("OUTPUTFORMAT", "GML3");
+        url.addQueryParameter("TYPENAMES", type);
+        url.addQueryParameter("SRSNAME", srsname);
+        url.addQueryParameter("BBOX", envelope.getMinX() + "," + envelope.getMinY() + "," + envelope.getMaxX() + "," + envelope.getMaxY() + "," + srsname);
+        url.addQueryParameter("STARTINDEX", 0);
+        url.addQueryParameter("COUNT", 1000);
+
+        InputStream stream;
         try {
-            url = new URL(baseURL);
+            stream = url.toURL().openStream(); // TODO Replace with an HTTP requesting tool to allow unit testing and snapshots
         } catch (MalformedURLException e) {
-            throw new GenerationFailedException("Malformed data source URL", e);
+            throw new GenerationFailedException("Invalid URL for layer", e);
+        } catch (IOException e) {
+            throw new RetryableException("Error opening connection", e);
         }
 
+        // This code is temporary and no attention is given to its (bad) performance
+        // TODO: Improve that!
+        byte[] bytes;
         try {
-            InputStream stream = url.openStream(); // TODO Replace with an HTTP requesting tool to allow unit testing and snapshots
-
-            // Invalidate schema declaration because GML version 3.1 is not used in this schema (version is unspecified, defaulting to 3.2)
-            // This code is temporary and no attention is given to its (bad) performance
-            // TODO: Improve that!
-            byte[] bytes = stream.readAllBytes();
+            bytes = stream.readAllBytes();
             stream.close();
-            String string = new String(bytes).replace("http://BDTOPO_V3", "explicitly-invalid");
-            InputStream replacedStream = new ByteArrayInputStream(string.getBytes());
-
-            return new FeaturesResult(gml.decodeFeatureCollection(replacedStream).features(), replacedStream);
         } catch (IOException e) {
-            throw new RetryableException(e);
+            throw new RetryableException("Error opening connection", e);
+        }
+
+        // Invalidate schema declaration because GML version 3.1 is not used in this schema (version is unspecified, defaulting to 3.2)
+        String string = new String(bytes).replace("http://BDTOPO_V3", "explicitly-invalid");
+        InputStream replacedStream = new ByteArrayInputStream(string.getBytes());
+
+        try {
+            return new FeaturesResult(new GML(GML.Version.GML3).decodeFeatureCollection(replacedStream).features(), replacedStream);
+        } catch (IOException e) {
+            throw new RetryableException("Error fetching data", e);
         } catch (ParserConfigurationException | SAXException e) {
             throw new GenerationFailedException("Unable to decode features", e);
         }
@@ -89,5 +120,10 @@ public class WFS1_1_GML3_1_DataProvider implements Provider<SimpleFeature> {
                 return features.next();
             }
         }
+    }
+
+    @Override
+    public CoordinateReferenceSystem crs() {
+        return envelope.getCoordinateReferenceSystem();
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/inputs/WMSFloatBilDataProvider.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/WMSFloatBilDataProvider.java
@@ -3,14 +3,13 @@ package com.ignfab.minalac.generator.inputs;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
-import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Iterator;
 
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.CRS;
-import org.locationtech.jts.geom.Envelope;
 
 import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
 import com.ignfab.minalac.generator.exceptions.RetryableException;
@@ -20,22 +19,26 @@ import com.ignfab.minalac.generator.utils.iterator.Iterators;
  * Data provider for Web Map Service (raster data).
  */
 public class WMSFloatBilDataProvider implements Provider<FloatGeographicDataMatrix2d> {
+    private static final String SERVICE = "WMS";
+    private static final String VERSION = "1.3.0";
+
     private final String baseURL;
-    private final CoordinateReferenceSystem crs;
-    private final Envelope envelope;
+    private final String layer;
+    private final ReferencedEnvelope envelope;
+
     private final int width;
     private final int height;
 
     /**
      * Creates a new {@code WMSDataProvider}.
      *
-     * @param baseURL base URL of the service (should include {@code service=} parameter but no other)
-     * @param crs Coordinate reference system to be used for data downloading and processing
-     * @param envelope Limit of area to fetch
+     * @param baseURL base URL of the service
+     * @param layer name of the WMS layer to query
+     * @param envelope limit of area to fetch
      */
-    public WMSFloatBilDataProvider(String baseURL, CoordinateReferenceSystem crs, Envelope envelope) {
+    public WMSFloatBilDataProvider(String baseURL, String layer, ReferencedEnvelope envelope) {
         this.baseURL = baseURL;
-        this.crs = crs;
+        this.layer = layer;
         this.envelope = envelope;
 
         // Let's say we want heightmap with 1 map unit precision.
@@ -53,32 +56,46 @@ public class WMSFloatBilDataProvider implements Provider<FloatGeographicDataMatr
 
     @Override
     public Provider.Result<FloatGeographicDataMatrix2d> provide() throws GenerationFailedException, RetryableException {
-        int size = 4 * width * height;
+        String srsname = CRS.toSRS(envelope.getCoordinateReferenceSystem());
+        if (srsname == null)
+            throw new GenerationFailedException("Could not retrieve SRS name for layer");
+
+        URLBuilder url = new URLBuilder(baseURL);
+        url.addQueryParameter("SERVICE", SERVICE);
+        url.addQueryParameter("VERSION", VERSION);
+        url.addQueryParameter("REQUEST", "GetMap");
+        url.addQueryParameter("LAYERS", layer);
+        url.addQueryParameter("FORMAT", "image/x-bil;bits=32");
+        url.addQueryParameter("STYLES", "");
+        url.addQueryParameter("CRS", srsname);
+        url.addQueryParameter("BBOX", envelope.getMinX() + "," + envelope.getMinY() + "," + envelope.getMaxX() + "," + envelope.getMaxY());
+        url.addQueryParameter("WIDTH", width);
+        url.addQueryParameter("HEIGHT", height);
 
         InputStream inputStream;
         try {
-            inputStream = new URL(baseURL
-                + "&FORMAT=image/x-bil;bits=32&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&STYLES="
-                + "&CRS=" + CRS.toSRS(crs) // TODO: Check we have a SRS!
-                + "&BBOX=" + envelope.getMinX() + "," + envelope.getMinY() + "," + envelope.getMaxX() + "," + envelope.getMaxY()
-                + "&WIDTH=" + width +  "&HEIGHT=" + height
-                ).openStream();
+            inputStream = url.toURL().openStream();
         } catch (MalformedURLException e) {
-            throw new GenerationFailedException("Shouldn't have happened", e);
+            throw new GenerationFailedException("Invalid URL for layer", e);
         } catch (IOException e) {
             throw new RetryableException("Error opening connection", e);
         }
 
-        byte[] data = new byte[size];
-
+        int size = 4 * width * height;
         int total = 0;
-        int read;
+
+        byte[] data = new byte[size];
         try {
+            int read;
             while (0 < (read = inputStream.read(data, total, size - total)))
                 total = total + read;
         } catch (IOException e) {
             throw new RetryableException("Error fetching data", e);
         }
+
+        try {
+            inputStream.close();
+        } catch (IOException ignored) {}
 
         if (total != size)
             throw new RetryableException("Incomplete data read from stream");
@@ -92,6 +109,7 @@ public class WMSFloatBilDataProvider implements Provider<FloatGeographicDataMatr
             envelope.getHeight() / height);
 
         ByteBuffer.wrap(data).order(ByteOrder.LITTLE_ENDIAN).asFloatBuffer().get(result.data());
+
         return new Result(result);
     }
 
@@ -108,6 +126,11 @@ public class WMSFloatBilDataProvider implements Provider<FloatGeographicDataMatr
 
         @Override
         public void close() throws IOException {}
+    }
+
+    @Override
+    public CoordinateReferenceSystem crs() {
+        return envelope.getCoordinateReferenceSystem();
     }
 
 }

--- a/src/main/java/com/ignfab/minalac/generator/parameters/DataSourceParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/DataSourceParams.java
@@ -1,0 +1,72 @@
+package com.ignfab.minalac.generator.parameters;
+
+import java.beans.ConstructorProperties;
+import java.util.List;
+
+import com.ignfab.minalac.generator.generation.DataSource;
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.inputs.Provider;
+import com.ignfab.minalac.generator.parameters.processors.ProcessorParams;
+import com.ignfab.minalac.generator.parameters.providers.ProviderParams;
+import com.ignfab.minalac.generator.processors.Processor;
+import com.ignfab.minalac.generator.processors.post.PostProcessor;
+
+/**
+ * Represents the parameters used for {@link DataSource} creation.
+ */
+// Since attributes are purposely kept public for this class the checkstyle for visibility is disabled.
+@SuppressWarnings("checkstyle:VisibilityModifier")
+public class DataSourceParams {
+    /**
+     * Type to give to provided models (required).
+     */
+    public String modelType;
+
+    /**
+     * Data provider (required).
+     */
+    public ProviderParams provider;
+
+    /**
+     * Data processor (required).
+     */
+    public ProcessorParams processor;
+
+    /**
+     * Dependencies (optional).
+     */
+    public List<String> after;
+
+   /**
+     * Constructor used to ensure that the required fields are present during deserialization.
+     *
+     * @param modelType type to give to resulting models
+     * @param provider data provider for this source
+     * @param processor data processor for provided data
+     */
+    @ConstructorProperties({"modelType", "provider", "processor"})
+    public DataSourceParams(String modelType, ProviderParams provider, ProcessorParams processor) {
+        this.modelType = modelType;
+        this.provider = provider;
+        this.processor = processor;
+    }
+
+    /**
+     * Creates the corresponding {@code DataSource}.
+     *
+     * @param generation the generation context
+     * @return the created data source
+     */
+    public DataSource create(Generation generation) {
+        Provider<?> provider = this.provider.create(generation);
+        Processor<?, ?> processor = this.processor.create(generation, provider.crs());
+
+        return new DataSource(
+            generation.models(),
+            modelType,
+            provider,
+            processor,
+            new PostProcessor<?, ?>[]{});
+            //TODO: Manage postprocessors
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/parameters/GenerationCreator.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/GenerationCreator.java
@@ -1,9 +1,11 @@
 package com.ignfab.minalac.generator.parameters;
 
+import com.ignfab.minalac.generator.generation.DataSource;
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.outputs.minecraft.MCVoxelWorld;
 import com.ignfab.minalac.generator.outputs.minetest.MTVoxelWorld;
 import com.ignfab.minalac.generator.utils.random.Seed;
+import com.ignfab.minalac.generator.renderers.Renderer;
 import com.ignfab.minalac.generator.world.VoxelWorld;
 import org.geotools.api.geometry.Position;
 import org.geotools.api.referencing.FactoryException;
@@ -71,10 +73,23 @@ public final class GenerationCreator {
             )
         );
 
+        // Data Sources scheduling
+        params.sources.forEach((name, dataSourceParams) -> {
+            DataSource dataSource = dataSourceParams.create(generation);
+            generation.scheduler().schedule(
+                "source:" + name,
+                dataSource::fetch,
+                dataSourceParams.after
+            );
+        });
+
+        // Renderers scheduling
         params.renderers.forEach((name, rendererParams) -> {
-            generation.renderers().add(
-                name,
-                rendererParams.create(generation)
+            Renderer renderer = rendererParams.create(generation);
+            generation.scheduler().schedule(
+                "renderer:" + name,
+                () -> renderer.render(generation.world().limits()),
+                rendererParams.after
             );
         });
 

--- a/src/main/java/com/ignfab/minalac/generator/parameters/GenerationParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/GenerationParams.java
@@ -74,6 +74,17 @@ public class GenerationParams {
     public Map<String, HeightmapParams> heightmaps = new LinkedHashMap<>();
 
     /**
+     * The map of sources used during the generation.
+     * This field is optional.
+     */
+    @JsonSetter(
+        nulls = Nulls.SKIP,
+        // To prevent null values on required field of an element of the map.
+        contentNulls = Nulls.FAIL
+    )
+    public Map<String, DataSourceParams> sources = new LinkedHashMap<>();
+
+    /**
      * The map of renderers used during the generation.
      * This field is optional.
      */

--- a/src/main/java/com/ignfab/minalac/generator/parameters/ParamsParser.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/ParamsParser.java
@@ -6,8 +6,6 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.ignfab.minalac.generator.parameters.renderers.RendererParams;
-
 
 /**
  * A Json/Yaml parser able to decode parameters into a {@code Generation} object.
@@ -48,13 +46,13 @@ public class ParamsParser {
     }
 
     /**
-     * Registers a new {@link com.ignfab.minalac.generator.parameters.renderers.RendererParams}.
+     * Registers a new {@link PolymorphicParams}.
      *
      * @param name the name used to associate the class during deserialization
-     * @param clazz The concrete class extending {@code RendererParams}
-     * @param <T> The type of the {@code RendererParams} subclass
+     * @param clazz The concrete class extending {@code PolymorphicParams}
+     * @param <T> The type of the {@code PolymorphicParams} subclass
      */
-    public <T extends RendererParams> void registerRenderer(String name, Class<T> clazz) {
+    public <T extends PolymorphicParams> void registerParams(String name, Class<T> clazz) {
         mapper.registerSubtypes(new NamedType(clazz, name));
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/parameters/PolymorphicParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/PolymorphicParams.java
@@ -1,0 +1,23 @@
+package com.ignfab.minalac.generator.parameters;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+/**
+ * Base class for all polymorphic parameters with validation.
+ */
+@SuppressWarnings("checkstyle:VisibilityModifier")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+public class PolymorphicParams {
+    /**
+     * This field is required.
+     * It is not deserialized but used to find out the class of parameters to deserialize.
+     */
+    public String type;
+
+    /**
+     * Checks if there are any blatantly invalid parameters.
+     *
+     * @throws IllegalArgumentException is any of the parameters is invalid.
+     */
+    public void validate() throws IllegalArgumentException {}
+}

--- a/src/main/java/com/ignfab/minalac/generator/parameters/processors/FloatMatrixProcessorParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/processors/FloatMatrixProcessorParams.java
@@ -1,0 +1,24 @@
+package com.ignfab.minalac.generator.parameters.processors;
+
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.inputs.FloatGeographicDataMatrix2d;
+import com.ignfab.minalac.generator.models.FloatMatrixModel;
+import com.ignfab.minalac.generator.processors.FloatMatrixProcessor;
+import com.ignfab.minalac.generator.processors.Processor;
+
+/**
+ * Parameters for float matrix processors.
+ */
+public class FloatMatrixProcessorParams extends ProcessorParams {
+    @Override
+    public Processor<FloatGeographicDataMatrix2d, FloatMatrixModel> create(Generation generation, CoordinateReferenceSystem layerCrs) {
+        try {
+            return new FloatMatrixProcessor(generation.makeCoordsConverter(layerCrs));
+        } catch (FactoryException e) {
+            throw new IllegalArgumentException("Could not find a converter from layer to generation CRS", e);
+        }
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/parameters/processors/GeoToolsVectorProcessorParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/processors/GeoToolsVectorProcessorParams.java
@@ -1,0 +1,24 @@
+package com.ignfab.minalac.generator.parameters.processors;
+
+import org.geotools.api.feature.simple.SimpleFeature;
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.models.JTSGeometryModel;
+import com.ignfab.minalac.generator.processors.GeoToolsVectorProcessor;
+import com.ignfab.minalac.generator.processors.Processor;
+
+/**
+ * Parameters for GeoTools vector processors.
+ */
+public class GeoToolsVectorProcessorParams extends ProcessorParams {
+    @Override
+    public Processor<SimpleFeature, JTSGeometryModel> create(Generation generation, CoordinateReferenceSystem layerCrs) {
+        try {
+            return new GeoToolsVectorProcessor(generation.makeCoordsConverter(layerCrs));
+        } catch (FactoryException e) {
+            throw new IllegalArgumentException("Could not find a converter from layer to generation CRS", e);
+        }
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/parameters/processors/ProcessorParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/processors/ProcessorParams.java
@@ -1,0 +1,21 @@
+package com.ignfab.minalac.generator.parameters.processors;
+
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.parameters.PolymorphicParams;
+import com.ignfab.minalac.generator.processors.Processor;
+
+/**
+ * Represents the parameters of a type of {@link Processor}.
+ */
+public abstract class ProcessorParams extends PolymorphicParams {
+    /**
+     * Creates the corresponding {@code Processor}.
+     *
+     * @param generation the generation context
+     * @param layerCrs CRS of the layer to be processed
+     * @return the resulting processor
+     */
+    public abstract Processor<?, ?> create(Generation generation, CoordinateReferenceSystem layerCrs);
+}

--- a/src/main/java/com/ignfab/minalac/generator/parameters/providers/ProviderParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/providers/ProviderParams.java
@@ -1,0 +1,18 @@
+package com.ignfab.minalac.generator.parameters.providers;
+
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.inputs.Provider;
+import com.ignfab.minalac.generator.parameters.PolymorphicParams;
+
+/**
+ * Represents the parameters of a type of {@link Provider}.
+ */
+public abstract class ProviderParams extends PolymorphicParams {
+    /**
+     * Creates the corresponding {@code Provider}.
+     *
+     * @param generation the generation context
+     * @return the resulting provider
+     */
+    public abstract Provider<?> create(Generation generation);
+}

--- a/src/main/java/com/ignfab/minalac/generator/parameters/providers/WFSProviderParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/providers/WFSProviderParams.java
@@ -1,0 +1,69 @@
+package com.ignfab.minalac.generator.parameters.providers;
+
+import java.beans.ConstructorProperties;
+
+import org.geotools.api.feature.simple.SimpleFeature;
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.CRS;
+
+import com.ignfab.minalac.generator.exceptions.TransformException;
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.inputs.Provider;
+import com.ignfab.minalac.generator.inputs.WFS1_1_GML3_1_DataProvider;
+
+/**
+ * Parameters for WFS providers.
+ */
+@SuppressWarnings("checkstyle:VisibilityModifier")
+public class WFSProviderParams extends ProviderParams {
+    /**
+     * Base URL for WFS queries (required).
+     */
+    public String url;
+
+    /**
+     * Type of features to fetch (required).
+     */
+    public String features;
+
+    /**
+     * Coordinate reference system (optional, default: target CRS).
+     */
+    public String crs;
+
+    /**
+     * Creates a new WFSProviderParams with mandatory fields.
+     *
+     * @param url Base URL for WFS queries (including protocol, port, domain name and path but not query arguments)
+     * @param features Type of features to ask for
+     */
+    @ConstructorProperties({"url", "features"})
+    public WFSProviderParams(String url, String features) {
+        this.url = url;
+        this.features = features;
+    }
+
+    @Override
+    public Provider<SimpleFeature> create(Generation generation) {
+        CoordinateReferenceSystem layerCrs;
+        if (crs != null)
+            try {
+                layerCrs = CRS.decode(crs);
+            } catch (FactoryException e) {
+                throw new IllegalArgumentException("CRS code \"%s\" is invalid".formatted(crs), e);
+            }
+        else
+            layerCrs = generation.crs();
+
+        ReferencedEnvelope envelope;
+        try {
+            envelope = generation.getEnvelopeForCRS(layerCrs);
+        } catch (FactoryException | TransformException e) {
+            throw new IllegalArgumentException("Unable to compute envelope for given CRS", e);
+        }
+
+        return new WFS1_1_GML3_1_DataProvider(url, features, envelope);
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/parameters/providers/WMSFloatBilProviderParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/providers/WMSFloatBilProviderParams.java
@@ -1,0 +1,69 @@
+package com.ignfab.minalac.generator.parameters.providers;
+
+import java.beans.ConstructorProperties;
+
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.CRS;
+
+import com.ignfab.minalac.generator.exceptions.TransformException;
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.inputs.FloatGeographicDataMatrix2d;
+import com.ignfab.minalac.generator.inputs.Provider;
+import com.ignfab.minalac.generator.inputs.WMSFloatBilDataProvider;
+
+/**
+ * Parameters for WMS float providers.
+ */
+@SuppressWarnings("checkstyle:VisibilityModifier")
+public class WMSFloatBilProviderParams extends ProviderParams {
+    /**
+     * Base URL for WFS queries (required).
+     */
+    public String url;
+
+    /**
+     * Layer to fetch (required).
+     */
+    public String layer;
+
+    /**
+     * Coordinate reference system (optional, default: target CRS).
+     */
+    public String crs;
+
+    /**
+     * Creates a new WFSProviderParams with mandatory fields.
+     *
+     * @param url Base URL for WFS queries (including protocol, port, domain name and directories but not query arguments)
+     * @param layer Type of features to ask for
+     */
+    @ConstructorProperties({"url", "layer"})
+    public WMSFloatBilProviderParams(String url, String layer) {
+        this.url = url;
+        this.layer = layer;
+    }
+
+    @Override
+    public Provider<FloatGeographicDataMatrix2d> create(Generation generation) {
+        CoordinateReferenceSystem layerCrs;
+        if (crs != null)
+            try {
+                layerCrs = CRS.decode(crs);
+            } catch (FactoryException e) {
+                throw new IllegalArgumentException("CRS code \"%s\" is invalid".formatted(crs), e);
+            }
+        else
+            layerCrs = generation.crs();
+
+        ReferencedEnvelope envelope;
+        try {
+            envelope = generation.getEnvelopeForCRS(layerCrs);
+        } catch (FactoryException | TransformException e) {
+            throw new IllegalArgumentException("Unable to compute envelope for given CRS", e);
+        }
+
+        return new WMSFloatBilDataProvider(url, layer, envelope);
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/parameters/renderers/GroundRendererParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/renderers/GroundRendererParams.java
@@ -1,0 +1,63 @@
+package com.ignfab.minalac.generator.parameters.renderers;
+
+import java.beans.ConstructorProperties;
+import java.util.LinkedHashMap;
+
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.renderers.GroundRenderer;
+import com.ignfab.minalac.generator.renderers.Renderer;
+import com.ignfab.minalac.generator.world.SemanticType;
+import com.ignfab.minalac.generator.world.SimpleVoxelPattern;
+import com.ignfab.minalac.generator.world.VoxelType;
+
+/**
+ * Parameters for a {@link GroundRenderer}.
+ *
+ * Until voxel structures are serializable, this perform a basic voxel structure creation
+ */
+@SuppressWarnings("checkstyle:VisibilityModifier")
+public class GroundRendererParams extends RendererParams {
+    /**
+     * The name of the heightmap to use (required).
+     */
+    public String heightmap;
+    /**
+     * List of voxel types and thickness (temporary, to be replaced with structures).
+     * THIS WILL NOT SUPPORT DUPLICATE TYPES
+     */
+    public LinkedHashMap<SemanticType, Integer> voxels;
+
+    /**
+     * Constructor used to ensure that the required fields are present during deserialization.
+     *
+     * @param heightmap the name of the heightmap to use
+     * @param voxels voxels to place as a pair of voxel type and number to place all the way down
+     */
+    @ConstructorProperties({"heightmap", "voxels"})
+    public GroundRendererParams(String heightmap, LinkedHashMap<SemanticType, Integer> voxels) {
+        this.heightmap = heightmap;
+        this.voxels = voxels;
+    }
+
+    @Override
+    public void validate() throws IllegalArgumentException {
+        if (heightmap.isEmpty())
+            throw new IllegalArgumentException("The field heightmap cannot be empty");
+    }
+
+    @Override
+    public Renderer create(Generation generation) {
+        SimpleVoxelPattern pattern = new SimpleVoxelPattern();
+        int z = 0;
+        for (SemanticType st : voxels.keySet()) {
+            VoxelType vt = generation.world().getFactory().createVoxelType(st);
+            int count = voxels.get(st);
+            while (count > 0) {
+                count--;
+                pattern.set(0, 0, z, vt);
+                z--;
+            }
+        }
+        return new GroundRenderer(generation.heightmaps().get(heightmap), pattern);
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/parameters/renderers/HeightmapRendererParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/renderers/HeightmapRendererParams.java
@@ -10,7 +10,6 @@ import java.beans.ConstructorProperties;
 /**
  * Concrete class of {@link RendererParams} representing the parameters of a {@link HeightmapRenderer}.
  */
-// Since attributes are purposely kept public for this class the checkstyle for visibility is disabled.
 @SuppressWarnings("checkstyle:VisibilityModifier")
 public class HeightmapRendererParams extends RendererParams {
     /**

--- a/src/main/java/com/ignfab/minalac/generator/parameters/renderers/RendererParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/renderers/RendererParams.java
@@ -1,36 +1,20 @@
 package com.ignfab.minalac.generator.parameters.renderers;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.util.List;
+
 import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.parameters.PolymorphicParams;
 import com.ignfab.minalac.generator.renderers.Renderer;
 
 /**
  * Represents the parameters of a type of {@link Renderer}.
- * The concrete class is resolved by using the value of the {@link RendererParams#type}.
- * Mapping a value with a class can be done by using {@link com.ignfab.minalac.generator.parameters.ParamsParser#registerRenderer(String, Class)}.
  */
-@JsonTypeInfo(
-    // name id used by jackson to map implementation classes. The id is created by jackson if not provided.
-    use = JsonTypeInfo.Id.NAME,
-    property = "type"
-)
-// Since attributes are purposely kept public for this class the checkstyle for visibility is disabled.
 @SuppressWarnings("checkstyle:VisibilityModifier")
-public abstract class RendererParams {
-    // This property isn't deserialized.
-    // If deserialization is needed, fields `include = JsonTypeInfo.As.EXISTING_PROPERTY` and `visible = true` should be added.
+public abstract class RendererParams extends PolymorphicParams {
     /**
-     * This field is required.
-     * It is not deserialized but used to find out the concrete class of the renderer.
+     * Dependencies (optional).
      */
-    public String type;
-
-    /**
-     * Checks if there are any blatantly invalid parameters.
-     *
-     * @throws IllegalArgumentException is any of the parameters is invalid.
-     */
-    public void validate() throws IllegalArgumentException {}
+    public List<String> after;
 
     /**
      * Creates the corresponding {@code Renderer}.

--- a/src/main/java/com/ignfab/minalac/generator/utils/execution/ScheduledTask.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/execution/ScheduledTask.java
@@ -36,6 +36,9 @@ public class ScheduledTask {
     public ScheduledTask(String id, Runnable task, Collection<String> conditions) {
         this.id = id;
         this.task = task;
+        if (conditions == null)
+            conditions = Collections.emptyList();
+
         // Synchronized collections are thread-safe equivalent of regular collections
         // This is important to ensure no problem occurs if two required tasks finishes at the same time
         this.conditions = Collections.synchronizedSet(new HashSet<>(conditions));
@@ -55,7 +58,9 @@ public class ScheduledTask {
      * This method will return when the runnable returns.
      */
     public void run() {
+        System.out.printf("[%s] %s%n", Thread.currentThread().getName(), "Starting " + id);
         task.run();
+        System.out.printf("[%s] %s%n", Thread.currentThread().getName(), id + " finished");
     }
 
     /**

--- a/src/test/java/com/ignfab/minalac/generator/inputs/TestingProvider.java
+++ b/src/test/java/com/ignfab/minalac/generator/inputs/TestingProvider.java
@@ -1,0 +1,29 @@
+package com.ignfab.minalac.generator.inputs;
+
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+
+import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
+import com.ignfab.minalac.generator.exceptions.RetryableException;
+
+public class TestingProvider implements Provider<String> {
+    private CoordinateReferenceSystem crs;
+
+    public TestingProvider(CoordinateReferenceSystem crs) {
+        this.crs = crs;
+    }
+
+    @Override
+    public Class<String> providedType() {
+        return String.class;
+    }
+
+    @Override
+    public Result<String> provide() throws GenerationFailedException, RetryableException {
+        return null;
+    }
+
+    @Override
+    public CoordinateReferenceSystem crs() {
+        return crs;
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/models/TestingModel.java
+++ b/src/test/java/com/ignfab/minalac/generator/models/TestingModel.java
@@ -1,11 +1,12 @@
-package com.ignfab.minalac.generator.processors.post;
-
-import com.ignfab.minalac.generator.models.Model;
+package com.ignfab.minalac.generator.models;
 
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * A testing model with only metadata and assertions.
+ */
 public class TestingModel extends Model {
     public TestingModel() {}
 

--- a/src/test/java/com/ignfab/minalac/generator/outputs/testing/TestingVoxelWorld.java
+++ b/src/test/java/com/ignfab/minalac/generator/outputs/testing/TestingVoxelWorld.java
@@ -37,12 +37,18 @@ public class TestingVoxelWorld extends VoxelWorld {
         factory = new TestingVoxelTypeFactory(this);
         maxLimits = bbox;
         voxels = new String[bbox.size().volume()];
-        setLimits(bbox);
+        super.setLimits(bbox);
     }
 
     @Override
     public WorldBBox3d maxLimits() {
         return maxLimits;
+    }
+
+    // Avoid "Limits already set" when performing deserialization tests
+    // and get rid of .setLimits in rendering tests
+    @Override
+    public void setLimits(WorldBBox3d bbox) {
     }
 
     @Override

--- a/src/test/java/com/ignfab/minalac/generator/parameters/GenerationParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/GenerationParamsTest.java
@@ -2,8 +2,10 @@ package com.ignfab.minalac.generator.parameters;
 
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.generation.Heightmap;
-import com.ignfab.minalac.generator.parameters.renderers.VectorRendererParams;
-import com.ignfab.minalac.generator.world.SemanticType;
+import com.ignfab.minalac.generator.parameters.processors.TestingProcessorParams;
+import com.ignfab.minalac.generator.parameters.providers.TestingProviderParams;
+import com.ignfab.minalac.generator.parameters.renderers.TestingRendererParams;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -107,12 +109,11 @@ public class GenerationParamsTest {
         params.crs = "EPSG:5643";
         params.heightmaps.put("ground", new HeightmapParams("0"));
         params.heightmaps.put("altitude", new HeightmapParams("minimal"));
-        params.renderers.put("building", new VectorRendererParams(
-            "building",
-            "ground",
-            SemanticType.COBBLE,
-            SemanticType.STONE)
-        );
+        params.renderers.put("renderer1", new TestingRendererParams("value1"));
+        params.renderers.put("renderer2", new TestingRendererParams("value2"));
+        params.sources.put("source1", new DataSourceParams("models1", new TestingProviderParams("value3"), new TestingProcessorParams("value4")));
+        params.sources.put("source2", new DataSourceParams("models2", new TestingProviderParams("value5"), new TestingProcessorParams("value6")));
+
         Generation generation = params.create();
 
         assertNotNull(generation);
@@ -125,7 +126,5 @@ public class GenerationParamsTest {
 
         Heightmap altitude = assertDoesNotThrow(() -> generation.heightmaps().get("altitude"));
         assertEquals(Integer.MIN_VALUE, altitude.get(0, 0));
-
-        assertDoesNotThrow(() -> generation.renderers().get("building"));
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/parameters/ParamsParserTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/ParamsParserTest.java
@@ -1,13 +1,9 @@
 package com.ignfab.minalac.generator.parameters;
 
-import com.fasterxml.jackson.annotation.JsonSetter;
-import com.fasterxml.jackson.annotation.Nulls;
-import com.ignfab.minalac.generator.generation.Generation;
-import com.ignfab.minalac.generator.parameters.renderers.RendererParams;
-import com.ignfab.minalac.generator.renderers.Renderer;
+import com.ignfab.minalac.generator.parameters.renderers.TestingRendererParams;
+
 import org.junit.jupiter.api.Test;
 
-import java.beans.ConstructorProperties;
 import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -189,7 +185,7 @@ public class ParamsParserTest {
         ), "Type field is missing");
 
         ParamsParser parser = new ParamsParser();
-        parser.registerRenderer("customIdentifier", TestingRendererParams.class);
+        parser.registerParams("customIdentifier", TestingRendererParams.class);
 
         GenerationParams genParams = assertDoesNotThrow(() -> parser.parse("""
             renderers:
@@ -216,36 +212,5 @@ public class ParamsParserTest {
             """
             + MINIMAL_YAML
         ), "Wrong type field value");
-    }
-
-    /**
-     * A RendererParams class for testing purposes.
-     */
-    @SuppressWarnings("checkstyle:VisibilityModifier")
-    public static class TestingRendererParams extends RendererParams {
-        /**
-         * A required field.
-         */
-        public String requiredField;
-        /**
-         * An optional field.
-         */
-        @JsonSetter(nulls = Nulls.SKIP)
-        public String optionalField = "defaultOptionalValue";
-
-        /**
-         * Constructor used to ensure that the required fields are present during deserialization.
-         *
-         * @param requiredField the required field.
-         */
-        @ConstructorProperties({"requiredField"})
-        public TestingRendererParams(String requiredField) {
-            this.requiredField = requiredField;
-        }
-
-        @Override
-        public Renderer create(Generation generation) {
-            throw new UnsupportedOperationException("This class is only for testing deserialization mechanisms");
-        }
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/parameters/processors/FloatMatrixProcessorParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/processors/FloatMatrixProcessorParamsTest.java
@@ -1,0 +1,33 @@
+package com.ignfab.minalac.generator.parameters.processors;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.NoSuchAuthorityCodeException;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.referencing.CRS;
+import org.junit.jupiter.api.Test;
+
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+
+public class FloatMatrixProcessorParamsTest {
+    @Test
+    public void testCreate() throws NoSuchAuthorityCodeException, FactoryException {
+        CoordinateReferenceSystem crs2154 = CRS.decode("EPSG:2154");
+        CoordinateReferenceSystem crs4326 = CRS.decode("EPSG:4326");
+
+        Generation generation = new Generation(
+            new TestingVoxelWorld(
+                new WorldBBox3d(-10, -10, -10, 20, 20, 20)
+            ), null, crs2154, 0, 0, 20, 20, 1, 1);
+
+        // A simple OK test with same CRS
+        final FloatMatrixProcessorParams params = new FloatMatrixProcessorParams();
+        assertDoesNotThrow(() -> params.create(generation, crs2154));
+
+        // A OK test with different CRS
+        assertDoesNotThrow(() -> params.create(generation, crs4326));
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/parameters/processors/GeoToolsVectorProcessorParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/processors/GeoToolsVectorProcessorParamsTest.java
@@ -1,0 +1,33 @@
+package com.ignfab.minalac.generator.parameters.processors;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.NoSuchAuthorityCodeException;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.referencing.CRS;
+import org.junit.jupiter.api.Test;
+
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+
+public class GeoToolsVectorProcessorParamsTest {
+    @Test
+    public void testCreate() throws NoSuchAuthorityCodeException, FactoryException {
+        CoordinateReferenceSystem crs2154 = CRS.decode("EPSG:2154");
+        CoordinateReferenceSystem crs4326 = CRS.decode("EPSG:4326");
+
+        Generation generation = new Generation(
+            new TestingVoxelWorld(
+                new WorldBBox3d(-10, -10, -10, 20, 20, 20)
+            ), null, crs2154, 0, 0, 20, 20, 1, 1);
+
+        // A simple OK test with same CRS
+        final GeoToolsVectorProcessorParams params = new GeoToolsVectorProcessorParams();
+        assertDoesNotThrow(() -> params.create(generation, crs2154));
+
+        // A OK test with different CRS
+        assertDoesNotThrow(() -> params.create(generation, crs4326));
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/parameters/processors/TestingProcessorParams.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/processors/TestingProcessorParams.java
@@ -1,0 +1,39 @@
+package com.ignfab.minalac.generator.parameters.processors;
+
+import java.beans.ConstructorProperties;
+
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.processors.Processor;
+import com.ignfab.minalac.generator.processors.TestingProcessor;
+
+@SuppressWarnings("checkstyle:VisibilityModifier")
+public class TestingProcessorParams extends ProcessorParams {
+    /**
+     * A required field.
+     */
+    public String requiredField;
+    /**
+     * An optional field.
+     */
+    @JsonSetter(nulls = Nulls.SKIP)
+    public String optionalField = "defaultOptionalValue";
+
+    /**
+     * Constructor used to ensure that the required fields are present during deserialization.
+     *
+     * @param requiredField the required field.
+     */
+    @ConstructorProperties({"requiredField"})
+    public TestingProcessorParams(String requiredField) {
+        this.requiredField = requiredField;
+    }
+
+    @Override
+    public Processor<?, ?> create(Generation generation, CoordinateReferenceSystem layerCrs) {
+        return new TestingProcessor();
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/parameters/providers/TestingProviderParams.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/providers/TestingProviderParams.java
@@ -1,0 +1,38 @@
+package com.ignfab.minalac.generator.parameters.providers;
+
+import java.beans.ConstructorProperties;
+
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.inputs.Provider;
+import com.ignfab.minalac.generator.inputs.TestingProvider;
+
+@SuppressWarnings("checkstyle:VisibilityModifier")
+public class TestingProviderParams extends ProviderParams {
+    /**
+     * A required field.
+     */
+    public String requiredField;
+    /**
+     * An optional field.
+     */
+    @JsonSetter(nulls = Nulls.SKIP)
+    public String optionalField = "defaultOptionalValue";
+
+    /**
+     * Constructor used to ensure that the required fields are present during deserialization.
+     *
+     * @param requiredField the required field.
+     */
+    @ConstructorProperties({"requiredField"})
+    public TestingProviderParams(String requiredField) {
+        this.requiredField = requiredField;
+    }
+
+    @Override
+    public Provider<?> create(Generation generation) {
+        return new TestingProvider(generation.crs());
+    }
+
+}

--- a/src/test/java/com/ignfab/minalac/generator/parameters/providers/WFSProviderParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/providers/WFSProviderParamsTest.java
@@ -1,0 +1,33 @@
+package com.ignfab.minalac.generator.parameters.providers;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.NoSuchAuthorityCodeException;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.referencing.CRS;
+import org.junit.jupiter.api.Test;
+
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+
+public class WFSProviderParamsTest {
+    @Test
+    public void testCreate() throws NoSuchAuthorityCodeException, FactoryException {
+        CoordinateReferenceSystem crs = CRS.decode("EPSG:2154");
+        Generation generation = new Generation(
+            new TestingVoxelWorld(
+                new WorldBBox3d(-10, -10, -10, 20, 20, 20)
+            ), null, crs, 0, 0, 20, 20, 1, 1);
+
+        // A simple OK test
+        final WFSProviderParams params = new WFSProviderParams("http://toto.com", "feature1");
+        assertDoesNotThrow(() -> params.create(generation));
+
+        // Wrong CRS test
+        params.crs = "ThisIsNotACrs";
+        assertThrows(RuntimeException.class, () -> params.create(generation));
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/parameters/providers/WMSFloatBilProviderParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/providers/WMSFloatBilProviderParamsTest.java
@@ -1,0 +1,32 @@
+package com.ignfab.minalac.generator.parameters.providers;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.NoSuchAuthorityCodeException;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.referencing.CRS;
+import org.junit.jupiter.api.Test;
+
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+
+public class WMSFloatBilProviderParamsTest {
+    @Test
+    public void testCreate() throws NoSuchAuthorityCodeException, FactoryException {
+        CoordinateReferenceSystem crs = CRS.decode("EPSG:2154");
+        Generation generation = new Generation(
+            new TestingVoxelWorld(
+                new WorldBBox3d(-50, -50, -50, 100, 100, 100)
+            ), null, crs, 0, 0, 100, 100, 1, 1);
+
+        // A simple OK test
+        final WMSFloatBilProviderParams params = new WMSFloatBilProviderParams("http://toto.com", "layer1");
+        assertDoesNotThrow(() -> params.create(generation));
+
+        // Wrong CRS test
+        params.crs = "ThisIsNotACrs";
+        assertThrows(RuntimeException.class, () -> params.create(generation));
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/parameters/renderers/TestingRendererParams.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/renderers/TestingRendererParams.java
@@ -1,0 +1,39 @@
+package com.ignfab.minalac.generator.parameters.renderers;
+
+import java.beans.ConstructorProperties;
+
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.renderers.Renderer;
+
+/**
+ * A RendererParams class for testing purposes.
+ */
+@SuppressWarnings("checkstyle:VisibilityModifier")
+public class TestingRendererParams extends RendererParams {
+    /**
+     * A required field.
+     */
+    public String requiredField;
+    /**
+     * An optional field.
+     */
+    @JsonSetter(nulls = Nulls.SKIP)
+    public String optionalField = "defaultOptionalValue";
+
+    /**
+     * Constructor used to ensure that the required fields are present during deserialization.
+     *
+     * @param requiredField the required field.
+     */
+    @ConstructorProperties({"requiredField"})
+    public TestingRendererParams(String requiredField) {
+        this.requiredField = requiredField;
+    }
+
+    @Override
+    public Renderer create(Generation generation) {
+        return null;
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/processors/TestingProcessor.java
+++ b/src/test/java/com/ignfab/minalac/generator/processors/TestingProcessor.java
@@ -1,0 +1,24 @@
+package com.ignfab.minalac.generator.processors;
+
+import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
+import com.ignfab.minalac.generator.exceptions.IgnorableException;
+import com.ignfab.minalac.generator.models.TestingModel;
+
+public class TestingProcessor implements Processor<String, TestingModel> {
+
+    @Override
+    public Class<String> acceptedType() {
+        return String.class;
+    }
+
+    @Override
+    public Class<TestingModel> modelType() {
+        return TestingModel.class;
+    }
+
+    @Override
+    public TestingModel process(String object) throws GenerationFailedException, IgnorableException {
+        return new TestingModel();
+    }
+
+}

--- a/src/test/java/com/ignfab/minalac/generator/processors/post/MetadataCopyPostProcessorTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/processors/post/MetadataCopyPostProcessorTest.java
@@ -1,6 +1,8 @@
 package com.ignfab.minalac.generator.processors.post;
 
 import com.ignfab.minalac.generator.models.Model;
+import com.ignfab.minalac.generator.models.TestingModel;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/ignfab/minalac/generator/processors/post/MetadataParsePostProcessorTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/processors/post/MetadataParsePostProcessorTest.java
@@ -3,6 +3,8 @@ package com.ignfab.minalac.generator.processors.post;
 import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
 import com.ignfab.minalac.generator.exceptions.IgnorableException;
 import com.ignfab.minalac.generator.models.Model;
+import com.ignfab.minalac.generator.models.TestingModel;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
### Changes

Get rid of most of SampleImplementation and put almost everything in Yaml

#### Feature description

This PR adds several stuff in Yaml configuration file:
- `sources` made of `providers` and `processors`;
- Dependencies between `renderers` and `sources` with the `after:` tag;

#### Technical changes

`Generation` object does not hold a `Renderer` store anymore but has a `Scheduler` instead. De-serialization of `Renderers` and `Sources` directly creates corresponding tasks in that scheduler.

A new `URLBuilder` class is in charge of managing URLs query arguments.

Most of the code removed from `SampleImplementation` have been moved to `DataSource` or replaced by Yaml configuration.

### TODOs

Better `FactoryException` management in `FloatMatrixProcessorParams` and `GeoToolsVectorProcessor`

### Not TODOs

This should be done in others PR later (avoid too big PR):
- Forbid circular dependencies and unknown tasks in `after:`;
- Get rid of SemanticType and use VoxelType definition instead;
- Deserialize post-processor;

### Self-checks

- [x] The code has unit tests associated
- [x] The code has Javadoc Comments associated
- ~~Complex / Unexpected code is explained / justified with a small comment~~
- [x] Relevant documentation inside the `/docs` folder has been updated
- [x] All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [x] The texts have been proofread (documentation, error messages, logs, comments...)
