### PR TITLE
Deserialization des post-processeurs "parse" et "default"

### DIFF
--- a/docs/usage/GenerationParameters.md
+++ b/docs/usage/GenerationParameters.md
@@ -163,6 +163,25 @@ A post-processor copying a metadata into another.
 - `abortIfMetadataIsAbsent` (optional, default `no`): `yes` to stop the copy if the metadata is missing, `no` to allow the copy to proceed even if the metadata is missing (in this case, the metadata value will be empty).
 - `keepExisting` (optional, default `no`): `no` to overwrite existing data, `yes` to keep existing metadata.
 
+### Metadata parse
+
+Post-processor parsing a metadata value in-place.
+
+**Type**: `parse`
+
+**Extra parameters**:
+- `metadata` (required): the name of the metadata to parse.
+- `as` (required): the type of parsed value: `integer`, `decimal`, `boolean`, `text`.
+- `ifMissing` (optional, default `error`): What to do when metadata is absent. See failure policies below.
+- `ifNotParsable` (optional, default `error`): What to do if data parsing fails. See failure policies below.
+
+| Failure policy | Explanation |
+| :--- | :--- |
+| `discardModel` | The model is discarded. |
+| `removeMetadata` | The metadata is removed. |
+| `ignore` | Failure is ignored, nothing is done. |
+| `error` | An error occurs, and the generation stops. |
+
 ## Renderer parameters
 
 Each renderer has a field `type` which is used to identify it.

--- a/docs/usage/GenerationParameters.md
+++ b/docs/usage/GenerationParameters.md
@@ -182,6 +182,17 @@ Post-processor parsing a metadata value in-place.
 | `ignore` | Failure is ignored, nothing is done. |
 | `error` | An error occurs, and the generation stops. |
 
+### Metadata default
+
+Post-processor that applies a default value for a specified metadata.
+
+**Type**: `default`
+
+**Extra parameters**
+- `metadata` (required): the name of the metadata.
+- `value` (required): the default value to use if the metadata is not present.
+- `as` (requires): the type to which the value should be converted:  `integer`, `decimal`, `boolean`, `text`
+
 ## Renderer parameters
 
 Each renderer has a field `type` which is used to identify it.

--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -27,6 +27,10 @@ sources:
         as: integer
         ifMissing: ignore
         ifNotParsable: removeMetadata
+      - type: default
+        metadata: height
+        value: 5
+        as: integer
 renderers:
   altitude:
     after:

--- a/examples/default.yaml
+++ b/examples/default.yaml
@@ -22,6 +22,11 @@ sources:
       - type: copy
         metadata: hauteur
         to: height
+      - type: parse
+        metadata: height
+        as: integer
+        ifMissing: ignore
+        ifNotParsable: removeMetadata
 renderers:
   altitude:
     after:

--- a/examples/minecraft.yaml
+++ b/examples/minecraft.yaml
@@ -27,6 +27,10 @@ sources:
         as: integer
         ifMissing: ignore
         ifNotParsable: removeMetadata
+      - type: default
+        metadata: height
+        value: 5
+        as: integer
 renderers:
   altitude:
     after:

--- a/examples/minecraft.yaml
+++ b/examples/minecraft.yaml
@@ -22,6 +22,11 @@ sources:
       - type: copy
         metadata: hauteur
         to: height
+      - type: parse
+        metadata: height
+        as: integer
+        ifMissing: ignore
+        ifNotParsable: removeMetadata
 renderers:
   altitude:
     after:

--- a/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
+++ b/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
@@ -12,6 +12,7 @@ import com.ignfab.minalac.generator.parameters.placeables.minetest.MTVoxelTypePa
 import com.ignfab.minalac.generator.parameters.processors.FloatMatrixProcessorParams;
 import com.ignfab.minalac.generator.parameters.processors.GeoToolsVectorProcessorParams;
 import com.ignfab.minalac.generator.parameters.processors.post.MetadataCopyPostProcessorParams;
+import com.ignfab.minalac.generator.parameters.processors.post.MetadataDefaultPostProcessorParams;
 import com.ignfab.minalac.generator.parameters.processors.post.MetadataParsePostProcessorParams;
 import com.ignfab.minalac.generator.parameters.providers.WFSProviderParams;
 import com.ignfab.minalac.generator.parameters.providers.WMSFloatBilProviderParams;
@@ -73,6 +74,7 @@ public final class SampleImplementation {
 
         parser.registerParams("copy", MetadataCopyPostProcessorParams.class);
         parser.registerParams("parse", MetadataParsePostProcessorParams.class);
+        parser.registerParams("default", MetadataDefaultPostProcessorParams.class);
 
         Generation generation = parser.parse(cli.readParameters()).create();
 

--- a/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
+++ b/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
@@ -12,6 +12,7 @@ import com.ignfab.minalac.generator.parameters.placeables.minetest.MTVoxelTypePa
 import com.ignfab.minalac.generator.parameters.processors.FloatMatrixProcessorParams;
 import com.ignfab.minalac.generator.parameters.processors.GeoToolsVectorProcessorParams;
 import com.ignfab.minalac.generator.parameters.processors.post.MetadataCopyPostProcessorParams;
+import com.ignfab.minalac.generator.parameters.processors.post.MetadataParsePostProcessorParams;
 import com.ignfab.minalac.generator.parameters.providers.WFSProviderParams;
 import com.ignfab.minalac.generator.parameters.providers.WMSFloatBilProviderParams;
 import com.ignfab.minalac.generator.parameters.renderers.GroundRendererParams;
@@ -71,6 +72,7 @@ public final class SampleImplementation {
         parser.registerParams("geoToolsVector", GeoToolsVectorProcessorParams.class);
 
         parser.registerParams("copy", MetadataCopyPostProcessorParams.class);
+        parser.registerParams("parse", MetadataParsePostProcessorParams.class);
 
         Generation generation = parser.parse(cli.readParameters()).create();
 

--- a/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/FailurePolicyParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/FailurePolicyParams.java
@@ -1,0 +1,51 @@
+package com.ignfab.minalac.generator.parameters.processors.post;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.ignfab.minalac.generator.processors.post.MetadataParsePostProcessor.ParsingFailurePolicy;
+
+/**
+ * Parameters for {@link ParsingFailurePolicy}.
+ *
+ * Avoids scattering configuration-specific names
+ * for {@link ParsingFailurePolicy} across the codebase.
+ */
+public enum FailurePolicyParams {
+    /**
+     * Maps the "ignore" JSON value to {@link ParsingFailurePolicy}.
+     */
+    @JsonProperty("ignore")
+    IGNORE(ParsingFailurePolicy.IGNORE),
+
+    /**
+     * Maps the "removeMetadata" JSON value to {@link ParsingFailurePolicy}.
+     */
+    @JsonProperty("removeMetadata")
+    REMOVE_METADATA(ParsingFailurePolicy.REMOVE_METADATA),
+
+    /**
+     * Maps the "discardModel" JSON value to {@link ParsingFailurePolicy}.
+     */
+    @JsonProperty("discardModel")
+    DISCARD_MODEL(ParsingFailurePolicy.DISCARD_MODEL),
+
+    /**
+     * Maps the "error" JSON value to {@link ParsingFailurePolicy}.
+     */
+    @JsonProperty("error")
+    ERROR(ParsingFailurePolicy.ERROR);
+
+    private final ParsingFailurePolicy parsingFailurePolicy;
+
+    FailurePolicyParams(ParsingFailurePolicy parsingFailurePolicy) {
+        this.parsingFailurePolicy = parsingFailurePolicy;
+    }
+
+    /**
+     * Returns the associated {@link ParsingFailurePolicy}.
+     *
+     * @return the corresponding {@link ParsingFailurePolicy}
+     */
+    public ParsingFailurePolicy create() {
+        return parsingFailurePolicy;
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataDefaultPostProcessorParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataDefaultPostProcessorParams.java
@@ -1,0 +1,60 @@
+package com.ignfab.minalac.generator.parameters.processors.post;
+
+import java.beans.ConstructorProperties;
+
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import com.ignfab.minalac.generator.models.Model;
+import com.ignfab.minalac.generator.parameters.processors.post.parsers.ValueParsers;
+import com.ignfab.minalac.generator.processors.post.PostProcessor;
+import com.ignfab.minalac.generator.processors.post.MetadataDefaultPostProcessor;
+
+/**
+ * Parameters for {@link MetadataDefaultPostProcessor}.
+ */
+public class MetadataDefaultPostProcessorParams extends PostProcessorParams {
+    /**
+     * Name of the metadata (required).
+     */
+    @JsonSetter(nulls = Nulls.FAIL)
+    public final String metadata;
+
+    /**
+     * Default value to use if the metadata is not present (required).
+     */
+    @JsonSetter(nulls = Nulls.FAIL)
+    public final String value;
+
+    /**
+     * Type to which the value should be converted (required).
+     */
+    @JsonSetter(nulls = Nulls.FAIL)
+    public final String as;
+
+    /**
+     * Constructor used to ensure that the required fields are present during
+     * deserialization.
+     *
+     * @param metadata name of the metadata
+     * @param value default value to use if the metadata is not present
+     * @param as type to which the value should be converted
+     */
+    @ConstructorProperties({ "metadata", "value", "as" })
+    public MetadataDefaultPostProcessorParams(String metadata, String value, String as) {
+        this.metadata = metadata;
+        this.value = value;
+        this.as = as;
+    }
+
+    @Override
+    public void validate() throws IllegalArgumentException {
+        if (metadata.isBlank())
+            throw new IllegalArgumentException("The 'metadata' field cannot be empty or contain only whitespace.");
+        ValueParsers.validate(as);
+    }
+
+    @Override
+    public PostProcessor<Model, Model> create() {
+        return new MetadataDefaultPostProcessor(metadata, ValueParsers.get(as).parser().apply(value));
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataParsePostProcessorParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataParsePostProcessorParams.java
@@ -1,0 +1,71 @@
+package com.ignfab.minalac.generator.parameters.processors.post;
+
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import com.ignfab.minalac.generator.models.Model;
+import com.ignfab.minalac.generator.parameters.processors.post.parsers.ValueParsers;
+import com.ignfab.minalac.generator.processors.post.MetadataParsePostProcessor;
+import com.ignfab.minalac.generator.processors.post.PostProcessor;
+
+import java.beans.ConstructorProperties;
+
+/**
+ * Parameters for {@link MetadataParsePostProcessor}.
+ */
+public class MetadataParsePostProcessorParams extends PostProcessorParams {
+    /**
+     * Name of the metadata to parse (required).
+     */
+    @JsonSetter(nulls = Nulls.FAIL)
+    public final String metadata;
+
+    /**
+     * Type of parsed value (required).
+     */
+    @JsonSetter(nulls = Nulls.FAIL)
+    public final String as;
+
+    /**
+     * Parsing function to use when the metadata is absent (optional).
+     */
+    @JsonSetter(nulls = Nulls.SKIP)
+    public FailurePolicyParams ifMissing = FailurePolicyParams.ERROR;
+
+    /**
+     * Parsing function to use when the {@code parser} return null (optional).
+     */
+    @JsonSetter(nulls = Nulls.SKIP)
+    public FailurePolicyParams ifNotParsable = FailurePolicyParams.ERROR;
+
+    /**
+     * Constructor used to ensure that the required fields
+     * are present during deserialization.
+     *
+     * @param metadata name of the metadata to parse
+     * @param as type of parsed value
+     */
+    @ConstructorProperties({ "metadata", "as" })
+    public MetadataParsePostProcessorParams(String metadata, String as) {
+        this.metadata = metadata;
+        this.as = as;
+    }
+
+    @Override
+    public void validate() throws IllegalArgumentException {
+        if (metadata.isBlank())
+            throw new IllegalArgumentException("The 'metadata' field cannot be empty or contain only whitespace.");
+        ValueParsers.validate(as);
+    }
+
+    @Override
+    public PostProcessor<Model, Model> create() {
+        ValueParsers.Parser<Object> parser = ValueParsers.get(as);
+        return new MetadataParsePostProcessor<>(
+            metadata,
+            parser.type(),
+            parser.parser(),
+            ifMissing.create(),
+            ifNotParsable.create()
+        );
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/parsers/ValueParsers.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/parsers/ValueParsers.java
@@ -1,0 +1,88 @@
+package com.ignfab.minalac.generator.parameters.processors.post.parsers;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Utility class for managing parsers for different types.
+ */
+public final class ValueParsers {
+
+    /**
+     * Parser for a specific type.
+     *
+     * @param <T> target type to convert to
+     * @param type target type to convert to
+     * @param parser function that performs the conversion
+     */
+    public record Parser<T>(Class<T> type, Function<Object, ? extends T> parser) {}
+
+    /**
+     * Map to register parsers for different types.
+     */
+    private static final Map<String, Parser<?>> PARSERS = new HashMap<>();
+
+    // Registers predefined parsers
+    static {
+        addParser("integer", Integer.class, obj -> Integer.valueOf(obj.toString()));
+        addParser("decimal", Double.class, obj -> Double.valueOf(obj.toString()));
+        addParser("text", String.class, Object::toString);
+        addParser("boolean", Boolean.class, obj -> (obj instanceof Boolean bool) ? bool : switch (obj.toString()) {
+            case "true" -> true;
+            case "false" -> false;
+            default -> throw new IllegalArgumentException("The value : " + obj.toString() + " isn't a boolean.");
+        });
+    }
+
+    /**
+     * Private constructor to prevent instantiation.
+     */
+    private ValueParsers() {
+        throw new UnsupportedOperationException("This is a utility class and cannot be instantiated.");
+    }
+
+    /**
+     * Checks if a parser has been registered for this key.
+     *
+     * @param key key identifying the parser
+     * @throws IllegalArgumentException if the key is blank or no parser is found for the key
+     */
+    public static void validate(String key) {
+        if (key.isBlank())
+            throw new IllegalArgumentException("The 'as' field cannot be empty or contain only whitespace.");
+
+        if (!PARSERS.containsKey(key))
+            throw new IllegalArgumentException("No parser found for key: " + key + ". Expected one of " + PARSERS.keySet());
+    }
+
+    /**
+     * Adds a new parser.
+     *
+     * @param <T> target type for the parser.
+     * @param key key identifying the parser
+     * @param type target type for the parser
+     * @param parser function that performs the parsing
+     * @throws IllegalArgumentException if the key already exists
+     */
+    public static <T> void addParser(String key, Class<T> type, Function<Object, ? extends T> parser) {
+        if (PARSERS.containsKey(key))
+            throw new IllegalArgumentException("Cannot add, the key is already registered");
+        PARSERS.put(key, new Parser<T>(type, parser));
+    }
+
+    /**
+     * Retrieves the parser associated with the given key.
+     *
+     * @param <T> target type of the parser
+     * @param key key identifying the parser
+     * @return parser associated with the key
+     * @throws IllegalArgumentException if no parser is found for the key
+     */
+    public static <T> Parser<T> get(String key) {
+        validate(key);
+        @SuppressWarnings("unchecked")
+        Parser<T> parser = (Parser<T>) PARSERS.get(key);
+        return parser;
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/processors/post/MetadataDefaultPostProcessor.java
+++ b/src/main/java/com/ignfab/minalac/generator/processors/post/MetadataDefaultPostProcessor.java
@@ -1,0 +1,39 @@
+package com.ignfab.minalac.generator.processors.post;
+
+import com.ignfab.minalac.generator.models.Model;
+
+/**
+ * Post-processor that applies a default value for a specified metadata.
+ */
+public class MetadataDefaultPostProcessor implements PostProcessor<Model, Model> {
+    private final String name;
+    private final Object defaultValue;
+
+    /**
+     * Creates a new post-processor with a default value for the specified metadata.
+     *
+     * @param name the name of the metadata
+     * @param defaultValue the default value to use if the metadata is not present
+     */
+    public MetadataDefaultPostProcessor(String name, Object defaultValue) {
+        this.name = name;
+        this.defaultValue = defaultValue;
+    }
+
+    @Override
+    public Class<? super Model> acceptedModelType() {
+        return Model.class;
+    }
+
+    @Override
+    public Class<? extends Model> processedModelType(Class<? extends Model> inputModelType) {
+       return inputModelType;
+    }
+
+    @Override
+    public Model process(Model model) {
+        if (!model.hasMetadata(name))
+            model.setMetadata(name, defaultValue);
+        return model;
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/processors/post/MetadataParsePostProcessor.java
+++ b/src/main/java/com/ignfab/minalac/generator/processors/post/MetadataParsePostProcessor.java
@@ -8,39 +8,37 @@ import java.util.function.Function;
 
 /**
  * Post-processor parsing a metadata value in-place.
+ *
  * @param <T> type of parsed value
  */
 public class MetadataParsePostProcessor<T> implements PostProcessor<Model, Model> {
     private final String name;
     private final Class<T> type;
     private final Function<Object, ? extends T> parser;
-    private final ParsingFailurePolicy failurePolicy;
-    private final boolean failWhenMissingMetadata;
-    private final boolean failWhenParserReturnNull;
+    private final ParsingFailurePolicy ifMissingMetadata;
+    private final ParsingFailurePolicy ifParserFails;
 
     /**
-     * Creates a new post-processor parsing {@code name} as a {@code type}.
-     * @param name the name of the metadata to parse
-     * @param type the type of parsed value
-     * @param parser the parsing function to use
-     * @param failurePolicy what to do in case of failure (e.g. exception in {@code parser})
-     * @param failWhenMissingMetadata whether the absence of metadata is a failure
-     * @param failWhenParserReturnNull whether {@code null} return value from {@code parser} is a failure
+     * Creates a new post-processor parsing metadata {@code name} as a {@code type}.
+     *
+     * @param name name of the metadata to parse
+     * @param type type of parsed value
+     * @param parser parsing function to use
+     * @param ifMissingMetadata policy to apply when the metadata is absent
+     * @param ifParserFails policy to apply when the {@code parser} return error
      */
     public MetadataParsePostProcessor(
         String name,
         Class<T> type,
         Function<Object, ? extends T> parser,
-        ParsingFailurePolicy failurePolicy,
-        boolean failWhenMissingMetadata,
-        boolean failWhenParserReturnNull
+        ParsingFailurePolicy ifMissingMetadata,
+        ParsingFailurePolicy ifParserFails
     ) {
         this.name = name;
         this.type = type;
         this.parser = parser;
-        this.failurePolicy = failurePolicy;
-        this.failWhenMissingMetadata = failWhenMissingMetadata;
-        this.failWhenParserReturnNull = failWhenParserReturnNull;
+        this.ifMissingMetadata = ifMissingMetadata;
+        this.ifParserFails = ifParserFails;
     }
 
     @Override
@@ -55,28 +53,28 @@ public class MetadataParsePostProcessor<T> implements PostProcessor<Model, Model
 
     @Override
     public Model process(Model model) throws GenerationFailedException, IgnorableException {
-        if (model.hasMetadata(name)) {
-            Object value = model.getMetadata(name);
-            if (type.isAssignableFrom(value.getClass()))
-                return model;
-            try {
-                T parsed = parser.apply(value);
-                if (parsed == null && failWhenParserReturnNull)
-                    throw new Exception("Parsing function returned null");
-                model.setMetadata(name, parsed);
-            } catch (Throwable e) {
-                switch (failurePolicy) {
-                    case IGNORE -> {}
-                    case REMOVE_METADATA -> model.setMetadata(name, null);
-                    case SKIP_MODEL -> throw new IgnorableException("Failed to parse metadata: " + name, e);
-                    case ERROR -> throw new GenerationFailedException("Failed to parse metadata: " + name, e);
+        if (!model.hasMetadata(name))
+            switch (ifMissingMetadata) {
+                case IGNORE, REMOVE_METADATA -> {
+                    return model;
                 }
-            }
-        } else if (failWhenMissingMetadata) {
-            switch (failurePolicy) {
-                case IGNORE, REMOVE_METADATA -> {}
-                case SKIP_MODEL -> throw new IgnorableException("Missing metadata: " + name);
+                case DISCARD_MODEL -> throw new IgnorableException("Missing metadata: " + name);
                 case ERROR -> throw new GenerationFailedException("Missing metadata: " + name);
+            }
+
+        Object value = model.getMetadata(name);
+        if (type.isInstance(value))
+            return model;
+
+        try {
+            T parsed = parser.apply(value);
+            model.setMetadata(name, parsed);
+        } catch (Throwable e) {
+            switch (ifParserFails) {
+                case IGNORE -> {}
+                case REMOVE_METADATA -> model.setMetadata(name, null);
+                case DISCARD_MODEL -> throw new IgnorableException("Failed to parse metadata: " + name, e);
+                case ERROR -> throw new GenerationFailedException("Failed to parse metadata: " + name, e);
             }
         }
         return model;
@@ -95,9 +93,9 @@ public class MetadataParsePostProcessor<T> implements PostProcessor<Model, Model
          */
         REMOVE_METADATA,
         /**
-         * Throws an {@link IgnorableException} to skip the model.
+         * Throws an {@link IgnorableException} to discard the model.
          */
-        SKIP_MODEL,
+        DISCARD_MODEL,
         /**
          * Throws an {@link GenerationFailedException} causing a fatal error.
          */

--- a/src/test/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataDefaultPostProcessorParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataDefaultPostProcessorParamsTest.java
@@ -1,0 +1,25 @@
+package com.ignfab.minalac.generator.parameters.processors.post;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class MetadataDefaultPostProcessorParamsTest {
+    @Test
+    public void testCreate() {
+        MetadataDefaultPostProcessorParams params;
+        params = new MetadataDefaultPostProcessorParams("toto", "toto", "integer");
+        assertThrows(NumberFormatException.class, params::create);
+
+        params = new MetadataDefaultPostProcessorParams("toto", "5", "integer");
+        assertDoesNotThrow(params::create);
+    }
+
+    @Test
+    public void testValidate() {
+        assertThrows(IllegalArgumentException.class, new MetadataDefaultPostProcessorParams("", "5", "integer")::validate);
+        assertThrows(IllegalArgumentException.class, new MetadataDefaultPostProcessorParams("toto", "5", "invalid")::validate);
+        assertDoesNotThrow(new MetadataDefaultPostProcessorParams("toto", "5", "integer")::validate);
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataParsePostProcessorParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataParsePostProcessorParamsTest.java
@@ -1,0 +1,63 @@
+package com.ignfab.minalac.generator.parameters.processors.post;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+public class MetadataParsePostProcessorParamsTest {
+    private static ObjectMapper mapper;
+
+    @BeforeAll
+    public static void init() {
+        mapper = new ObjectMapper(new YAMLFactory());
+        mapper.registerSubtypes(new NamedType(MetadataParsePostProcessorParams.class, "parse"));
+    }
+
+    @Test
+    public void testValidate() {
+        assertThrows(IllegalArgumentException.class, new MetadataParsePostProcessorParams("", "integer")::validate);
+        assertThrows(IllegalArgumentException.class, new MetadataParsePostProcessorParams("toto", "invalid")::validate);
+        assertDoesNotThrow(new MetadataParsePostProcessorParams("toto", "integer")::validate);
+    }
+
+    @Test
+    public void testCreate() throws JsonProcessingException {
+        String parseYaml = """
+        type: parse
+        metadata: tata
+        as: decimal
+        ifMissing: discardModel
+        ifNotParsable: removeMetadata
+        """;
+
+        MetadataParsePostProcessorParams params = mapper.readValue(parseYaml, MetadataParsePostProcessorParams.class);
+        assertDoesNotThrow(params::create);
+
+        parseYaml = """
+        type: parse
+        metadata: tata
+        as: decimal
+        ifMissing: discardModel
+        """;
+
+        params = mapper.readValue(parseYaml, MetadataParsePostProcessorParams.class);
+        assertDoesNotThrow(params::create);
+
+        parseYaml = """
+        type: parse
+        metadata: tata
+        as: decimal
+        ifNotParsable: removeMetadata
+        """;
+
+        params = mapper.readValue(parseYaml, MetadataParsePostProcessorParams.class);
+        assertDoesNotThrow(params::create);
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/parameters/processors/post/parsers/ValueParsersTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/processors/post/parsers/ValueParsersTest.java
@@ -1,0 +1,76 @@
+package com.ignfab.minalac.generator.parameters.processors.post.parsers;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Test;
+
+public class ValueParsersTest {
+    @Test
+    public void testValidate() {
+        assertDoesNotThrow(() -> ValueParsers.validate("integer"));
+
+        assertThrows(IllegalArgumentException.class, () -> ValueParsers.validate(""));
+        assertThrows(IllegalArgumentException.class, () -> ValueParsers.validate("toto"));
+    }
+
+    @Test
+    public void testAddParser() {
+        assertDoesNotThrow(() -> ValueParsers.addParser("dummy", String.class, Object::toString));
+        assertThrows(IllegalArgumentException.class, () -> ValueParsers.addParser("dummy", String.class, Object::toString));
+    }
+
+    @Test
+    public void testIntegerParser() {
+        Integer result;
+        Function<Object, ?> parser = ValueParsers.get("integer").parser();
+
+        result = (Integer) assertDoesNotThrow(() -> parser.apply("1234567890"));
+        assertEquals(1234567890, result);
+
+        result = (Integer) assertDoesNotThrow(() -> parser.apply("-3"));
+        assertEquals(-3, result);
+
+        assertDoesNotThrow(() -> parser.apply(12345));
+
+        assertThrows(NumberFormatException.class, () -> parser.apply(12345.6789));
+        assertThrows(NumberFormatException.class, () -> parser.apply("12345.67890"));
+    }
+
+    @Test
+    public void testDecimalParser() {
+        Double result;
+        Function<Object, ?> parser = ValueParsers.get("decimal").parser();
+
+        result = (Double) assertDoesNotThrow(() -> parser.apply("12345.67890"));
+        assertEquals(12345.6789, result);
+
+        result = (Double) assertDoesNotThrow(() -> parser.apply("-9"));
+        assertEquals(-9, result);
+
+        result = (Double) assertDoesNotThrow(() -> parser.apply(1234567890));
+        assertEquals(1234567890, result);
+
+        assertThrows(NumberFormatException.class, () -> parser.apply("toto"));
+    }
+
+    @Test
+    public void testTextParser() {
+        // Assume converting "dummy" to a string works with "1", "8.9", or an object, so no further testing is needed.
+        assertEquals("dummy", (String) ValueParsers.get("text").parser().apply("dummy"));
+    }
+
+    @Test
+    public void testBooleanParser() {
+        Function<Object, ?> parser = ValueParsers.get("boolean").parser();
+
+        assertTrue((Boolean) assertDoesNotThrow(() -> parser.apply("true")));
+        assertTrue((Boolean) assertDoesNotThrow(() -> parser.apply(true)));
+        assertFalse((Boolean) assertDoesNotThrow(() -> parser.apply("false")));
+        assertFalse((Boolean) assertDoesNotThrow(() -> parser.apply(false)));
+
+        assertThrows(IllegalArgumentException.class, () -> parser.apply("yes"));
+        assertThrows(IllegalArgumentException.class, () -> parser.apply(1.));
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/processors/post/MetadataDefaultPostProcessorTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/processors/post/MetadataDefaultPostProcessorTest.java
@@ -1,0 +1,27 @@
+package com.ignfab.minalac.generator.processors.post;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import org.junit.jupiter.api.Test;
+
+import com.ignfab.minalac.generator.models.TestingModel;
+
+public class MetadataDefaultPostProcessorTest {
+    @Test
+    public static void testConstructor() {
+        assertDoesNotThrow(() -> new MetadataDefaultPostProcessor("toto", 1));
+    }
+
+    @Test
+    public void testProcess() {
+        MetadataDefaultPostProcessor processor = new MetadataDefaultPostProcessor("toto", 1);
+        TestingModel model = new TestingModel();
+
+        assertDoesNotThrow(() -> processor.process(model));
+        model.assertMetadata("toto", 1);
+
+        model.setMetadata("toto", 10);
+        assertDoesNotThrow(() -> processor.process(model));
+        model.assertMetadata("toto", 10);
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/processors/post/MetadataParsePostProcessorTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/processors/post/MetadataParsePostProcessorTest.java
@@ -32,8 +32,7 @@ public class MetadataParsePostProcessorTest {
             Object.class,
             Function.identity(),
             MetadataParsePostProcessor.ParsingFailurePolicy.IGNORE,
-            false,
-            false
+            MetadataParsePostProcessor.ParsingFailurePolicy.IGNORE
         );
         assertTrue(postProcessor.acceptedModelType().isAssignableFrom(TestingModel.class), "post-processor accepts any model type");
         assertTrue(TestingModel.class.isAssignableFrom(postProcessor.processedModelType(TestingModel.class)), "post-processor produces same model type");
@@ -52,8 +51,7 @@ public class MetadataParsePostProcessorTest {
             Objects::toString,
             // Failure policy is irrelevant for this test as there is no failure
             MetadataParsePostProcessor.ParsingFailurePolicy.ERROR,
-            false,
-            false
+            MetadataParsePostProcessor.ParsingFailurePolicy.ERROR
         ));
         processed.assertMetadata("int", "7");
         processed.assertMetadata("string", "value", "Unrelated metadata untouched");
@@ -68,8 +66,7 @@ public class MetadataParsePostProcessorTest {
                 throw new RuntimeException();
             },
             MetadataParsePostProcessor.ParsingFailurePolicy.ERROR,
-            false,
-            false
+            MetadataParsePostProcessor.ParsingFailurePolicy.ERROR
         ).process(model));
     }
 
@@ -79,9 +76,8 @@ public class MetadataParsePostProcessorTest {
             "missing",
             String.class,
             Objects::toString,
-            MetadataParsePostProcessor.ParsingFailurePolicy.ERROR,
-            false,
-            false
+            MetadataParsePostProcessor.ParsingFailurePolicy.IGNORE,
+            MetadataParsePostProcessor.ParsingFailurePolicy.IGNORE
         ));
         processed.assertMetadataAbsent("missing", "Metadata still absent");
     }
@@ -93,8 +89,7 @@ public class MetadataParsePostProcessorTest {
             String.class,
             Objects::toString,
             MetadataParsePostProcessor.ParsingFailurePolicy.ERROR,
-            true,
-            false
+            MetadataParsePostProcessor.ParsingFailurePolicy.ERROR
         ).process(model));
     }
 
@@ -105,22 +100,9 @@ public class MetadataParsePostProcessorTest {
             String.class,
             obj -> null,
             MetadataParsePostProcessor.ParsingFailurePolicy.ERROR,
-            false,
-            false
+            MetadataParsePostProcessor.ParsingFailurePolicy.REMOVE_METADATA
         ));
         processed.assertMetadataAbsent("int", "Metadata removed");
-    }
-
-    @Test
-    public void testNullForbidden() {
-        assertThrows(GenerationFailedException.class, () -> new MetadataParsePostProcessor<>(
-            "int",
-            String.class,
-            obj -> null,
-            MetadataParsePostProcessor.ParsingFailurePolicy.ERROR,
-            false,
-            true
-        ).process(model));
     }
 
     @Test
@@ -132,8 +114,7 @@ public class MetadataParsePostProcessorTest {
                 throw new RuntimeException();
             },
             MetadataParsePostProcessor.ParsingFailurePolicy.IGNORE,
-            false,
-            false
+            MetadataParsePostProcessor.ParsingFailurePolicy.IGNORE
         ));
         processed.assertMetadata("int", 7, "Original value kept");
     }
@@ -147,8 +128,7 @@ public class MetadataParsePostProcessorTest {
                 throw new RuntimeException();
             },
             MetadataParsePostProcessor.ParsingFailurePolicy.REMOVE_METADATA,
-            false,
-            false
+            MetadataParsePostProcessor.ParsingFailurePolicy.REMOVE_METADATA
         ));
         processed.assertMetadataAbsent("int", "Original value cleared");
     }
@@ -161,9 +141,8 @@ public class MetadataParsePostProcessorTest {
             obj -> {
                 throw new RuntimeException();
             },
-            MetadataParsePostProcessor.ParsingFailurePolicy.SKIP_MODEL,
-            false,
-            false
+            MetadataParsePostProcessor.ParsingFailurePolicy.DISCARD_MODEL,
+            MetadataParsePostProcessor.ParsingFailurePolicy.DISCARD_MODEL
         ).process(model));
     }
 
@@ -176,8 +155,7 @@ public class MetadataParsePostProcessorTest {
                 throw new RuntimeException();
             },
             MetadataParsePostProcessor.ParsingFailurePolicy.ERROR,
-            false,
-            false
+            MetadataParsePostProcessor.ParsingFailurePolicy.ERROR
         ).process(model));
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to this project!
You must fill out the information below before we can review this pull request.
Be sure to update the relevant sections of this template and to complete the list of self-checks at the end.

If you need more time to check everything, consider opening a draft pull request instead.
Don't forget to update this comment to track your progress.
-->

### Type of modification

<!--
Indicate here the kind of stuff you've touched.
If your modification fits into multiple types, select all that apply and try to sort them from the most to the least important.

Types:
- Code
  - General
  - Inputs
  - Outputs
  - Tools
  - Other: (specify)
- Documentation
  - Javadoc Comments
  - Markdown Files
  - Code Comments
- Tests
- Resources
- CI/CD
- Other: (specify)
-->

Types:
- Documentation
  - Javadoc Comments
  - Markdown Files
  - Code Comments
- Code
  - processors
    - post
  - parameters
    - processors
      - post
- ~~Tests~~ (TODO)

### Issue

<!--
If an issue or a JIRA ticket about the changes in this PR exists, link it here.
Otherwise, remove this section.

> Format GitHub issue:
Closes #<issue-number>

> Format JIRA ticket:
MINALAC-<ticket-number>
-->

MINALAC-80
MINALAC-78

### Changes

<!--
Summarize in a sentence the work done here.
You will explain more deeply in the following subsections.
-->

Ajout des classes `MetadataDefaultPostProcessorParams` et `MetadataParsePostProcessorParams`.

#### Feature description

<!--
Explain in details what your pull request modifies.
Don't hesitate to put here any additional information, observation, links that you find useful and on-topic.
-->

Création de 2 nouvelles classes :
- MetadataDefaultPostProcessorParams.java
- MetadataParsePostProcessorParams.java

Ajout de la classe MetadataDefaultPostProcessorParams pour permettre de set une valeurs par défaut dans la metadonnée du model lorsque la valeur de la metadonnée est null

Enregistrement des params dans le fichier SimpleImplementation

#### Showcase

<!--
Show examples of the features related to this PR.
State explicitly how to reproduce them (step-by-step).

Try to impersonate the reviewer: What should you run? What should you do? What should you observe?
-->

```yaml
sources:
  # ...
  bati:
    modelType: building
    provider:
      type: wfs
      url: https://data.geopf.fr/wfs/wfs
      features: BDTOPO_V3:batiment
    processor:
      type: geoToolsVector
    postProcessors:
      - type: copy
        metadata: hauteur
        to: height
      - type: parse
        metadata: height
        as: integer
      - type: default
        metadata: height
        value: 20
        as: integer
```

### Reason

<!--
Justify why these changes should be merged into the project.
Share your opinion about other possible solutions that might have served the same purpose, and why you did not choose them.
-->

Les PostProcessors, disparus du fichier SampleImplementation où mes renderers #24 en avaient besoin, je dois mettre à jour le fonctionnement des PostProcessors pour ensuite mettre à jour ma PR #24 afin qu'elle puisse refonctionner.

### TODOs

<!--
List here all TODOs affected by this PR, or remove this section if none.
Include TODOs from files as well as any additional task remaining that needs to be done.

Added: Explain briefly why you left them to-do, and how they can be resolved later.
Removed: Explain briefly how you achieved the task.
Changed: Explain briefly why the task evolved.
-->

- [x] Faire le test que MetadataDefaultPostProcessorParams

### Self-checks

<!--
Check everything you did about your work in this PR.
The goal here is to save some precious time by self-checking common issues.

In case something is irrelevant to the subject, please remove the [ ] checkbox and ~~strike through~~ the text.
Example:
- [x] This task is done
- ~~This task does not apply to the work done in this PR~~
- [ ] This task still needs to be done
-->

- [x] The code has unit tests associated
- [x] The code has Javadoc Comments associated
- [x] Complex / Unexpected code is explained / justified with a small comment
- [x] Relevant documentation inside the `/docs` folder has been updated
- [x] All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [x] The texts have been proofread (documentation, error messages, logs, comments...)
