### PR TITLE
docs(typo): Fix minor typos and mislocated file

### DIFF
--- a/docs/dev/RandomNumbers.md
+++ b/docs/dev/RandomNumbers.md
@@ -45,7 +45,7 @@ renderers working on same models need to have different randomness.
 
 Every model representing a feature has to implement a `salt()` method returning
 a *salt* string unique enough to ensure its random stuff to be different from
-its neighboors.
+its neighbors.
 
 Example of a `Model` `salt()` method using coordinates as salt string:
 ```java
@@ -67,7 +67,7 @@ based salt.
 ### Renderers
 
 Whenever a renderer needs random number, its constructor should have a `Seed`
-parameter. The generation main `Seed` will be passed to this constructor and it
+parameter. The generation's main `Seed` will be passed to this constructor. It
 must be salted with rendered model before use.
 
 Example of a renderer using random numbers:

--- a/docs/usage/GenerationParameters.md
+++ b/docs/usage/GenerationParameters.md
@@ -45,7 +45,7 @@ format: minetest
       - `default` (int or str): Default value for all heightmap cells (integer or one of `minimal`, `min`, `maximal` or `max`)
 - `sources`: Sources providing models to render
   - _`<name>`_: Unique name of the source
-    - `after` (optional list): List of [dependancies](#dependancies)
+    - `after` (optional list): List of [dependencies](#dependencies)
     - `modelType`: the type of models to create
     - `provider`: Definition of the data provider to use
         - `type`: Type of data provider
@@ -85,9 +85,9 @@ renderers:
     ...
 ```
 
-**BEWARE** : For now, `after` values are not checked. Generator will get stuck waiting in case of dependency loop or if a value refers to nonexistant source or renderer.
+**BEWARE** : For now, `after` values are not checked. Generator will get stuck waiting in case of dependency loop or if a value refers to nonexistent source or renderer.
 
-## Providers parameters
+## Provider parameters
 
 A provider fetches data from a source and provides it as-is to a processor. Provider type is identified by `type` field.
 


### PR DESCRIPTION
### Type of modification

- Documentation
  - Markdown Files

### Changes

Fix typos in documentation and merge `/docs/development` into `/docs/dev`.

#### Feature description

While updating the documentation for another feature, I realized there was 2 "dev docs" folders:
- `/docs/development`
- `/docs/dev`

I opted for `/docs/dev`, merging the content of the two directories.

I also fixed some typos that sneaked their way into the main branch.

### Reason

`/docs/dev` is shorter than `/docs/development`, while still maintaining readability.

Some links where broken due to typos (difference between the title and the anchor reference).

### Self-checks

- ~~The code has unit tests associated~~
- ~~The code has Javadoc Comments associated~~
- ~~Complex / Unexpected code is explained / justified with a small comment~~
- ~~Relevant documentation inside the `/docs` folder has been updated~~
- ~~All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)~~
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [x] The texts have been proofread (documentation, error messages, logs, comments...)
