### PR TITLE
feat(input): Add GeoPackage and Shapefile data providers

### DIFF
--- a/docs/usage/GenerationParameters.md
+++ b/docs/usage/GenerationParameters.md
@@ -126,6 +126,17 @@ A provider capable of reading vector data from a [GeoPackage](https://en.wikiped
 
 **Suitable processors**: `geoToolsVector`
 
+### Shapefile
+A provider capable of reading vector data from a [Shapefile](https://en.wikipedia.org/wiki/Shapefile).
+
+**Type**: `shapefile`
+
+**Extra parameters**:
+- `filePath` (required): Path of the Shapefile (absolute, or relative to execution context)
+- `crsOverride` (optional, default none): CRS to use when reading data. By default, the CRS is read from the Shapefile itself. You should only use this parameter if the CRS is invalid or missing from the file. This **DOES NOT** reproject data!
+
+**Suitable processors**: `geoToolsVector`
+
 ### Web Map Service with floating point values
 A provider capable of fetching **float** data from a [Web Map Service](https://en.wikipedia.org/wiki/Web_Map_Service) source. Source must be able to provide `x-bil` format.
 
@@ -150,7 +161,7 @@ This processor is able to take vector features and turn them into models, using 
 
 **Extra parameters**: None
 
-**Suitable providers**: `wfs`, `gpkg`
+**Suitable providers**: `wfs`, `gpkg`, `shapefile`
 
 ### Float matrix vector processor
 

--- a/docs/usage/GenerationParameters.md
+++ b/docs/usage/GenerationParameters.md
@@ -114,6 +114,18 @@ A provider capable of fetching vector data from a [Web Feature Service](https://
 
 **Suitable processors**: `geoToolsVector`
 
+### GeoPackage
+A provider capable of reading vector data from a [GeoPackage](https://en.wikipedia.org/wiki/GeoPackage) file.
+
+**Type**: `gpkg`
+
+**Extra parameters**:
+- `filePath` (required): Path of the GPKG file (absolute, or relative to execution context)
+- `typeName` (required): Name of feature type to read
+- `crsOverride` (optional, default none): CRS to use when reading data. By default, the CRS is read from the GeoPackage itself. You should only use this parameter if the CRS is invalid or missing from the file. This **DOES NOT** reproject data!
+
+**Suitable processors**: `geoToolsVector`
+
 ### Web Map Service with floating point values
 A provider capable of fetching **float** data from a [Web Map Service](https://en.wikipedia.org/wiki/Web_Map_Service) source. Source must be able to provide `x-bil` format.
 
@@ -138,7 +150,7 @@ This processor is able to take vector features and turn them into models, using 
 
 **Extra parameters**: None
 
-**Suitable providers**: `wfs`
+**Suitable providers**: `wfs`, `gpkg`
 
 ### Float matrix vector processor
 

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,11 @@
             <artifactId>gt-referencing</artifactId>
             <version>${geotools.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-geopkg</artifactId>
+            <version>${geotools.version}</version>
+        </dependency>
         <!--
             Required to identify coordinates reference systems
             Example error: No code "EPSG:4326" from authority "EPSG"
@@ -232,6 +237,21 @@
                                 <exclude>modeling32.png</exclude>
                                 <exclude>plugin.xml</exclude>
                                 <exclude>plugin.properties</exclude>
+                            </excludes>
+                        </filter>
+                        <!-- Removes JAI-EXT registry files overlapping with each-other -->
+                        <filter>
+                            <artifact>*:jt-*</artifact>
+                            <excludes>
+                                <exclude>META-INF/registryFile.jai*</exclude>
+                            </excludes>
+                        </filter>
+                        <!-- Removes some files of jt-scale2 that are already provided by jt-scale -->
+                        <filter>
+                            <artifact>it.geosolutions.jaiext.scale2:jt-scale2</artifact>
+                            <excludes>
+                                <exclude>it/geosolutions/jaiext/scale/JaiI18N.class</exclude>
+                                <exclude>it/geosolutions/jaiext/resources/image/it.geosolutions.jaiext.scale.properties</exclude>
                             </excludes>
                         </filter>
                     </filters>

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,11 @@
             <artifactId>gt-geopkg</artifactId>
             <version>${geotools.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-shapefile</artifactId>
+            <version>${geotools.version}</version>
+        </dependency>
         <!--
             Required to identify coordinates reference systems
             Example error: No code "EPSG:4326" from authority "EPSG"

--- a/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
+++ b/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
@@ -14,6 +14,7 @@ import com.ignfab.minalac.generator.parameters.processors.GeoToolsVectorProcesso
 import com.ignfab.minalac.generator.parameters.processors.post.MetadataCopyPostProcessorParams;
 import com.ignfab.minalac.generator.parameters.processors.post.MetadataDefaultPostProcessorParams;
 import com.ignfab.minalac.generator.parameters.processors.post.MetadataParsePostProcessorParams;
+import com.ignfab.minalac.generator.parameters.providers.GeoPackageProviderParams;
 import com.ignfab.minalac.generator.parameters.providers.WFSProviderParams;
 import com.ignfab.minalac.generator.parameters.providers.WMSFloatBilProviderParams;
 import com.ignfab.minalac.generator.parameters.renderers.GroundRendererParams;
@@ -27,7 +28,6 @@ import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
 import com.ignfab.minalac.generator.world.MapWriteException;
 import com.ignfab.minalac.generator.world.VoxelWorldMetadata;
-
 import org.geotools.api.referencing.FactoryException;
 
 import java.io.File;
@@ -76,6 +76,7 @@ public final class SampleImplementation {
         parser.registerParams("building", BuildingRendererParams.class);
 
         parser.registerParams("wfs", WFSProviderParams.class);
+        parser.registerParams("gpkg", GeoPackageProviderParams.class);
         parser.registerParams("wmsFloat", WMSFloatBilProviderParams.class);
 
         parser.registerParams("floatMatrix", FloatMatrixProcessorParams.class);

--- a/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
+++ b/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
@@ -15,6 +15,7 @@ import com.ignfab.minalac.generator.parameters.processors.post.MetadataCopyPostP
 import com.ignfab.minalac.generator.parameters.processors.post.MetadataDefaultPostProcessorParams;
 import com.ignfab.minalac.generator.parameters.processors.post.MetadataParsePostProcessorParams;
 import com.ignfab.minalac.generator.parameters.providers.GeoPackageProviderParams;
+import com.ignfab.minalac.generator.parameters.providers.ShapefileProviderParams;
 import com.ignfab.minalac.generator.parameters.providers.WFSProviderParams;
 import com.ignfab.minalac.generator.parameters.providers.WMSFloatBilProviderParams;
 import com.ignfab.minalac.generator.parameters.renderers.GroundRendererParams;
@@ -77,6 +78,7 @@ public final class SampleImplementation {
 
         parser.registerParams("wfs", WFSProviderParams.class);
         parser.registerParams("gpkg", GeoPackageProviderParams.class);
+        parser.registerParams("shapefile", ShapefileProviderParams.class);
         parser.registerParams("wmsFloat", WMSFloatBilProviderParams.class);
 
         parser.registerParams("floatMatrix", FloatMatrixProcessorParams.class);

--- a/src/main/java/com/ignfab/minalac/generator/generation/DataSource.java
+++ b/src/main/java/com/ignfab/minalac/generator/generation/DataSource.java
@@ -1,9 +1,5 @@
 package com.ignfab.minalac.generator.generation;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
 import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
 import com.ignfab.minalac.generator.exceptions.IgnorableException;
 import com.ignfab.minalac.generator.exceptions.RetryableException;
@@ -12,6 +8,10 @@ import com.ignfab.minalac.generator.models.Model;
 import com.ignfab.minalac.generator.models.ModelStore;
 import com.ignfab.minalac.generator.processors.Processor;
 import com.ignfab.minalac.generator.processors.post.PostProcessor;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * A data source with a provider, a processor and some (or no) post-processors.
@@ -68,6 +68,7 @@ public class DataSource {
      */
     public void fetch() {
         try (Provider.Result<?> result = provider.provide()) {
+            processor.initialize(result.crs());
             while (result.hasNext()) {
                 Object data = result.next();
                 try {

--- a/src/main/java/com/ignfab/minalac/generator/inputs/GeoPackageDataProvider.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/GeoPackageDataProvider.java
@@ -1,0 +1,44 @@
+package com.ignfab.minalac.generator.inputs;
+
+import com.ignfab.minalac.generator.utils.coordinates.EnvelopeProvider;
+import org.geotools.api.data.DataStore;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+
+import java.io.File;
+import java.util.Map;
+
+/**
+ * Data provider using GeoPackage.
+ */
+public class GeoPackageDataProvider extends GeoToolsDataStoreProvider {
+    private final File file;
+    private final String typeName;
+
+    /**
+     * Constructs a new {@code GeoPackageDataProvider}.
+     *
+     * @param file the GPKG file.
+     * @param typeName the type name to use inside the file.
+     * @param crsOverride the CRS to use regardless of one found in data.
+     * @param envelopeProvider the envelope provider to filter features.
+     */
+    public GeoPackageDataProvider(File file, String typeName, CoordinateReferenceSystem crsOverride, EnvelopeProvider envelopeProvider) {
+        super(crsOverride, envelopeProvider);
+        this.file = file;
+        this.typeName = typeName;
+    }
+
+    @Override
+    protected Map<String, ?> dataStoreParams() {
+        return Map.of(
+            "dbtype", "geopkg",
+            "database", file.getAbsolutePath(),
+            "read-only", true
+        );
+    }
+
+    @Override
+    protected String typeName(DataStore store) {
+        return typeName;
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/inputs/GeoToolsDataStoreProvider.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/GeoToolsDataStoreProvider.java
@@ -1,0 +1,121 @@
+package com.ignfab.minalac.generator.inputs;
+
+import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
+import com.ignfab.minalac.generator.exceptions.RetryableException;
+import com.ignfab.minalac.generator.exceptions.TransformException;
+import com.ignfab.minalac.generator.utils.coordinates.EnvelopeProvider;
+import org.geotools.api.data.DataStore;
+import org.geotools.api.data.DataStoreFinder;
+import org.geotools.api.data.FeatureReader;
+import org.geotools.api.data.Query;
+import org.geotools.api.data.Transaction;
+import org.geotools.api.feature.simple.SimpleFeature;
+import org.geotools.api.feature.simple.SimpleFeatureType;
+import org.geotools.api.feature.type.GeometryDescriptor;
+import org.geotools.api.filter.Filter;
+import org.geotools.api.filter.FilterFactory;
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Data provider using GeoTools {@link DataStore}.
+ */
+public abstract class GeoToolsDataStoreProvider implements Provider<SimpleFeature> {
+    private final CoordinateReferenceSystem crsOverride;
+    private final EnvelopeProvider envelopeProvider;
+
+    /**
+     * Constructs a new {@code GeoToolsDataStoreProvider}.
+     *
+     * @param crsOverride the CRS to use regardless of one found in data.
+     * @param envelopeProvider the envelope provider to filter features.
+     */
+    public GeoToolsDataStoreProvider(CoordinateReferenceSystem crsOverride, EnvelopeProvider envelopeProvider) {
+        this.crsOverride = crsOverride;
+        this.envelopeProvider = envelopeProvider;
+    }
+
+    /**
+     * Computes params for GeoTools to find the data store.
+     * @return the appropriate params
+     * @throws GenerationFailedException if something goes wrong
+     * @see DataStoreFinder#getDataStore(Map)
+     */
+    protected abstract Map<String, ?> dataStoreParams() throws GenerationFailedException;
+
+    /**
+     * Computes the type name to use.
+     * @param store the data store
+     * @return the appropriate type name
+     * @throws GenerationFailedException if something goes wrong
+     * @throws RetryableException if something retryable goes wrong
+     * @see DataStore#getSchema(String)
+     */
+    protected abstract String typeName(DataStore store) throws GenerationFailedException, RetryableException;
+
+    @Override
+    public Class<SimpleFeature> providedType() {
+        return SimpleFeature.class;
+    }
+
+    @Override
+    public Result<SimpleFeature> provide() throws GenerationFailedException, RetryableException {
+        try {
+            // TODO Find a better way to make sure we dispose the store in case of exception
+            // (but be careful not to dispose it too early, especially before reading data!)
+            DataStore store = DataStoreFinder.getDataStore(dataStoreParams());
+            if (store == null)
+                throw new GenerationFailedException("No DataStore found by GeoTools. Wrong params?");
+            String typeName = typeName(store);
+            GeometryDescriptor geom = store.getSchema(typeName).getGeometryDescriptor();
+
+            CoordinateReferenceSystem crs = crsOverride == null ? geom.getCoordinateReferenceSystem() : crsOverride;
+            ReferencedEnvelope envelope;
+            try {
+                envelope = envelopeProvider.computeForCRS(crs);
+            } catch (FactoryException | TransformException e) {
+                store.dispose();
+                throw new GenerationFailedException(e);
+            }
+
+            FilterFactory ff = CommonFactoryFinder.getFilterFactory();
+            Filter filter = ff.bbox(ff.property(geom.getLocalName()), envelope);
+            Query query = new Query(typeName, filter);
+
+            return new FeaturesResult(crs, store.getFeatureReader(query, Transaction.AUTO_COMMIT), store);
+        } catch (IOException e) {
+            throw new RetryableException(e);
+        }
+    }
+
+    private record FeaturesResult(CoordinateReferenceSystem crs, FeatureReader<SimpleFeatureType, SimpleFeature> reader, DataStore store) implements Result<SimpleFeature> {
+        @Override
+        public void close() throws IOException {
+            reader.close();
+            store.dispose();
+        }
+
+        @Override
+        public boolean hasNext() throws RetryableException {
+            try {
+                return reader.hasNext();
+            } catch (IOException e) {
+                throw new RetryableException(e);
+            }
+        }
+
+        @Override
+        public SimpleFeature next() throws RetryableException {
+            try {
+                return reader.next();
+            } catch (IOException e) {
+                throw new RetryableException(e);
+            }
+        }
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/inputs/Provider.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/Provider.java
@@ -2,10 +2,9 @@ package com.ignfab.minalac.generator.inputs;
 
 import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
 import com.ignfab.minalac.generator.exceptions.RetryableException;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 
 import java.io.Closeable;
-
-import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 
 /**
  * A provider is responsible for acquiring data.
@@ -22,13 +21,6 @@ import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
  * @param <T> The type of provided elements
  */
 public interface Provider<T> {
-    /**
-     * Returns the coordinate reference system of provided data.
-     *
-     * @return CRS of provided data
-     */
-    CoordinateReferenceSystem crs();
-
     /**
      * Returns the type of provided elements.
      *
@@ -62,6 +54,13 @@ public interface Provider<T> {
      * @param <T> The type of wrapped elements
      */
     interface Result<T> extends Closeable {
+        /**
+         * Returns the coordinate reference system of resulting data.
+         *
+         * @return CRS of resulting data
+         */
+        CoordinateReferenceSystem crs();
+
         /**
          * Tells if more results are available for iteration.
          *

--- a/src/main/java/com/ignfab/minalac/generator/inputs/ShapefileDataProvider.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/ShapefileDataProvider.java
@@ -1,0 +1,51 @@
+package com.ignfab.minalac.generator.inputs;
+
+import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
+import com.ignfab.minalac.generator.exceptions.RetryableException;
+import com.ignfab.minalac.generator.utils.coordinates.EnvelopeProvider;
+import org.geotools.api.data.DataStore;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.util.Map;
+
+/**
+ * Data provider using Shapefile.
+ */
+public class ShapefileDataProvider extends GeoToolsDataStoreProvider {
+    private final File file;
+
+    /**
+     * Constructs a new {@code ShapefileDataProvider}.
+     *
+     * @param file the Shapefile.
+     * @param crsOverride the CRS to use regardless of one found in data.
+     * @param envelopeProvider the envelope provider to filter features.
+     */
+    public ShapefileDataProvider(File file, CoordinateReferenceSystem crsOverride, EnvelopeProvider envelopeProvider) {
+        super(crsOverride, envelopeProvider);
+        this.file = file;
+    }
+
+    @Override
+    protected Map<String, ?> dataStoreParams() throws GenerationFailedException {
+        try {
+            return Map.of(
+                "url", file.toURI().toURL()
+            );
+        } catch (MalformedURLException e) {
+            throw new GenerationFailedException(e);
+        }
+    }
+
+    @Override
+    protected String typeName(DataStore store) throws RetryableException {
+        try {
+            return store.getTypeNames()[0];
+        } catch (IOException e) {
+            throw new RetryableException(e);
+        }
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/inputs/WFS1_1_GML3_1_DataProvider.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/WFS1_1_GML3_1_DataProvider.java
@@ -1,15 +1,7 @@
 package com.ignfab.minalac.generator.inputs;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.MalformedURLException;
-import java.util.NoSuchElementException;
-
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.parsers.SAXParser;
-import javax.xml.parsers.SAXParserFactory;
-
+import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
+import com.ignfab.minalac.generator.exceptions.RetryableException;
 import org.geotools.api.feature.simple.SimpleFeature;
 import org.geotools.api.feature.type.FeatureType;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
@@ -26,8 +18,14 @@ import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
 
-import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
-import com.ignfab.minalac.generator.exceptions.RetryableException;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.util.NoSuchElementException;
 
 /**
  * Data provider using WFS 1.1 and GML 3.1.
@@ -116,7 +114,7 @@ public class WFS1_1_GML3_1_DataProvider implements Provider<SimpleFeature> {
      */
     private class Result implements Provider.Result<SimpleFeature> {
 
-        private int total;
+        private final int total;
         private int remaining;
         private SimpleFeatureIterator iterator;
 
@@ -125,6 +123,11 @@ public class WFS1_1_GML3_1_DataProvider implements Provider<SimpleFeature> {
             remaining = total;
             iterator = null;
         }
+
+       @Override
+       public CoordinateReferenceSystem crs() {
+           return envelope.getCoordinateReferenceSystem();
+       }
 
         /**
          * Fetches more results from URL.
@@ -207,11 +210,6 @@ public class WFS1_1_GML3_1_DataProvider implements Provider<SimpleFeature> {
                 throw new RetryableException("Could not fetch all expected features", e);
             }
         }
-    }
-
-    @Override
-    public CoordinateReferenceSystem crs() {
-        return envelope.getCoordinateReferenceSystem();
     }
 
     /**

--- a/src/main/java/com/ignfab/minalac/generator/inputs/WMSFloatBilDataProvider.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/WMSFloatBilDataProvider.java
@@ -1,19 +1,18 @@
 package com.ignfab.minalac.generator.inputs;
 
+import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
+import com.ignfab.minalac.generator.exceptions.RetryableException;
+import com.ignfab.minalac.generator.utils.iterator.Iterators;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.CRS;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Iterator;
-
-import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
-import org.geotools.geometry.jts.ReferencedEnvelope;
-import org.geotools.referencing.CRS;
-
-import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
-import com.ignfab.minalac.generator.exceptions.RetryableException;
-import com.ignfab.minalac.generator.utils.iterator.Iterators;
 
 /**
  * Data provider for Web Map Service (raster data).
@@ -127,7 +126,12 @@ public class WMSFloatBilDataProvider implements Provider<FloatGeographicDataMatr
         }
 
         @Override
-        public void close() throws IOException {}
+        public CoordinateReferenceSystem crs() {
+            return envelope.getCoordinateReferenceSystem();
+        }
+
+        @Override
+        public void close() {}
 
         @Override
         public boolean hasNext() {
@@ -139,10 +143,4 @@ public class WMSFloatBilDataProvider implements Provider<FloatGeographicDataMatr
             return iterator.next();
         }
     }
-
-    @Override
-    public CoordinateReferenceSystem crs() {
-        return envelope.getCoordinateReferenceSystem();
-    }
-
 }

--- a/src/main/java/com/ignfab/minalac/generator/parameters/DataSourceParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/DataSourceParams.java
@@ -1,9 +1,5 @@
 package com.ignfab.minalac.generator.parameters;
 
-import java.beans.ConstructorProperties;
-import java.util.ArrayList;
-import java.util.List;
-
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.ignfab.minalac.generator.generation.DataSource;
@@ -14,6 +10,10 @@ import com.ignfab.minalac.generator.parameters.processors.post.PostProcessorPara
 import com.ignfab.minalac.generator.parameters.providers.ProviderParams;
 import com.ignfab.minalac.generator.processors.Processor;
 import com.ignfab.minalac.generator.processors.post.PostProcessor;
+
+import java.beans.ConstructorProperties;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Represents the parameters used for {@link DataSource} creation.
@@ -83,7 +83,7 @@ public class DataSourceParams {
      */
     public DataSource create(Generation generation) {
         Provider<?> provider = this.provider.create(generation);
-        Processor<?, ?> processor = this.processor.create(generation, provider.crs());
+        Processor<?, ?> processor = this.processor.create(generation);
         List<PostProcessor<?, ?>> postProcessors = new ArrayList<>();
         for (PostProcessorParams params : this.postProcessors)
             postProcessors.add(params.create());

--- a/src/main/java/com/ignfab/minalac/generator/parameters/processors/FloatMatrixProcessorParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/processors/FloatMatrixProcessorParams.java
@@ -1,8 +1,5 @@
 package com.ignfab.minalac.generator.parameters.processors;
 
-import org.geotools.api.referencing.FactoryException;
-import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
-
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.inputs.FloatGeographicDataMatrix2d;
 import com.ignfab.minalac.generator.models.FloatMatrixModel;
@@ -14,11 +11,7 @@ import com.ignfab.minalac.generator.processors.Processor;
  */
 public class FloatMatrixProcessorParams extends ProcessorParams {
     @Override
-    public Processor<FloatGeographicDataMatrix2d, FloatMatrixModel> create(Generation generation, CoordinateReferenceSystem layerCrs) {
-        try {
-            return new FloatMatrixProcessor(generation.makeCoordsConverter(layerCrs));
-        } catch (FactoryException e) {
-            throw new IllegalArgumentException("Could not find a converter from layer to generation CRS", e);
-        }
+    public Processor<FloatGeographicDataMatrix2d, FloatMatrixModel> create(Generation generation) {
+        return new FloatMatrixProcessor(generation::makeCoordsConverter);
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/parameters/processors/GeoToolsVectorProcessorParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/processors/GeoToolsVectorProcessorParams.java
@@ -1,24 +1,17 @@
 package com.ignfab.minalac.generator.parameters.processors;
 
-import org.geotools.api.feature.simple.SimpleFeature;
-import org.geotools.api.referencing.FactoryException;
-import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
-
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.models.JTSGeometryModel;
 import com.ignfab.minalac.generator.processors.GeoToolsVectorProcessor;
 import com.ignfab.minalac.generator.processors.Processor;
+import org.geotools.api.feature.simple.SimpleFeature;
 
 /**
  * Parameters for GeoTools vector processors.
  */
 public class GeoToolsVectorProcessorParams extends ProcessorParams {
     @Override
-    public Processor<SimpleFeature, JTSGeometryModel> create(Generation generation, CoordinateReferenceSystem layerCrs) {
-        try {
-            return new GeoToolsVectorProcessor(generation.makeCoordsConverter(layerCrs));
-        } catch (FactoryException e) {
-            throw new IllegalArgumentException("Could not find a converter from layer to generation CRS", e);
-        }
+    public Processor<SimpleFeature, JTSGeometryModel> create(Generation generation) {
+        return new GeoToolsVectorProcessor(generation::makeCoordsConverter);
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/parameters/processors/ProcessorParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/processors/ProcessorParams.java
@@ -1,7 +1,5 @@
 package com.ignfab.minalac.generator.parameters.processors;
 
-import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
-
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.parameters.PolymorphicParams;
 import com.ignfab.minalac.generator.processors.Processor;
@@ -14,8 +12,7 @@ public abstract class ProcessorParams extends PolymorphicParams {
      * Creates the corresponding {@code Processor}.
      *
      * @param generation the generation context
-     * @param layerCrs CRS of the layer to be processed
      * @return the resulting processor
      */
-    public abstract Processor<?, ?> create(Generation generation, CoordinateReferenceSystem layerCrs);
+    public abstract Processor<?, ?> create(Generation generation);
 }

--- a/src/main/java/com/ignfab/minalac/generator/parameters/providers/GeoPackageProviderParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/providers/GeoPackageProviderParams.java
@@ -1,0 +1,71 @@
+package com.ignfab.minalac.generator.parameters.providers;
+
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.inputs.GeoPackageDataProvider;
+import com.ignfab.minalac.generator.inputs.Provider;
+import org.geotools.api.feature.simple.SimpleFeature;
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.referencing.CRS;
+
+import java.beans.ConstructorProperties;
+import java.io.File;
+
+/**
+ * Parameters for GeoPackage providers.
+ */
+public class GeoPackageProviderParams extends ProviderParams {
+    /**
+     * Path to GPKG file (required).
+     */
+    @JsonSetter(nulls = Nulls.FAIL)
+    public String filePath;
+
+    /**
+     * Type of features to read (required).
+     */
+    @JsonSetter(nulls = Nulls.FAIL)
+    public String typeName;
+
+    /**
+     * Coordinate reference system to use when reading data (optional, default: none).
+     * By default, the CRS is read from the GeoPackage itself. You should only use this
+     * parameter if the CRS is invalid or missing from the file.
+     * This DOES NOT reproject data!
+     */
+    @JsonSetter(nulls = Nulls.SKIP)
+    public String crsOverride;
+
+    /**
+     * Creates a new GeoPackageProviderParams with mandatory fields.
+     *
+     * @param filePath Path to GPKG file (absolute, or relative to current execution context)
+     * @param typeName Type of features to read inside the file
+     */
+    @ConstructorProperties({"filePath", "typeName"})
+    public GeoPackageProviderParams(String filePath, String typeName) {
+        this.filePath = filePath;
+        this.typeName = typeName;
+    }
+
+    @Override
+    public Provider<SimpleFeature> create(Generation generation) {
+        CoordinateReferenceSystem crsOverride;
+        if (this.crsOverride != null)
+            try {
+                crsOverride = CRS.decode(this.crsOverride);
+            } catch (FactoryException e) {
+                throw new IllegalArgumentException("CRS code \"%s\" is invalid".formatted(this.crsOverride), e);
+            }
+        else
+            crsOverride = null;
+
+        File file = new File(filePath);
+        if (!file.isFile())
+            throw new IllegalArgumentException("File \"%s\" does not exist".formatted(file.getAbsolutePath()));
+
+        return new GeoPackageDataProvider(file, typeName, crsOverride, generation::getEnvelopeForCRS);
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/parameters/providers/ShapefileProviderParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/providers/ShapefileProviderParams.java
@@ -1,0 +1,63 @@
+package com.ignfab.minalac.generator.parameters.providers;
+
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.inputs.Provider;
+import com.ignfab.minalac.generator.inputs.ShapefileDataProvider;
+import org.geotools.api.feature.simple.SimpleFeature;
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.referencing.CRS;
+
+import java.beans.ConstructorProperties;
+import java.io.File;
+
+/**
+ * Parameters for Shapefile providers.
+ */
+public class ShapefileProviderParams extends ProviderParams {
+    /**
+     * Path to Shapefile (required).
+     */
+    @JsonSetter(nulls = Nulls.FAIL)
+    public String filePath;
+
+    /**
+     * Coordinate reference system to use when reading data (optional, default: none).
+     * By default, the CRS is read from the Shapefile itself. You should only use this
+     * parameter if the CRS is invalid or missing from the file.
+     * This DOES NOT reproject data!
+     */
+    @JsonSetter(nulls = Nulls.SKIP)
+    public String crsOverride;
+
+    /**
+     * Creates a new ShapefileProviderParams with mandatory fields.
+     *
+     * @param filePath Path to Shapefile (absolute, or relative to current execution context)
+     */
+    @ConstructorProperties({"filePath"})
+    public ShapefileProviderParams(String filePath) {
+        this.filePath = filePath;
+    }
+
+    @Override
+    public Provider<SimpleFeature> create(Generation generation) {
+        CoordinateReferenceSystem crsOverride;
+        if (this.crsOverride != null)
+            try {
+                crsOverride = CRS.decode(this.crsOverride);
+            } catch (FactoryException e) {
+                throw new IllegalArgumentException("CRS code \"%s\" is invalid".formatted(this.crsOverride), e);
+            }
+        else
+            crsOverride = null;
+
+        File file = new File(filePath);
+        if (!file.isFile())
+            throw new IllegalArgumentException("File \"%s\" does not exist".formatted(file.getAbsolutePath()));
+
+        return new ShapefileDataProvider(file, crsOverride, generation::getEnvelopeForCRS);
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/processors/FloatMatrixProcessor.java
+++ b/src/main/java/com/ignfab/minalac/generator/processors/FloatMatrixProcessor.java
@@ -1,26 +1,38 @@
 package com.ignfab.minalac.generator.processors;
 
+import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
 import com.ignfab.minalac.generator.exceptions.IgnorableException;
 import com.ignfab.minalac.generator.exceptions.TransformException;
 import com.ignfab.minalac.generator.inputs.FloatGeographicDataMatrix2d;
 import com.ignfab.minalac.generator.models.FloatMatrixModel;
+import com.ignfab.minalac.generator.utils.coordinates.CoordsConverterProvider;
 import com.ignfab.minalac.generator.utils.coordinates.MapToWorldConverter;
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 
 /**
  * Processor transforming {@link FloatGeographicDataMatrix2d} into a
  * {@link FloatMatrixModel}.
  */
 public class FloatMatrixProcessor implements Processor<FloatGeographicDataMatrix2d, FloatMatrixModel> {
-
+    private final CoordsConverterProvider converterProvider;
     private MapToWorldConverter converter;
 
     /**
      * Creates a new {@code FloatMatrixProcessor}.
-     *
-     * @param converter converter to use to transform coordinates from map to world
+     * @param converterProvider converter provider to transform coordinates from map to world
      */
-    public FloatMatrixProcessor(MapToWorldConverter converter) {
-        this.converter = converter;
+    public FloatMatrixProcessor(CoordsConverterProvider converterProvider) {
+        this.converterProvider = converterProvider;
+    }
+
+    @Override
+    public void initialize(CoordinateReferenceSystem layerCrs) throws GenerationFailedException {
+        try {
+            converter = converterProvider.computeForCRS(layerCrs);
+        } catch (FactoryException e) {
+            throw new GenerationFailedException("Could not find a converter from layer to generation CRS", e);
+        }
     }
 
     @Override
@@ -41,5 +53,4 @@ public class FloatMatrixProcessor implements Processor<FloatGeographicDataMatrix
             throw new IgnorableException(e);
         }
     }
-
 }

--- a/src/main/java/com/ignfab/minalac/generator/processors/GeoToolsVectorProcessor.java
+++ b/src/main/java/com/ignfab/minalac/generator/processors/GeoToolsVectorProcessor.java
@@ -1,12 +1,15 @@
 package com.ignfab.minalac.generator.processors;
 
+import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
 import com.ignfab.minalac.generator.exceptions.IgnorableException;
 import com.ignfab.minalac.generator.exceptions.TransformException;
 import com.ignfab.minalac.generator.models.JTSGeometryModel;
+import com.ignfab.minalac.generator.utils.coordinates.CoordsConverterProvider;
 import com.ignfab.minalac.generator.utils.coordinates.MapToWorldConverter;
-
 import org.geotools.api.feature.Property;
 import org.geotools.api.feature.simple.SimpleFeature;
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.locationtech.jts.geom.Geometry;
 
 /**
@@ -17,14 +20,24 @@ import org.locationtech.jts.geom.Geometry;
  * This processor pairs well with {@link com.ignfab.minalac.generator.inputs.WFS1_1_GML3_1_DataProvider}.
  */
 public class GeoToolsVectorProcessor implements Processor<SimpleFeature, JTSGeometryModel> {
-    private final MapToWorldConverter converter;
+    private final CoordsConverterProvider converterProvider;
+    private MapToWorldConverter converter;
 
     /**
      * Creates a new processor using the given converter to for the {@link JTSGeometryModel}.
-     * @param converter the converter to pass to the geometry model
+     * @param converterProvider the converter provider to transform coordinates from map to world
      */
-    public GeoToolsVectorProcessor(MapToWorldConverter converter) {
-        this.converter = converter;
+    public GeoToolsVectorProcessor(CoordsConverterProvider converterProvider) {
+        this.converterProvider = converterProvider;
+    }
+
+    @Override
+    public void initialize(CoordinateReferenceSystem layerCrs) throws GenerationFailedException {
+        try {
+            converter = converterProvider.computeForCRS(layerCrs);
+        } catch (FactoryException e) {
+            throw new GenerationFailedException("Could not find a converter from layer to generation CRS", e);
+        }
     }
 
     @Override

--- a/src/main/java/com/ignfab/minalac/generator/processors/Processor.java
+++ b/src/main/java/com/ignfab/minalac/generator/processors/Processor.java
@@ -3,6 +3,7 @@ package com.ignfab.minalac.generator.processors;
 import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
 import com.ignfab.minalac.generator.exceptions.IgnorableException;
 import com.ignfab.minalac.generator.models.Model;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 
 /**
  * A processor is responsible for transforming elements coming from
@@ -34,6 +35,13 @@ public interface Processor<T, M extends Model> {
      * @return the type of created models
      */
     Class<M> modelType();
+
+    /**
+     * Initializes this processor with the given CRS.
+     * @param layerCrs CRS of the layer to be processed
+     * @throws GenerationFailedException If unable to initialize
+     */
+    void initialize(CoordinateReferenceSystem layerCrs) throws GenerationFailedException;
 
     /**
      * Processes an element and creates a corresponding model.

--- a/src/main/java/com/ignfab/minalac/generator/utils/coordinates/CoordsConverterProvider.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/coordinates/CoordsConverterProvider.java
@@ -1,0 +1,20 @@
+package com.ignfab.minalac.generator.utils.coordinates;
+
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+
+/**
+ * A {@code CoordsConverterProvider} computes converter from a given CRS.
+ * This is useful to get a coords converter without knowing the CRS yet.
+ * @see #computeForCRS(CoordinateReferenceSystem)
+ */
+@FunctionalInterface
+public interface CoordsConverterProvider {
+    /**
+     * Computes and returns the coords converter from the given CRS.
+     * @param fromCrs the source CRS of the conversion
+     * @return the resulting converter
+     * @see com.ignfab.minalac.generator.generation.Generation#makeCoordsConverter(CoordinateReferenceSystem)
+     */
+    MapToWorldConverter computeForCRS(CoordinateReferenceSystem fromCrs) throws FactoryException;
+}

--- a/src/main/java/com/ignfab/minalac/generator/utils/coordinates/EnvelopeProvider.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/coordinates/EnvelopeProvider.java
@@ -1,0 +1,22 @@
+package com.ignfab.minalac.generator.utils.coordinates;
+
+import com.ignfab.minalac.generator.exceptions.TransformException;
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+
+/**
+ * An {@code EnvelopeProvider} computes envelope in a given CRS.
+ * This is useful to get an envelope without knowing the CRS yet.
+ * @see #computeForCRS(CoordinateReferenceSystem)
+ */
+@FunctionalInterface
+public interface EnvelopeProvider {
+    /**
+     * Computes and returns the envelope in the given CRS.
+     * @param crs the CRS to encode coordinates in
+     * @return the resulting envelope
+     * @see com.ignfab.minalac.generator.generation.Generation#getEnvelopeForCRS(CoordinateReferenceSystem)
+     */
+    ReferencedEnvelope computeForCRS(CoordinateReferenceSystem crs) throws FactoryException, TransformException;
+}

--- a/src/test/java/com/ignfab/minalac/generator/inputs/TestingProvider.java
+++ b/src/test/java/com/ignfab/minalac/generator/inputs/TestingProvider.java
@@ -2,11 +2,10 @@ package com.ignfab.minalac.generator.inputs;
 
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 
-import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
-import com.ignfab.minalac.generator.exceptions.RetryableException;
+import java.util.NoSuchElementException;
 
 public class TestingProvider implements Provider<String> {
-    private CoordinateReferenceSystem crs;
+    private final CoordinateReferenceSystem crs;
 
     public TestingProvider(CoordinateReferenceSystem crs) {
         this.crs = crs;
@@ -18,12 +17,25 @@ public class TestingProvider implements Provider<String> {
     }
 
     @Override
-    public Result<String> provide() throws GenerationFailedException, RetryableException {
-        return null;
-    }
+    public Result<String> provide() {
+        return new Result<>() {
+            @Override
+            public CoordinateReferenceSystem crs() {
+                return crs;
+            }
 
-    @Override
-    public CoordinateReferenceSystem crs() {
-        return crs;
+            @Override
+            public void close() {}
+
+            @Override
+            public boolean hasNext() {
+                return false;
+            }
+
+            @Override
+            public String next() {
+                throw new NoSuchElementException();
+            }
+        };
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/parameters/processors/FloatMatrixProcessorParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/processors/FloatMatrixProcessorParamsTest.java
@@ -1,33 +1,27 @@
 package com.ignfab.minalac.generator.parameters.processors;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import org.geotools.api.referencing.FactoryException;
-import org.geotools.api.referencing.NoSuchAuthorityCodeException;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.referencing.CRS;
 import org.junit.jupiter.api.Test;
 
-import com.ignfab.minalac.generator.generation.Generation;
-import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
-import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class FloatMatrixProcessorParamsTest {
     @Test
-    public void testCreate() throws NoSuchAuthorityCodeException, FactoryException {
+    public void testCreate() throws FactoryException {
         CoordinateReferenceSystem crs2154 = CRS.decode("EPSG:2154");
-        CoordinateReferenceSystem crs4326 = CRS.decode("EPSG:4326");
 
         Generation generation = new Generation(
             new TestingVoxelWorld(
                 new WorldBBox3d(-10, -10, -10, 20, 20, 20)
             ), null, crs2154, 0, 0, 20, 20, 1, 1, 0.0);
 
-        // A simple OK test with same CRS
+        // A simple OK test
         final FloatMatrixProcessorParams params = new FloatMatrixProcessorParams();
-        assertDoesNotThrow(() -> params.create(generation, crs2154));
-
-        // A OK test with different CRS
-        assertDoesNotThrow(() -> params.create(generation, crs4326));
+        assertDoesNotThrow(() -> params.create(generation));
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/parameters/processors/GeoToolsVectorProcessorParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/processors/GeoToolsVectorProcessorParamsTest.java
@@ -1,33 +1,27 @@
 package com.ignfab.minalac.generator.parameters.processors;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import org.geotools.api.referencing.FactoryException;
-import org.geotools.api.referencing.NoSuchAuthorityCodeException;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.referencing.CRS;
 import org.junit.jupiter.api.Test;
 
-import com.ignfab.minalac.generator.generation.Generation;
-import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
-import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class GeoToolsVectorProcessorParamsTest {
     @Test
-    public void testCreate() throws NoSuchAuthorityCodeException, FactoryException {
+    public void testCreate() throws FactoryException {
         CoordinateReferenceSystem crs2154 = CRS.decode("EPSG:2154");
-        CoordinateReferenceSystem crs4326 = CRS.decode("EPSG:4326");
 
         Generation generation = new Generation(
             new TestingVoxelWorld(
                 new WorldBBox3d(-10, -10, -10, 20, 20, 20)
             ), null, crs2154, 0, 0, 20, 20, 1, 1, 0.0);
 
-        // A simple OK test with same CRS
+        // A simple OK test
         final GeoToolsVectorProcessorParams params = new GeoToolsVectorProcessorParams();
-        assertDoesNotThrow(() -> params.create(generation, crs2154));
-
-        // A OK test with different CRS
-        assertDoesNotThrow(() -> params.create(generation, crs4326));
+        assertDoesNotThrow(() -> params.create(generation));
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/parameters/processors/TestingProcessorParams.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/processors/TestingProcessorParams.java
@@ -1,14 +1,12 @@
 package com.ignfab.minalac.generator.parameters.processors;
 
-import java.beans.ConstructorProperties;
-
-import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
-
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.processors.Processor;
 import com.ignfab.minalac.generator.processors.TestingProcessor;
+
+import java.beans.ConstructorProperties;
 
 public class TestingProcessorParams extends ProcessorParams {
     /**
@@ -32,7 +30,7 @@ public class TestingProcessorParams extends ProcessorParams {
     }
 
     @Override
-    public Processor<?, ?> create(Generation generation, CoordinateReferenceSystem layerCrs) {
+    public Processor<?, ?> create(Generation generation) {
         return new TestingProcessor();
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/parameters/providers/GeoPackageProviderParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/providers/GeoPackageProviderParamsTest.java
@@ -1,0 +1,42 @@
+package com.ignfab.minalac.generator.parameters.providers;
+
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.referencing.CRS;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class GeoPackageProviderParamsTest {
+    @Test
+    public void testCreate(@TempDir File tmp) throws FactoryException, IOException {
+        CoordinateReferenceSystem crs = CRS.decode("EPSG:2154");
+        Generation generation = new Generation(
+            new TestingVoxelWorld(
+                new WorldBBox3d(-10, -10, -10, 20, 20, 20)
+            ), null, crs, 0, 0, 20, 20, 1, 1, 0);
+        File file = new File(tmp, "fake.gpkg");
+        if (!file.createNewFile())
+            fail("Unable to setup test file");
+
+        // A simple OK test
+        GeoPackageProviderParams params = new GeoPackageProviderParams(file.getAbsolutePath(), "feature1");
+        assertDoesNotThrow(() -> params.create(generation));
+
+        // Missing file test
+        params.filePath = "/tmp/invalid/path.gpkg";
+        assertThrows(IllegalArgumentException.class, () -> params.create(generation));
+        params.filePath = file.getAbsolutePath();
+
+        // Wrong CRS test
+        params.crsOverride = "ThisIsNotACrs";
+        assertThrows(IllegalArgumentException.class, () -> params.create(generation));
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/parameters/providers/ShapefileProviderParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/providers/ShapefileProviderParamsTest.java
@@ -1,0 +1,42 @@
+package com.ignfab.minalac.generator.parameters.providers;
+
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.referencing.CRS;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ShapefileProviderParamsTest {
+    @Test
+    public void testCreate(@TempDir File tmp) throws FactoryException, IOException {
+        CoordinateReferenceSystem crs = CRS.decode("EPSG:2154");
+        Generation generation = new Generation(
+            new TestingVoxelWorld(
+                new WorldBBox3d(-10, -10, -10, 20, 20, 20)
+            ), null, crs, 0, 0, 20, 20, 1, 1, 0);
+        File file = new File(tmp, "fake.shp");
+        if (!file.createNewFile())
+            fail("Unable to setup test file");
+
+        // A simple OK test
+        ShapefileProviderParams params = new ShapefileProviderParams(file.getAbsolutePath());
+        assertDoesNotThrow(() -> params.create(generation));
+
+        // Missing file test
+        params.filePath = "/tmp/invalid/path.shp";
+        assertThrows(IllegalArgumentException.class, () -> params.create(generation));
+        params.filePath = file.getAbsolutePath();
+
+        // Wrong CRS test
+        params.crsOverride = "ThisIsNotACrs";
+        assertThrows(IllegalArgumentException.class, () -> params.create(generation));
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/processors/GeoToolsVectorProcessorTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/processors/GeoToolsVectorProcessorTest.java
@@ -8,13 +8,17 @@ import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
 import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
 import org.geotools.api.feature.simple.SimpleFeature;
 import org.geotools.api.feature.simple.SimpleFeatureType;
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.data.DataUtilities;
 import org.geotools.feature.SchemaException;
+import org.geotools.referencing.CRS;
 import org.geotools.referencing.operation.transform.IdentityTransform;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.util.AffineTransformation;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.ignfab.minalac.generator.utils.iterator.IteratorTester.assertBrowsesAllOnce;
 import static org.junit.jupiter.api.Assertions.*;
@@ -23,8 +27,15 @@ public class GeoToolsVectorProcessorTest {
     private static final MapToWorldConverter IDENTITY_CONVERTER = new MapToWorldConverter(IdentityTransform.create(2), new AffineTransformation());
 
     @Test
-    public void test() throws SchemaException {
-        GeoToolsVectorProcessor processor = new GeoToolsVectorProcessor(IDENTITY_CONVERTER);
+    public void test() throws SchemaException, FactoryException {
+        CoordinateReferenceSystem crs2154 = CRS.decode("EPSG:2154");
+        AtomicBoolean initialized = new AtomicBoolean(false);
+        GeoToolsVectorProcessor processor = new GeoToolsVectorProcessor(crs -> {
+            initialized.set(crs == crs2154);
+            return IDENTITY_CONVERTER;
+        });
+        assertDoesNotThrow(() -> processor.initialize(crs2154)); // layerCrs is only validated but not actually used by the converter provider we gave above
+        assertTrue(initialized.get(), "processor initialized with given CRS");
 
         // Validate capabilities of processor
         assertTrue(processor.acceptedType().isAssignableFrom(SimpleFeature.class), "processor accepts SimpleFeature");

--- a/src/test/java/com/ignfab/minalac/generator/processors/TestingProcessor.java
+++ b/src/test/java/com/ignfab/minalac/generator/processors/TestingProcessor.java
@@ -1,8 +1,7 @@
 package com.ignfab.minalac.generator.processors;
 
-import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
-import com.ignfab.minalac.generator.exceptions.IgnorableException;
 import com.ignfab.minalac.generator.models.TestingModel;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 
 public class TestingProcessor implements Processor<String, TestingModel> {
 
@@ -17,7 +16,10 @@ public class TestingProcessor implements Processor<String, TestingModel> {
     }
 
     @Override
-    public TestingModel process(String object) throws GenerationFailedException, IgnorableException {
+    public void initialize(CoordinateReferenceSystem layerCrs) {}
+
+    @Override
+    public TestingModel process(String object) {
         return new TestingModel();
     }
 


### PR DESCRIPTION
### Type of modification

- Code
  - Inputs
- Documentation
  - Javadoc Comments
  - Markdown Files

### Changes

Add two new data providers: GeoPackage & Shapefile

#### Feature description

This PR adds two data providers based on GeoTools. They both rely on the `DataStore` class, and the `GeoToolsDataStoreProvider` is an abstract class created to reduce code duplication.

The `GeoPackageDataProvider` reads features `typeName` from a `.gpkg` file.

The `ShapefileDataProvider` reads features from a `.shp` file and its supporting files.

They are both fully compatible with `GeoToolsVectorProcessor` and can be interchanged with `WFS1_1_GML3_1_DataProvider`.

#### Technical changes

`gt-geopkg` are GeoPackage bindings for GeoTools.
`gt-shapefile` are Shapefime bindings for GeoTools.

### Reason

Having GeoPackage files may help with integration testing, and some data sources are only available as GeoPackage or Shapefile download.

### Self-checks

- ~~The code has unit tests associated~~
- [x] The code has Javadoc Comments associated
- ~~Complex / Unexpected code is explained / justified with a small comment~~
- [x] Relevant documentation inside the `/docs` folder has been updated
- [x] All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [x] The texts have been proofread (documentation, error messages, logs, comments...)
