### PR TITLE
Update README.md with JDK version information

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ Compile and run using Maven:
 ```shell
 mvn -DskipTests=true clean package && java -jar target/Generator.jar -p examples/default.yaml $HOME/.minetest/worlds/minalac
 ```
+
+Make sure you're using a JDK whose version is equal to or later than the target compiler version specified in `pom.xml`. For example, for this current release :
+
+```shell
+sudo apt install openjdk-17-jdk # install JDK matching target compiler version or higher
+mvn -v # check maven is using the new JDK
+```
+
 <!--
 ### From pre-built JAR
 


### PR DESCRIPTION
### Type of modification

Documentation

### Issue

None

### Changes

Adding information about JDK version to README.md.

#### Feature description

Adding information about JDK version to README.md. 

#### Technical changes

None

#### Showcase

Had to install a new version of openjdk to build the generator (was running openjdk 11 by default on ubuntu 22.04)

### Reason

Might help newcomers.
