### PR TITLE
chore(deps): Upgrade to checkstyle 10.19.0

### DIFF
--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           checkstyle_config: checkstyle.xml
+          checkstyle_version: "10.19.0"
           level: error
           reporter: github-check # Check may be reported on wrong checksuite, but it's a known issue of GitHub Checks API: https://github.com/reviewdog/reviewdog/issues/403
           reviewdog_flags: -name checkstyle

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -160,6 +160,7 @@
       <property name="allowEmptyLambdas" value="true"/>
       <property name="allowEmptyLoops" value="true"/>
       <property name="allowEmptyMethods" value="true"/>
+      <property name="allowEmptySwitchBlockStatements" value="true"/>
       <property name="allowEmptyTypes" value="true"/>
       <property name="ignoreEnhancedForColon" value="false"/>
     </module>

--- a/pom.xml
+++ b/pom.xml
@@ -248,7 +248,7 @@
                         <!-- Overrides checkstyle version -->
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>10.18.1</version>
+                        <version>10.19.0</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/suppressions.xml
+++ b/suppressions.xml
@@ -7,12 +7,5 @@
 <suppressions>
     <suppress checks="MissingJavadocMethod" files=".*[\\/]src[\\/]test[\\/]"/>
     <suppress checks="MissingJavadocType" files=".*[\\/]src[\\/]test[\\/]"/>
-
-    <!--
-    Disable WhitespaceAround check for empty block inside switch expression
-    See https://github.com/checkstyle/checkstyle/issues/9540 for more info
-    -->
-    <suppress-xpath checks="WhitespaceAround" query="//LITERAL_SWITCH//SLIST"/>
-    <suppress-xpath checks="WhitespaceAround" query="//LITERAL_SWITCH//RCURLY"/>
 </suppressions>
 


### PR DESCRIPTION
### Type of modification

Types:
- Other: Tools

### Changes

Upgrade checkstyle dependency version to 10.19.0.

#### Feature description

In this latest version, checkstyle added the `allowEmptySwitchBlockStatements` properties in the `WhitespaceAround` check. This was something we needed, and we used a workaround to partially ignore this check for now.

#### Technical changes

Changed checkstyle version in `pom.xml`, removed dirty workaround in `suppressions.xml` and replaced it with clean property in `checkstyle.xml`.

Official checkstyle documentation about this new property: https://checkstyle.org/checks/whitespace/whitespacearound.html#WhitespaceAround

Related GitHub issue: https://github.com/checkstyle/checkstyle/issues/9540

### Reason

The checkstyle config is cleaner, as got rid of this workaround.

### Self-checks

- ~~The code has unit tests associated~~
- ~~The code has Javadoc Comments associated~~
- ~~Complex / Unexpected code is explained / justified with a small comment~~
- ~~Relevant documentation inside the `/docs` folder has been updated~~
- ~~All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)~~
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- ~~The texts have been proofread (documentation, error messages, logs, comments...)~~
