### PR TITLE
style(params): Disable checkstyle "VisibilityModifier" rule for all params classes automatically

### DIFF
--- a/src/main/java/com/ignfab/minalac/generator/parameters/DataSourceParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/DataSourceParams.java
@@ -18,8 +18,6 @@ import com.ignfab.minalac.generator.processors.post.PostProcessor;
 /**
  * Represents the parameters used for {@link DataSource} creation.
  */
-// Since attributes are purposely kept public for this class the checkstyle for visibility is disabled.
-@SuppressWarnings("checkstyle:VisibilityModifier")
 public class DataSourceParams {
     /**
      * Type to give to provided models (required).

--- a/src/main/java/com/ignfab/minalac/generator/parameters/GenerationParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/GenerationParams.java
@@ -19,8 +19,6 @@ import java.util.Map;
  *
  * Refer to docs/usage/GenerationParameters.md for parameters format.
  */
-// Since attributes are purposely kept public for this class the checkstyle for visibility is disabled.
-@SuppressWarnings("checkstyle:VisibilityModifier")
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class GenerationParams {
     // For now :

--- a/src/main/java/com/ignfab/minalac/generator/parameters/HeightmapParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/HeightmapParams.java
@@ -8,8 +8,6 @@ import java.beans.ConstructorProperties;
 /**
  * Represents the parameters of a type of {@link Heightmap}.
  */
-// Since attributes are purposely kept public for this class the checkstyle for visibility is disabled.
-@SuppressWarnings("checkstyle:VisibilityModifier")
 public class HeightmapParams {
     /**
      * The default value for all heightmap cells.

--- a/src/main/java/com/ignfab/minalac/generator/parameters/PolymorphicParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/PolymorphicParams.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 /**
  * Base class for all polymorphic parameters with validation.
  */
-@SuppressWarnings("checkstyle:VisibilityModifier")
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 public class PolymorphicParams {
     /**

--- a/src/main/java/com/ignfab/minalac/generator/parameters/placeables/minecraft/MCVoxelTypeParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/placeables/minecraft/MCVoxelTypeParams.java
@@ -15,7 +15,6 @@ import com.ignfab.minalac.generator.world.VoxelWorld;
 /**
  * A voxel type parameters for simple Minecraft voxel types with only block type name.
  */
-@SuppressWarnings("VisibilityModifier")
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE) // Prevents default deserializer from requiring type when using "default" placeable param structure
 public class MCVoxelTypeParams extends PlaceableParams {
     /**

--- a/src/main/java/com/ignfab/minalac/generator/parameters/placeables/minetest/MTVoxelTypeParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/placeables/minetest/MTVoxelTypeParams.java
@@ -14,7 +14,6 @@ import com.ignfab.minalac.generator.world.VoxelWorld;
 /**
  * A voxel type parameters for Minetest voxel types with only node type name.
  */
-@SuppressWarnings("VisibilityModifier")
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE) // Prevents default deserializer from requiring type when using "default" placeable param structure
 public class MTVoxelTypeParams extends CustomPlaceableParams {
     /**

--- a/src/main/java/com/ignfab/minalac/generator/parameters/placeables/structures/StackStructureParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/placeables/structures/StackStructureParams.java
@@ -17,7 +17,6 @@ import com.ignfab.minalac.generator.world.VoxelWorld;
 /**
  * A simple structure made out of stacked voxels.
  */
-@SuppressWarnings("VisibilityModifier")
 public class StackStructureParams extends CustomPlaceableParams {
     /**
      * List of layers constituting the structure.

--- a/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataCopyPostProcessorParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataCopyPostProcessorParams.java
@@ -11,7 +11,6 @@ import com.ignfab.minalac.generator.processors.post.MetadataCopyPostProcessor;
 /**
  * Parameters for {@link MetadataCopyPostProcessor}.
  */
-@SuppressWarnings("checkstyle:VisibilityModifier")
 public class MetadataCopyPostProcessorParams extends PostProcessorParams {
     /**
      * Name of the metadata to copy (required).

--- a/src/main/java/com/ignfab/minalac/generator/parameters/providers/WFSProviderParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/providers/WFSProviderParams.java
@@ -16,7 +16,6 @@ import com.ignfab.minalac.generator.inputs.WFS1_1_GML3_1_DataProvider;
 /**
  * Parameters for WFS providers.
  */
-@SuppressWarnings("checkstyle:VisibilityModifier")
 public class WFSProviderParams extends ProviderParams {
     /**
      * Base URL for WFS queries (required).

--- a/src/main/java/com/ignfab/minalac/generator/parameters/providers/WMSFloatBilProviderParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/providers/WMSFloatBilProviderParams.java
@@ -16,7 +16,6 @@ import com.ignfab.minalac.generator.inputs.WMSFloatBilDataProvider;
 /**
  * Parameters for WMS float providers.
  */
-@SuppressWarnings("checkstyle:VisibilityModifier")
 public class WMSFloatBilProviderParams extends ProviderParams {
     /**
      * Base URL for WFS queries (required).

--- a/src/main/java/com/ignfab/minalac/generator/parameters/renderers/GroundRendererParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/renderers/GroundRendererParams.java
@@ -12,7 +12,6 @@ import com.ignfab.minalac.generator.renderers.Renderer;
  *
  * Until voxel structures are serializable, this perform a basic voxel structure creation
  */
-@SuppressWarnings("checkstyle:VisibilityModifier")
 public class GroundRendererParams extends RendererParams {
     /**
      * The name of the heightmap to use (required).

--- a/src/main/java/com/ignfab/minalac/generator/parameters/renderers/HeightmapRendererParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/renderers/HeightmapRendererParams.java
@@ -10,7 +10,6 @@ import java.beans.ConstructorProperties;
 /**
  * Concrete class of {@link RendererParams} representing the parameters of a {@link HeightmapRenderer}.
  */
-@SuppressWarnings("checkstyle:VisibilityModifier")
 public class HeightmapRendererParams extends RendererParams {
     /**
      * The type of models to render.

--- a/src/main/java/com/ignfab/minalac/generator/parameters/renderers/RendererParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/renderers/RendererParams.java
@@ -9,7 +9,6 @@ import com.ignfab.minalac.generator.renderers.Renderer;
 /**
  * Represents the parameters of a type of {@link Renderer}.
  */
-@SuppressWarnings("checkstyle:VisibilityModifier")
 public abstract class RendererParams extends PolymorphicParams {
     /**
      * Dependencies (optional).

--- a/src/main/java/com/ignfab/minalac/generator/parameters/renderers/VectorRendererParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/renderers/VectorRendererParams.java
@@ -11,8 +11,6 @@ import java.beans.ConstructorProperties;
 /**
  * Concrete class of {@link RendererParams} representing the parameters of a {@link VectorRenderer}.
  */
-// Since attributes are purposely kept public for this class the checkstyle for visibility is disabled.
-@SuppressWarnings("checkstyle:VisibilityModifier")
 public class VectorRendererParams extends RendererParams {
     /**
      * The type of models to render (required).

--- a/src/test/java/com/ignfab/minalac/generator/parameters/placeables/TestingVoxelTypeParams.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/placeables/TestingVoxelTypeParams.java
@@ -13,7 +13,6 @@ import com.ignfab.minalac.generator.world.VoxelWorld;
 /**
  * A voxel type parameters for simple Minetest voxel types with only node type name.
  */
-@SuppressWarnings("VisibilityModifier")
 @JsonTypeInfo(use = JsonTypeInfo.Id.NONE) // Prevents default deserializer from requiring type when using "default" placeable param structure
 public class TestingVoxelTypeParams extends CustomPlaceableParams {
     /**

--- a/src/test/java/com/ignfab/minalac/generator/parameters/processors/TestingProcessorParams.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/processors/TestingProcessorParams.java
@@ -10,7 +10,6 @@ import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.processors.Processor;
 import com.ignfab.minalac.generator.processors.TestingProcessor;
 
-@SuppressWarnings("checkstyle:VisibilityModifier")
 public class TestingProcessorParams extends ProcessorParams {
     /**
      * A required field.

--- a/src/test/java/com/ignfab/minalac/generator/parameters/providers/TestingProviderParams.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/providers/TestingProviderParams.java
@@ -8,7 +8,6 @@ import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.inputs.Provider;
 import com.ignfab.minalac.generator.inputs.TestingProvider;
 
-@SuppressWarnings("checkstyle:VisibilityModifier")
 public class TestingProviderParams extends ProviderParams {
     /**
      * A required field.

--- a/src/test/java/com/ignfab/minalac/generator/parameters/renderers/TestingRendererParams.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/renderers/TestingRendererParams.java
@@ -10,7 +10,6 @@ import com.ignfab.minalac.generator.renderers.Renderer;
 /**
  * A RendererParams class for testing purposes.
  */
-@SuppressWarnings("checkstyle:VisibilityModifier")
 public class TestingRendererParams extends RendererParams {
     /**
      * A required field.

--- a/src/test/java/com/ignfab/minalac/generator/renderers/ModelRendererTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/renderers/ModelRendererTest.java
@@ -45,9 +45,8 @@ public class ModelRendererTest {
         assertEquals(0, idleRenderer.modelsRendered.size());
     }
 
-    @SuppressWarnings("checkstyle:VisibilityModifier")
     private static class ModelRendererImpl extends ModelRenderer {
-        List<ModelImpl> modelsRendered = new ArrayList<>();
+        private final List<ModelImpl> modelsRendered = new ArrayList<>();
 
         ModelRendererImpl(ModelStore store, String modelType) {
             super(new ModelSelection(store, modelType));
@@ -60,9 +59,8 @@ public class ModelRendererTest {
         }
     }
 
-    @SuppressWarnings("checkstyle:VisibilityModifier")
     private static class ModelImpl extends Model {
-        public char type;
+        private final char type;
 
         ModelImpl(char type) {
             this.type = type;

--- a/suppressions.xml
+++ b/suppressions.xml
@@ -7,5 +7,10 @@
 <suppressions>
     <suppress checks="MissingJavadocMethod" files=".*[\\/]src[\\/]test[\\/]"/>
     <suppress checks="MissingJavadocType" files=".*[\\/]src[\\/]test[\\/]"/>
+    <!--
+    Disable VisibilityModifier check for params classes.
+    Attributes in those classes are purposely kept public to be deserialized by Jackson
+    -->
+    <suppress checks="VisibilityModifier" files=".*[\\/]src[\\/](main|test)[\\/]java[\\/]com[\\/]ignfab[\\/]minalac[\\/]generator[\\/]parameters[\\/].*Params\.java"/>
 </suppressions>
 


### PR DESCRIPTION
### Type of modification

- Resources
- Other: Code-style

### Changes

Disable checkstyle "VisibilityModifier" rule for all params classes automatically.

#### Feature description

This PR adds a Checkstyle suppression in the `/suppressions.xml` file to disable the check "VisibilityModifier" for all *params* classes. We defined *params* classes as:
- A Java source class located under the `com.ignfab.minalac.generator.parameters` package
- With its name ending with the word "Params"

The check was previously disabled individually in each class, using the `@SuppressWarnings` annotation. Those have been removed as well, as they are no longer necessary.

On the other hand, there is something related to this that we may or may not want to include in this PR as well (effectively replacing it). The visibility of attributes in *params* classes have been set to `public` supposedly to allow Jackson to write them when deserializing. But this is not necessary at all. In Java, the visibility restriction can easily be bypassed at runtime using reflection, which Jackson is likely doing. It is perfectly fine to put those attributes `private` and thus remove the checkstyle rule suppression. However, using the `private` visibility might add an extra layer of encapsulation toward unit tests. For this reason, we shall decide between adding getters or using the "package-private" (aka no modifier) visibility, that will trigger a Checkstyle rule violation like `public`.

#### Showcase

Everything works as before.

### Reason

This is cleaner to do so, because it reduces meta-code duplication, and prevent mistakes that could have happened if you forget to include the annotation. Furthermore, the explanation was sometimes duplicated as well, and sometimes not. Things are now harmonized.

### Self-checks

- ~~The code has unit tests associated~~
- ~~The code has Javadoc Comments associated~~
- [x] Complex / Unexpected code is explained / justified with a small comment
- ~~Relevant documentation inside the `/docs` folder has been updated~~
- [x] All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [x] The texts have been proofread (documentation, error messages, logs, comments...)
