### PR TITLE
Deserialization du post-processeur "copy" depuis les sources

### DIFF
--- a/docs/usage/GenerationParameters.md
+++ b/docs/usage/GenerationParameters.md
@@ -18,6 +18,9 @@ sources:
     processor:
       type: geoToolsVector
     postProcessors:
+      - type: copy
+        metadata: hauteur
+        to: height
 renderers:
   building:
     after:
@@ -148,7 +151,17 @@ Processor translating a float data matrix to a model.
 
 A post-processor alters models so they can comply with renderers requirements.
 
-<!-- Documentation of post-processor params here -->
+### Metadata copy
+
+A post-processor copying a metadata into another.
+
+**Type**: copy
+
+**Extra parameters**:
+- `metadata` (required, `text`): Name of the metadata to copy.
+- `to` (required, `text`): Name of destination metadata.
+- `abortIfMetadataIsAbsent` (optional, default `no`): `yes` to stop the copy if the metadata is missing, `no` to allow the copy to proceed even if the metadata is missing (in this case, the metadata value will be empty).
+- `keepExisting` (optional, default `no`): `no` to overwrite existing data, `yes` to keep existing metadata.
 
 ## Renderer parameters
 

--- a/docs/usage/GenerationParameters.md
+++ b/docs/usage/GenerationParameters.md
@@ -17,6 +17,7 @@ sources:
       features: BDTOPO_V3:batiment
     processor:
       type: geoToolsVector
+    postProcessors:
 renderers:
   building:
     after:
@@ -48,11 +49,15 @@ format: minetest
     - `after` (optional list): List of [dependencies](#dependencies)
     - `modelType`: the type of models to create
     - `provider`: Definition of the data provider to use
-        - `type`: Type of data provider
-        - Additional parameters specific to the given [type](#provider-parameters)
+      - `type`: Type of data provider
+      - Additional parameters specific to the given [type](#provider-parameters)
     - `processor`: Definition of the data processor to use
-        - `type`: Type of data processor
-        - Additional parameters specific to the given [type](#processor-parameters)
+      - `type`: Type of data processor
+      - Additional parameters specific to the given [type](#processor-parameters)
+    - `postProcessors`: Definition of post processors to use
+      - _List item_:
+        - `type`: Type of post processor
+        - Additional parameters specific to the given [type](#post-processor-parameters)
 - `renderers`: Renderers used to generate the map
   - _`<name>`_: Unique name of the renderer
     - `after` (list): List of [dependencies](#dependencies)
@@ -138,6 +143,12 @@ Processor translating a float data matrix to a model.
 **Extra parameters**: None
 
 **Suitable providers**: `wmsFloat`
+
+## Post processor parameters
+
+A post-processor alters models so they can comply with renderers requirements.
+
+<!-- Documentation of post-processor params here -->
 
 ## Renderer parameters
 

--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -18,6 +18,10 @@ sources:
       features: BDTOPO_V3:batiment
     processor:
       type: geoToolsVector
+    postProcessors:
+      - type: copy
+        metadata: hauteur
+        to: height
 renderers:
   altitude:
     after:

--- a/examples/minecraft.yaml
+++ b/examples/minecraft.yaml
@@ -18,6 +18,10 @@ sources:
       features: BDTOPO_V3:batiment
     processor:
       type: geoToolsVector
+    postProcessors:
+      - type: copy
+        metadata: hauteur
+        to: height
 renderers:
   altitude:
     after:

--- a/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
+++ b/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
@@ -6,6 +6,7 @@ import com.ignfab.minalac.generator.parameters.ParamsParser;
 import com.ignfab.minalac.generator.parameters.ParseException;
 import com.ignfab.minalac.generator.parameters.processors.FloatMatrixProcessorParams;
 import com.ignfab.minalac.generator.parameters.processors.GeoToolsVectorProcessorParams;
+import com.ignfab.minalac.generator.parameters.processors.post.MetadataCopyPostProcessorParams;
 import com.ignfab.minalac.generator.parameters.providers.WFSProviderParams;
 import com.ignfab.minalac.generator.parameters.providers.WMSFloatBilProviderParams;
 import com.ignfab.minalac.generator.parameters.renderers.GroundRendererParams;
@@ -59,6 +60,8 @@ public final class SampleImplementation {
 
         parser.registerParams("floatMatrix", FloatMatrixProcessorParams.class);
         parser.registerParams("geoToolsVector", GeoToolsVectorProcessorParams.class);
+
+        parser.registerParams("copy", MetadataCopyPostProcessorParams.class);
 
         Generation generation = parser.parse(cli.readParameters()).create();
 

--- a/src/main/java/com/ignfab/minalac/generator/generation/DataSource.java
+++ b/src/main/java/com/ignfab/minalac/generator/generation/DataSource.java
@@ -1,6 +1,8 @@
 package com.ignfab.minalac.generator.generation;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
 import com.ignfab.minalac.generator.exceptions.IgnorableException;
@@ -19,7 +21,7 @@ public class DataSource {
     private final String modelType;
     private final Provider<?> provider;
     private final Processor<Object, ?> processor;
-    private final PostProcessor<Model, ?>[] postProcessors;
+    private final List<PostProcessor<Model, ?>> postProcessors;
 
     /**
      * Creates a new data source.
@@ -30,37 +32,35 @@ public class DataSource {
      * @param processor processor converting provided data to models
      * @param postProcessors eventual post-processor to run on created models
      */
-
     public DataSource(
         ModelStore modelStore,
         String modelType,
         Provider<?> provider,
         Processor<?, ? extends Model> processor,
-        PostProcessor<?, ?>[] postProcessors
+        List<PostProcessor<?, ?>> postProcessors
     ) {
         Class<? extends Model> modelClass = processor.modelType();
 
         if (!processor.acceptedType().isAssignableFrom(provider.providedType()))
             throw new IllegalArgumentException("Processor cannot treat provided type. Provided = %s, Accepted = %s".formatted(provider.providedType(), processor.acceptedType()));
 
+        this.postProcessors = new ArrayList<>();
         for (PostProcessor<?, ?> postProcessor : postProcessors) {
             if (!postProcessor.acceptedModelType().isAssignableFrom(modelClass))
                 throw new IllegalArgumentException("PostProcessor cannot treat model type. Current model type = %s, Accepted model type = %s".formatted(modelType, postProcessor.acceptedModelType()));
             @SuppressWarnings("unchecked") // The model type has been validated above
             PostProcessor<Model, ?> uncheckedPostProcessor = (PostProcessor<Model, ?>) postProcessor;
+            this.postProcessors.add(uncheckedPostProcessor);
             modelClass = uncheckedPostProcessor.processedModelType(modelClass);
         }
 
         @SuppressWarnings("unchecked")
         Processor<Object, ?> uncheckedProcessor = (Processor<Object, ?>) processor;
-        @SuppressWarnings("unchecked")
-        PostProcessor<Model, ?>[] uncheckedPostProcessors = (PostProcessor<Model, ?>[]) postProcessors;
 
         this.modelStore = modelStore;
         this.modelType = modelType;
         this.provider = provider;
         this.processor = uncheckedProcessor;
-        this.postProcessors = uncheckedPostProcessors;
     }
 
     /**

--- a/src/main/java/com/ignfab/minalac/generator/parameters/DataSourceParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/DataSourceParams.java
@@ -1,12 +1,16 @@
 package com.ignfab.minalac.generator.parameters;
 
 import java.beans.ConstructorProperties;
+import java.util.ArrayList;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import com.ignfab.minalac.generator.generation.DataSource;
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.inputs.Provider;
 import com.ignfab.minalac.generator.parameters.processors.ProcessorParams;
+import com.ignfab.minalac.generator.parameters.processors.post.PostProcessorParams;
 import com.ignfab.minalac.generator.parameters.providers.ProviderParams;
 import com.ignfab.minalac.generator.processors.Processor;
 import com.ignfab.minalac.generator.processors.post.PostProcessor;
@@ -20,6 +24,7 @@ public class DataSourceParams {
     /**
      * Type to give to provided models (required).
      */
+    @JsonSetter(nulls = Nulls.FAIL)
     public String modelType;
 
     /**
@@ -31,6 +36,12 @@ public class DataSourceParams {
      * Data processor (required).
      */
     public ProcessorParams processor;
+
+    /**
+     * Additional data-processing steps (optional).
+     */
+    @JsonSetter(nulls = Nulls.SKIP)
+    public List<PostProcessorParams> postProcessors = new ArrayList<>();
 
     /**
      * Dependencies (optional).
@@ -52,6 +63,21 @@ public class DataSourceParams {
     }
 
     /**
+     * Checks if there are any blatantly invalid parameters.
+     *
+     * @throws IllegalArgumentException is any of the parameters is invalid.
+     */
+    public void validate() throws IllegalArgumentException {
+        if (modelType.isBlank())
+            throw new IllegalArgumentException("The 'modelType' field cannot be empty or contain only whitespace.");
+
+        provider.validate();
+        processor.validate();
+        for (PostProcessorParams params : postProcessors)
+            params.validate();
+    }
+
+    /**
      * Creates the corresponding {@code DataSource}.
      *
      * @param generation the generation context
@@ -60,13 +86,16 @@ public class DataSourceParams {
     public DataSource create(Generation generation) {
         Provider<?> provider = this.provider.create(generation);
         Processor<?, ?> processor = this.processor.create(generation, provider.crs());
+        List<PostProcessor<?, ?>> postProcessors = new ArrayList<>();
+        for (PostProcessorParams params : this.postProcessors)
+            postProcessors.add(params.create());
 
         return new DataSource(
             generation.models(),
             modelType,
             provider,
             processor,
-            new PostProcessor<?, ?>[]{});
-            //TODO: Manage postprocessors
+            postProcessors
+        );
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/parameters/GenerationParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/GenerationParams.java
@@ -131,6 +131,8 @@ public class GenerationParams {
 
         for (HeightmapParams params : heightmaps.values())
             params.validate();
+        for (DataSourceParams params : sources.values())
+            params.validate();
         for (RendererParams params : renderers.values())
             params.validate();
     }

--- a/src/main/java/com/ignfab/minalac/generator/parameters/processors/ProcessorParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/processors/ProcessorParams.java
@@ -7,7 +7,7 @@ import com.ignfab.minalac.generator.parameters.PolymorphicParams;
 import com.ignfab.minalac.generator.processors.Processor;
 
 /**
- * Represents the parameters of a type of {@link Processor}.
+ * Parameters for {@link Processor}.
  */
 public abstract class ProcessorParams extends PolymorphicParams {
     /**

--- a/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataCopyPostProcessorParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataCopyPostProcessorParams.java
@@ -1,0 +1,69 @@
+package com.ignfab.minalac.generator.parameters.processors.post;
+
+import java.beans.ConstructorProperties;
+
+import com.ignfab.minalac.generator.processors.post.PostProcessor;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import com.ignfab.minalac.generator.models.Model;
+import com.ignfab.minalac.generator.processors.post.MetadataCopyPostProcessor;
+
+/**
+ * Parameters for {@link MetadataCopyPostProcessor}.
+ */
+@SuppressWarnings("checkstyle:VisibilityModifier")
+public class MetadataCopyPostProcessorParams extends PostProcessorParams {
+    /**
+     * Name of the metadata to copy (required).
+     */
+    @JsonSetter(nulls = Nulls.FAIL)
+    public String metadata;
+
+    /**
+     * Name of copied metadata (required).
+     */
+    @JsonSetter(nulls = Nulls.FAIL)
+    public String to;
+
+    /**
+     * Whether to abort if metadata is absent (optional).
+     */
+    @JsonSetter(nulls = Nulls.SKIP)
+    public boolean abortIfMetadataIsAbsent = false;
+
+    /**
+     * Whether to keep existing metadata or not (optional).
+     */
+    @JsonSetter(nulls = Nulls.SKIP)
+    public boolean keepExisting = false;
+
+    /**
+     * Constructor used to ensure that the required fields are present during deserialization.
+     *
+     * @param metadata name of the metadata to copy
+     * @param to name of copied metadata
+     */
+    @ConstructorProperties({"metadata", "to"})
+    public MetadataCopyPostProcessorParams(String metadata, String to) {
+        this.metadata = metadata;
+        this.to = to;
+    }
+
+    @Override
+    public void validate() throws IllegalArgumentException {
+        if (metadata.isBlank())
+            throw new IllegalArgumentException("The 'metadata' field cannot be empty or contain only whitespace.");
+        if (to.isBlank())
+            throw new IllegalArgumentException("The 'to' field cannot be empty or contain only whitespace.");
+    }
+
+    @Override
+    public PostProcessor<Model, ?> create() {
+        return new MetadataCopyPostProcessor(
+            metadata,
+            to,
+            abortIfMetadataIsAbsent,
+            keepExisting
+        );
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/PostProcessorParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/PostProcessorParams.java
@@ -1,0 +1,16 @@
+package com.ignfab.minalac.generator.parameters.processors.post;
+
+import com.ignfab.minalac.generator.parameters.PolymorphicParams;
+import com.ignfab.minalac.generator.processors.post.PostProcessor;
+
+/**
+ * Parameters for {@link PostProcessor}.
+ */
+public abstract class PostProcessorParams extends PolymorphicParams {
+    /**
+     * Creates the corresponding {@link PostProcessor}.
+     *
+     * @return the created {@link PostProcessor}
+     */
+    public abstract PostProcessor<?, ?> create();
+}

--- a/src/test/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataCopyPostProcessorParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataCopyPostProcessorParamsTest.java
@@ -1,0 +1,67 @@
+package com.ignfab.minalac.generator.parameters.processors.post;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+import org.junit.jupiter.api.BeforeAll;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class MetadataCopyPostProcessorParamsTest {
+    private static ObjectMapper mapper;
+
+    @BeforeAll
+    public static void init() {
+        mapper = new ObjectMapper(new YAMLFactory());
+        mapper.registerSubtypes(new NamedType(MetadataCopyPostProcessorParams.class, "copy"));
+    }
+
+    @Test
+    public void testCreate() {
+        MetadataCopyPostProcessorParams params = new MetadataCopyPostProcessorParams("toto", "tata");
+        assertDoesNotThrow(params::create);
+    }
+
+    @Test
+    public void testValidate() {
+        assertDoesNotThrow(new MetadataCopyPostProcessorParams("toto", "tata")::validate);
+        assertThrows(IllegalArgumentException.class, new MetadataCopyPostProcessorParams("toto", "")::validate);
+        assertThrows(IllegalArgumentException.class, new MetadataCopyPostProcessorParams("", "tata")::validate);
+    }
+
+    @Test
+    public void testDeserialization() {
+        String requiredFields = """
+            type: copy
+            metadata: hauteur
+            to: height
+        """;
+
+        MetadataCopyPostProcessorParams requiredParams = assertDoesNotThrow(() -> mapper.readValue(requiredFields, MetadataCopyPostProcessorParams.class));
+        assertEquals("hauteur", requiredParams.metadata);
+        assertEquals("height", requiredParams.to);
+        assertFalse(requiredParams.abortIfMetadataIsAbsent);
+        assertFalse(requiredParams.keepExisting);
+
+        String requiredAndOptionalFields = """
+            type: copy
+            metadata: toto
+            to: tata
+            keepExisting: yes
+            abortIfMetadataIsAbsent: yes
+        """;
+
+        MetadataCopyPostProcessorParams requiredAndOptionalParams = assertDoesNotThrow(() -> mapper.readValue(requiredAndOptionalFields, MetadataCopyPostProcessorParams.class));
+        assertEquals("toto", requiredAndOptionalParams.metadata);
+        assertEquals("tata", requiredAndOptionalParams.to);
+        assertTrue(requiredAndOptionalParams.abortIfMetadataIsAbsent);
+        assertTrue(requiredAndOptionalParams.keepExisting);
+    }
+}


### PR DESCRIPTION
### Type of modification

Types:
- Documentation
  - Javadoc Comments
  - Markdown Files
  - Code Comments
- Code
  - processors
    - post
  - parameters
    - processors
      - post
- Tests

### Issue

MINALAC-79

### Changes

La possibilité de désérialiser une liste de post-processeurs depuis les sous elements de `sources` grâce au champ `postProcessors`.
Prise en charge du post-processeur "copy".

#### Feature description

Modification de l'objet `DataSourceParams` pour permettre la prise en charge des `PostProcessor` dans le fichier YAML.

Création de 2 nouvelles classes dans un nouveau dossier au sein du projet, portant le nom de `processors/post` : 
- `MetadataCopyPostProcessorParams.java` : permet de désérialiser un post-processeur "copy".
- `PostProcessorParams.java` : class parent des params des post-processeurs.

Ajout d'un param "copy" dans le fichier `SimpleImplementation`

#### Showcase

```yaml
# ...
sources:
  # ...
  bati:
    # ...
    postProcessors:
      - type: copy
        metadata: hauteur
        to: height
# ...
```

### Reason

Les Post-Processeurs, disparus du fichier `SampleImplementation` où mes renderers #24 en avaient besoin (mais peuvent faire sans). J'ai donc ajouter le support des post-processeurs dans le fichier YAML.

### TODOs

- [x] Ecrire les JavaDocs
- [x] Améliorer l'écriture du code
- [x] Régler les problèmes de code style
- [x] Supprimer les `sout` restants (s'il y'en a)
- [x] Supprimer le fichier `.vscode`
- [x] Améliorer le nom des params dans l'`yaml`
- ~~Tester de mettre PostProcessorParams en interface~~
- [x] Ajouter les champs manquants dans les classes de paramètres créées.
- [x] Mettre des valeurs par défaut aux champs non obligatoire
- [x] Mettre à jour le `/docs`
- [x] Mettre à jour le fichier `minecraft.yaml`
- [x] Le paramètre `failurePolicy` de `MetadataParsePostProcessorParams` non géré
- [x] Faire les tests unitaire des params

### Self-checks

- [x] The code has unit tests associated
- [x] The code has Javadoc Comments associated
- ~~Complex / Unexpected code is explained / justified with a small comment~~
- [x] Relevant documentation inside the `/docs` folder has been updated
- [x] All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [x] The texts have been proofread (documentation, error messages, logs, comments...)
