### PR TITLE
feat(renderer): Basic road renderer

### DIFF
--- a/docs/usage/GenerationParameters.md
+++ b/docs/usage/GenerationParameters.md
@@ -194,3 +194,20 @@ Fields:
 - `type`: Must be the value `heightmap`
 - `modelType`: the type of models to render
 - `heightmap`: the name of the heightmap to use. It must exist.
+
+### Road renderer
+
+```yaml
+type: road
+modelType: road
+heightmap: ground
+large: true
+voxel: CONCRETE
+```
+
+Fields:
+- `type`: Must be the value `road`.
+- `modelType`: the type of models to render
+- `heightmap`: the name of the ground heightmap to use. It must exist.
+- `large`: whether to make a large road or small path
+- `voxel`: the semantic type of the voxel used

--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -18,6 +18,14 @@ sources:
       features: BDTOPO_V3:batiment
     processor:
       type: geoToolsVector
+  road:
+    modelType: road
+    provider:
+      type: wfs
+      url: https://data.geopf.fr/wfs/wfs
+      features: BDTOPO_V3:troncon_de_route
+    processor:
+      type: geoToolsVector
 renderers:
   altitude:
     after:
@@ -43,6 +51,15 @@ renderers:
     heightmap: ground
     inside: COBBLE
     edge: STONE
+  road:
+    after:
+      - source:road
+      - renderer:ground
+    type: road
+    modelType: road
+    heightmap: ground
+    large: true
+    voxel: CONCRETE
 verticalScale: 1.0
 horizontalScale: 1.0
 area:

--- a/examples/minecraft.yaml
+++ b/examples/minecraft.yaml
@@ -18,6 +18,14 @@ sources:
       features: BDTOPO_V3:batiment
     processor:
       type: geoToolsVector
+  road:
+    modelType: road
+    provider:
+      type: wfs
+      url: https://data.geopf.fr/wfs/wfs
+      features: BDTOPO_V3:troncon_de_route
+    processor:
+      type: geoToolsVector
 renderers:
   altitude:
     after:
@@ -43,6 +51,15 @@ renderers:
     heightmap: ground
     inside: COBBLE
     edge: STONE
+  road:
+    after:
+      - source:road
+      - renderer:ground
+    type: road
+    modelType: road
+    heightmap: ground
+    large: true
+    voxel: CONCRETE
 verticalScale: 1.0
 horizontalScale: 1.0
 area:

--- a/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
+++ b/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
@@ -10,6 +10,7 @@ import com.ignfab.minalac.generator.parameters.providers.WFSProviderParams;
 import com.ignfab.minalac.generator.parameters.providers.WMSFloatBilProviderParams;
 import com.ignfab.minalac.generator.parameters.renderers.GroundRendererParams;
 import com.ignfab.minalac.generator.parameters.renderers.HeightmapRendererParams;
+import com.ignfab.minalac.generator.parameters.renderers.RoadRendererParams;
 import com.ignfab.minalac.generator.parameters.renderers.VectorRendererParams;
 import com.ignfab.minalac.generator.utils.execution.TaskFailedException;
 import com.ignfab.minalac.generator.utils.network.HttpTrustAllSSL;
@@ -53,6 +54,7 @@ public final class SampleImplementation {
         parser.registerParams("heightmap", HeightmapRendererParams.class);
         parser.registerParams("ground", GroundRendererParams.class);
         parser.registerParams("vector", VectorRendererParams.class);
+        parser.registerParams("road", RoadRendererParams.class);
 
         parser.registerParams("wfs", WFSProviderParams.class);
         parser.registerParams("wmsFloat", WMSFloatBilProviderParams.class);

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelTypeFactory.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelTypeFactory.java
@@ -36,6 +36,7 @@ public class MCVoxelTypeFactory implements VoxelTypeFactory {
             case DIRT -> "minecraft:dirt";
             case COBBLE -> "minecraft:cobblestone";
             case BRICK -> "minecraft:stone_bricks";
+            case CONCRETE -> "minecraft:black_wool";
         });
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelWorld.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelWorld.java
@@ -154,7 +154,7 @@ public class MCVoxelWorld extends VoxelWorld {
                     gameRules.putString("disableRaids", "false");
                     gameRules.putString("doDaylightCycle", "true");
                     gameRules.putString("doEntityDrops", "true");
-                    gameRules.putString("doFireTick", "true");
+                    gameRules.putString("doFireTick", "false"); // Toggled to avoid accidents!
                     gameRules.putString("doImmediateRespawn", "false");
                     gameRules.putString("doInsomnia", "true");
                     gameRules.putString("doLimitedCrafting", "false");

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelTypeFactory.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelTypeFactory.java
@@ -1,9 +1,9 @@
 package com.ignfab.minalac.generator.outputs.minetest;
 
-import com.ignfab.minalac.generator.world.SemanticType;
-import com.ignfab.minalac.generator.world.VoxelTypeFactory;
-import com.ignfab.minalac.generator.world.VoxelType;
 import com.ignfab.minalac.generator.outputs.minetest.voxelType.MTSimpleVoxelType;
+import com.ignfab.minalac.generator.world.SemanticType;
+import com.ignfab.minalac.generator.world.VoxelType;
+import com.ignfab.minalac.generator.world.VoxelTypeFactory;
 
 /**
  * Factory for creating {@link MTVoxelType}.
@@ -38,6 +38,7 @@ public class MTVoxelTypeFactory implements VoxelTypeFactory {
             case COBBLE -> new MTSimpleVoxelType(this.world, "default:cobble");
             case BRICK -> new MTSimpleVoxelType(this.world, "default:stonebrick");
             case WATER -> new MTSimpleVoxelType(this.world, "default:water_source");
+            case CONCRETE -> new MTSimpleVoxelType(this.world, "default:obsidian");
             default -> new MTSimpleVoxelType(this.world, "air");
         };
     }

--- a/src/main/java/com/ignfab/minalac/generator/parameters/renderers/RoadRendererParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/renderers/RoadRendererParams.java
@@ -1,0 +1,77 @@
+package com.ignfab.minalac.generator.parameters.renderers;
+
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.models.ModelSelection;
+import com.ignfab.minalac.generator.renderers.Renderer;
+import com.ignfab.minalac.generator.renderers.RoadRenderer;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+import com.ignfab.minalac.generator.world.SemanticType;
+import com.ignfab.minalac.generator.world.SimpleVoxelPattern;
+import com.ignfab.minalac.generator.world.VoxelType;
+
+import java.beans.ConstructorProperties;
+
+/**
+ * Parameters for a {@link RoadRenderer}.
+ * <p>
+ * Until voxel structures are deserializable, this performs a basic voxel structure creation
+ */
+@SuppressWarnings("checkstyle:VisibilityModifier")
+public class RoadRendererParams extends RendererParams {
+    /**
+     * The type of models to render (required).
+     */
+    public String modelType;
+    /**
+     * The name of the heightmap to use (required).
+     */
+    public String heightmap;
+    /**
+     * Whether to create a large road (temporary, to be replaced with structures, then improved using real width).
+     */
+    public boolean large;
+    /**
+     * Voxel type to place (temporary, to be replaced with structures).
+     */
+    public SemanticType voxel;
+
+    /**
+     * Constructor used to ensure that the required fields are present during deserialization.
+     *
+     * @param modelType the type of models to render
+     * @param heightmap the name of the heightmap to use
+     * @param voxel voxel to place
+     */
+    @ConstructorProperties({"modelType", "heightmap", "voxel"})
+    public RoadRendererParams(String modelType, String heightmap, SemanticType voxel) {
+        this.modelType = modelType;
+        this.heightmap = heightmap;
+        this.voxel = voxel;
+    }
+
+    @Override
+    public void validate() throws IllegalArgumentException {
+        if (heightmap.isEmpty())
+            throw new IllegalArgumentException("The field heightmap cannot be empty");
+    }
+
+    @Override
+    public Renderer create(Generation generation) {
+        SimpleVoxelPattern pattern = new SimpleVoxelPattern();
+        VoxelType v = generation.world().getFactory().createVoxelType(voxel);
+        if (large) {
+            pattern.set(new WorldBBox3d(-1, -2, 0, 3, 1, 1), v);
+            pattern.set(new WorldBBox3d(-2, -1, 0, 5, 3, 1), v);
+            pattern.set(new WorldBBox3d(-1, +2, 0, 3, 1, 1), v);
+        } else {
+            pattern.set(new WorldBBox3d(-1, 0, 0, 3, 1, 1), v);
+            pattern.set(new WorldBBox3d(0, -1, 0, 1, 3, 1), v);
+        }
+
+        return new RoadRenderer(
+            new ModelSelection(generation.models(), modelType),
+            generation.heightmaps().get(heightmap),
+            pattern
+        );
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/renderers/RoadRenderer.java
+++ b/src/main/java/com/ignfab/minalac/generator/renderers/RoadRenderer.java
@@ -1,0 +1,50 @@
+package com.ignfab.minalac.generator.renderers;
+
+import com.ignfab.minalac.generator.generation.Heightmap;
+import com.ignfab.minalac.generator.models.Model;
+import com.ignfab.minalac.generator.models.ModelSelection;
+import com.ignfab.minalac.generator.models.ShapesVoxelizable3d;
+import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
+import com.ignfab.minalac.generator.voxelization.shape3d.LineVoxel3d;
+import com.ignfab.minalac.generator.voxelization.shape3d.ShapesVoxelizer3d;
+import com.ignfab.minalac.generator.world.VoxelPattern;
+
+/**
+ * A basic road renderer intended to evolve.
+ */
+public class RoadRenderer extends ModelRenderer {
+    private final Heightmap heightmap;
+    private final VoxelPattern voxelPattern;
+
+    /**
+     * Creates a new {@code RoadRenderer}.
+     *
+     * @param models Models to be rendered (only ShapesVoxelizable3d ones will be)
+     * @param heightmap Heightmap of the ground (on which features will be placed)
+     * @param voxelPattern Pattern to place along the road
+     */
+    public RoadRenderer(ModelSelection models, Heightmap heightmap, VoxelPattern voxelPattern) {
+        super(models);
+        this.heightmap = heightmap;
+        this.voxelPattern = voxelPattern;
+    }
+
+    @Override
+    protected void render(Model model, WorldBBox3d bbox) {
+        if (!(model instanceof ShapesVoxelizable3d voxelizable)) {
+            // TODO: Better warning about not possible to render a non shapes-voxelizable model
+            System.err.println("Ignoring non shapes-voxelizable model. Type: " + model.getClass());
+            return;
+        }
+        ShapesVoxelizer3d voxelizer = voxelizable.voxelize3d(bbox);
+
+        for (LineVoxel3d voxel : voxelizer.borders()) {
+            WorldCoords3d c = voxel.coords();
+            WorldCoords2d c2d = c.to2d();
+            if (heightmap.bbox().contains(c2d))
+                voxelPattern.place(c.x(), c.y(), Math.max(heightmap.get(c2d), c.z()));
+        }
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/world/SemanticType.java
+++ b/src/main/java/com/ignfab/minalac/generator/world/SemanticType.java
@@ -42,5 +42,10 @@ public enum SemanticType {
      * Represent a brick voxel.
      * Can be used to represent a brick-built wall.
      */
-    BRICK
+    BRICK,
+    /**
+     * Represent a concrete voxel.
+     * Can be used to represent a road.
+     */
+    CONCRETE
 }


### PR DESCRIPTION
### Type of modification

- Code
  - General
  - Inputs
  - Outputs
- Documentation
  - Javadoc Comments
  - Markdown Files
- Resources

### Changes

Add simple road renderer (from an old commit [`e64f98c`](https://github.com/ignfab/minalac-generator/commit/e64f98cea4ea0e66fe6a4aa6c6e68cec1550b5e4) by @pyrollo)

#### Feature description

Multiple small things:
- Create a basic road renderer
- New semantic type: Concrete
- Workaround to deserialize voxel pattern
- Generation inside the map:
  - Data from `BDTOPO:troncon_de_route`
  - Concrete voxel placed by road renderer

#### Showcase

Generated from `examples/default.yaml`:
![image](https://github.com/user-attachments/assets/31193123-e240-4d4e-a03c-9c946248bc3c)

### Reason

Exists in v1

### TODOs

Improve when voxel pattern deserialization is available!

Maybe add some unit tests, but because this is still not final, I think this would be extra unnecessary work...

### Self-checks

- ~~The code has unit tests associated~~
- [x] The code has Javadoc Comments associated
- ~~Complex / Unexpected code is explained / justified with a small comment~~
- [x] Relevant documentation inside the `/docs` folder has been updated
- [x] All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [x] The texts have been proofread (documentation, error messages, logs, comments...)
