### PR TITLE
Preliminary fixes to allow perfectly tiled generation

### DIFF
--- a/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
+++ b/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
@@ -13,6 +13,7 @@ import com.ignfab.minalac.generator.parameters.renderers.HeightmapRendererParams
 import com.ignfab.minalac.generator.parameters.renderers.VectorRendererParams;
 import com.ignfab.minalac.generator.utils.execution.TaskFailedException;
 import com.ignfab.minalac.generator.utils.network.HttpTrustAllSSL;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
 import com.ignfab.minalac.generator.world.MapWriteException;
 import com.ignfab.minalac.generator.world.VoxelWorldMetadata;
@@ -72,7 +73,10 @@ public final class SampleImplementation {
 
         System.out.println("Saving world");
         VoxelWorldMetadata metadata = generation.world().getMetadata();
-        metadata.setSpawn(new WorldCoords3d(0, 0, generation.heightmaps().get("ground").get(0, 0) + 1));
+        WorldBBox3d limits = generation.world().limits();
+        int spawnX = (limits.minX() + limits.maxX() + 1) / 2;
+        int spawnY = (limits.minY() + limits.maxY() + 1) / 2;
+        metadata.setSpawn(new WorldCoords3d(spawnX, spawnY, generation.heightmaps().get("ground").get(spawnX, spawnY) + 1));
         metadata.setWorldName("Minalac");
 
         File directory = cli.getOutputPath().toFile();

--- a/src/main/java/com/ignfab/minalac/generator/generation/Generation.java
+++ b/src/main/java/com/ignfab/minalac/generator/generation/Generation.java
@@ -143,12 +143,16 @@ public class Generation {
     public ReferencedEnvelope getEnvelopeForCRS(CoordinateReferenceSystem crs) throws FactoryException, TransformException {
         WorldToMapConverter converter = makeCoordsConverter(crs).inverse();
 
+        int minX = world.limits().minX();
+        int minY = world.limits().minY();
+        int maxX = world.limits().maxX() + 1;
+        int maxY = world.limits().maxY() + 1;
         Geometry geom = new GeometryFactory().createLinearRing(new Coordinate[] {
-            new Coordinate(world.limits().minX(), world.limits().minY()),
-            new Coordinate(world.limits().maxX(), world.limits().minY()),
-            new Coordinate(world.limits().maxX(), world.limits().maxY()),
-            new Coordinate(world.limits().minX(), world.limits().maxY()),
-            new Coordinate(world.limits().minX(), world.limits().minY())
+            new Coordinate(minX, minY),
+            new Coordinate(maxX, minY),
+            new Coordinate(maxX, maxY),
+            new Coordinate(minX, maxY),
+            new Coordinate(minX, minY)
         });
 
         return new ReferencedEnvelope(converter.convert(geom).getEnvelopeInternal(), crs);

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCBlockEntityVoxelType.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCBlockEntityVoxelType.java
@@ -45,8 +45,8 @@ public abstract class MCBlockEntityVoxelType extends MCVoxelType {
         // X/Y/Z => X/Z/-Y
         block.putInt("x", x);
         block.putInt("y", z);
-        block.putInt("z", -y);
+        block.putInt("z", -y - 1);
         serialize(block);
-        world.addBlockEntity(x, z, -y, block); // X/Y/Z => X/Z/-Y
+        world.addBlockEntity(x, z, -y - 1, block); // X/Y/Z => X/Z/-Y
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelType.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelType.java
@@ -59,6 +59,6 @@ public class MCVoxelType implements VoxelType {
             properties.forEach(state::putString);
             block.put("Properties", state);
         }
-        world.setBlockState(x, z, -y, block); // X/Y/Z => X/Z/-Y
+        world.setBlockState(x, z, -y - 1, block); // X/Y/Z => X/Z/-Y
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelWorld.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelWorld.java
@@ -100,8 +100,8 @@ public class MCVoxelWorld extends VoxelWorld {
                 WorldBBox3d bbox = limits();
                 WorldSize3d size = limits().size();
                 double minSize = Math.max(size.x(), size.y());
-                data.putDouble("BorderCenterX", (bbox.minX() + bbox.maxX()) / 2d);
-                data.putDouble("BorderCenterZ", (bbox.minY() + bbox.maxY()) / 2d); // Y => Z
+                data.putDouble("BorderCenterX", (bbox.minX() + bbox.maxX() + 1) / 2d);
+                data.putDouble("BorderCenterZ", -(bbox.minY() + bbox.maxY() + 1) / 2d); // X/Y/Z => X/Z/-Y
                 data.putDouble("BorderDamagePerBlock", 0.2);
                 data.putDouble("BorderSafeZone", 5);
                 data.putDouble("BorderSize", minSize);
@@ -299,7 +299,7 @@ public class MCVoxelWorld extends VoxelWorld {
                         // TODO Replace by a better constraint management mechanism
                         // pos.addDouble(metadata.getSpawn().z());
                         pos.addDouble(Math.min(Math.max(limits().minZ(), metadata.getSpawn().z()), limits().maxZ()));
-                        pos.addDouble(-metadata.getSpawn().y() + 0.5);
+                        pos.addDouble(-(metadata.getSpawn().y() + 0.5));
                     }
                     player.put("Pos", pos);
 
@@ -365,7 +365,7 @@ public class MCVoxelWorld extends VoxelWorld {
                 // TODO Replace by a better constraint management mechanism
                 // data.putInt("SpawnY", metadata.getSpawn().z());
                 data.putInt("SpawnY", Math.min(Math.max(limits().minZ(), metadata.getSpawn().z()), limits().maxZ()));
-                data.putInt("SpawnZ", -metadata.getSpawn().y());
+                data.putInt("SpawnZ", -metadata.getSpawn().y() - 1);
 
                 data.putBoolean("thundering", false);
                 data.putInt("thunderTime", 0x7FFFFFFF);
@@ -517,6 +517,6 @@ public class MCVoxelWorld extends VoxelWorld {
     // In-Game coords
     /* package-private */ boolean isOutOfLimits(int blockX, int blockY, int blockZ) {
         // (In-Game coords to world coords) X/Z/-Y => X/Y/Z
-        return !limits().contains(blockX, -blockZ, blockY);
+        return !limits().contains(blockX, -(blockZ + 1), blockY);
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/generation/TestGeneration.java
+++ b/src/test/java/com/ignfab/minalac/generator/generation/TestGeneration.java
@@ -40,16 +40,16 @@ public class TestGeneration {
 
     @Test
     public void testGeneration() throws FactoryException, TransformException {
-        VoxelWorld world = new EmptyVoxelWorld(501, 501);
+        VoxelWorld world = new EmptyVoxelWorld(500, 500);
         // 657_781, 6_860_729 (EPSG:2154) IGN Saint Mandé
-        Generation generation = new Generation(world, seed, crs2154, 657_781, 6_860_729, 501, 501, 2.0, 3.0);
+        Generation generation = new Generation(world, seed, crs2154, 657_781, 6_860_729, 500, 500, 2.0, 3.0);
 
         assertEquals(seed, generation.seed());
         WorldBBox3d box = generation.world().limits();
         assertEquals(-250, box.minX());
         assertEquals(-250, box.minY());
-        assertEquals(250, box.maxX());
-        assertEquals(250, box.maxY());
+        assertEquals(249, box.maxX());
+        assertEquals(249, box.maxY());
 
         // We should have an envelope +/- 500 around center (250 voxel * 2.0 meters/voxels = 500m)
         Envelope envelope = generation.getEnvelopeForCRS(crs2154);

--- a/src/test/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelTypeTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelTypeTest.java
@@ -26,7 +26,7 @@ public class MCVoxelTypeTest {
         air.place(3, -7, 64);
         CompoundTag expectedAir = new CompoundTag();
         expectedAir.putString("Name", "minecraft:air");
-        worldMock.assertBlockStateAt(3, 64, 7, expectedAir); // X/Y/Z => X/Z/-Y
+        worldMock.assertBlockStateAt(3, 64, 6, expectedAir); // X/Y/Z => X/Z/-Y
 
         MCVoxelType stairs = new MCVoxelType(worldMock, "minecraft:oak_stairs", Map.of(
             "facing", "north",
@@ -43,7 +43,7 @@ public class MCVoxelTypeTest {
         properties.putString("shape", "straight");
         properties.putString("waterlogged", "false");
         expectedStairs.put("Properties", properties);
-        worldMock.assertBlockStateAt(-43, 192, 0, expectedStairs); // X/Y/Z => X/Z/-Y
+        worldMock.assertBlockStateAt(-43, 192, -1, expectedStairs); // X/Y/Z => X/Z/-Y
     }
 
     private static final class WorldMock extends MCVoxelWorld {

--- a/src/test/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelWorldTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelWorldTest.java
@@ -58,16 +58,16 @@ public class MCVoxelWorldTest {
         world.setLimits(new WorldBBox3d(new WorldCoords3d(-10, -20, 0), new WorldCoords3d(20, 30, 40)));
 
         // X/Y/Z => X/Z/-Y
-        assertFalse(world.isOutOfLimits(-10, 0, 20));
-        assertFalse(world.isOutOfLimits(20, 40, -30));
+        assertFalse(world.isOutOfLimits(-10, 0, 19));
+        assertFalse(world.isOutOfLimits(20, 40, -31));
 
-        assertFalse(world.isOutOfLimits(5, 5, -20));
+        assertFalse(world.isOutOfLimits(5, 5, -21));
 
-        assertTrue(world.isOutOfLimits(21, 40, -30));
-        assertTrue(world.isOutOfLimits(20, 41, -30));
-        assertTrue(world.isOutOfLimits(20, 40, -31));
-        assertTrue(world.isOutOfLimits(-11, 0, 20));
-        assertTrue(world.isOutOfLimits(-10, -1, 20));
-        assertTrue(world.isOutOfLimits(-10, 0, 21));
+        assertTrue(world.isOutOfLimits(21, 40, -31));
+        assertTrue(world.isOutOfLimits(20, 41, -31));
+        assertTrue(world.isOutOfLimits(20, 40, -32));
+        assertTrue(world.isOutOfLimits(-11, 0, 19));
+        assertTrue(world.isOutOfLimits(-10, -1, 19));
+        assertTrue(world.isOutOfLimits(-10, 0, 20));
     }
 }


### PR DESCRIPTION
### Type of modification

- Code
  - General
  - Outputs
- Tests

### Changes

Preliminary fixes to allow perfectly tiled generation.

#### Feature description

While experimenting with tiled generation, I ran into issues due to imperfect tiling (misaligned edges, gaps between tiles...) and this PR fixes all those little bugs.

Three small fixes are included:
1. (Minecraft only) The generated world was offset by 1 along the Z axis.
2. The envelope computed by the `Generation` class was 1 unit short compared to the generated world size.
3. The world spawn was not located at the center of the generated world, but rather at fixed location (0, 0).

I will quickly describe each issue as well as why it was present and how I fixed it.

**1. Z offset in Minecraft**
In Minecraft, the Z axis is facing south, as opposed to both Minetest and IRL maps where Z is traditionally facing north. Initially, we didn't notice this until I start to experiment with roads (now in PR #58). At the early stage of development, I committed a fix via PR #50, to use `-z` instead. However, what I failed to notice after this fix was the 1-block-offset I introduced!

To understand this bug, we first need to take a closer look at the world's size (when even), and how the integer coordinates are handled (explained here in 2d for simplicity):
- Voxel position (0, 0) is the voxel from decimal (0.0, 0.0) to (0.99, 0.99).
- The absolute middle of the generated world is decimal (0.0, 0.0), meaning that if we split the world into 4 equals quarters, voxel (0, 0) belongs to the upper-right (IRL north-east) quarter.
- With world size (32, 32), the resulting limits are voxel (-16, -16) to voxel (15, 15).

With that said, it becomes clear that a simple minus sign in front of the `z` value won't work. A voxel on the border of the world with Z = 15 will be placed at Z = -15 (instead of -16), and voxel at Z = -16 will be placed at Z = 16 (instead of 15), causing a +1 shift of the whole generated world. Furthermore, the limits are also affected, meaning that they become -15 to 16.

Luckily enough, the fix is pretty easy: Subtract 1 to Z when converting from "Generator => Minecraft", and add 1 back to reverse from "Minecraft => Generator".

However, this fix will cause the shift to be present on odd world size. Nevertheless, odd world size is unusual, as Minecraft stores blocks (voxels) in 16x16x16 areas, and tiling can only be achieved with size divisible by 512, thus I prefer to focus on even size.

**2. Envelope too small**
The `Generation` class computes an `Envelope` from the in-game world size, by applying the appropriate transformation. The envelope is the smallest bounding box in decimal coordinates that contains all the generated world. However, I noticed that the computed envelope was 1 unit short on each axis, effectively causing the last row and the last column of voxels to be missing data.

The reason behind this bug is somewhat similar to the previous one, it depends on the interpretation of the world's limits. As said before, size (32, 32) leads to bounds (-16, -16) and (15, 15). In voxel coordinates, this is exact (because the voxel from 15.0 to 15.99 is included), however, in decimal coordinates, this leads to a size of 31, excluding the last voxel.

The fix for this is trivial, to include in the envelope the last row/column of voxels, we just need to take decimal bounds from voxel min to voxel max + 1 (so the last voxel is inside).

**3. Spawn location at (0, 0)**
The in-game spawn location is computed inside `SampleImplementation`. The current code was using hardcoded (0, 0) coordinates instead of the real center (computed from world's limits). Furthermore, the height was retrieved from the ground heightmap without even checking that those coordinates were in-bounds.

When trying to introduce an "offset" to the generation, I moved the world's limits and at some point, the location (0, 0) was outside of the generated area. This caused an exception when trying to read the height.

The fix is also relatively simple, the spawn location is now computed as the center of the generated world area, and the height is assured to be valid. This does not change anything without an offset, and because the offset mechanism is not included in this PR, this change effectively has not effect on current generation.

#### Showcase

I will illustrate the issues using a 32x32 Minecraft generation.

_From above:_
![minecraft-32x32-bugged-above](https://github.com/user-attachments/assets/82faa79a-370d-43a6-b5f9-1e978e87a9dc)
In yellow, the world border is also offset by 0.5. this issue was not mentioned because it was fixed as a result of Minecraft Z offset issue and small envelope issue.
In red, the offset of the generated world along the Z axis (red arrow). Voxels on the right are missing, because the whole map is shifted by 1 and extra voxels goes beyond the expected border (on the left).

_From beneath:_
![minecraft-32x32-bugged-below](https://github.com/user-attachments/assets/0921cd04-27e2-4cda-95a0-57b79dbff6cb)
In green, we can see a row and column of voxels at a default height of 0, because no height data was loaded for them (envelope too small, they were outside).
In purple, the correct height where they should have been generated.

_With fixes applied:_
![minecraft-32x32-fixed](https://github.com/user-attachments/assets/48365e2a-91e4-451f-8ad8-7f678a7f76b3)
The generated world now perfectly fills the expected area

_Note: The outside of the border is randomly generated by Minecraft the first time the world is opened in the game. This also explains the difference of grass color and flowing liquids (will probably need to be addressed in a later PR)_

### Reason

While those bugs were not a big deal with current generation (only caused imperfection at the edge of the generated world), they needed to be addressed before starting working on tiling. In fact, the edge of generated tiles must be perfect to align properly each other!

### Self-checks

- [x] The code has unit tests associated
- [x] The code has Javadoc Comments associated
- ~~Complex / Unexpected code is explained / justified with a small comment~~
- ~~Relevant documentation inside the `/docs` folder has been updated~~
- [x] All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [x] The texts have been proofread (documentation, error messages, logs, comments...)
