### PR TITLE
Place nothing

### DIFF
--- a/docs/usage/GenerationParameters.md
+++ b/docs/usage/GenerationParameters.md
@@ -280,6 +280,18 @@ Note that `voxel` type corresponds to Minecraft/Minetest voxel description (see 
 
 See corresponding structure or pattern for extra fields.
 
+#### Nothing
+
+**Type**: `nothing`
+
+Places nothing. Conveniant when a material is required but you want to place nothing.
+
+Example using `nothing` in a `place` field:
+```yaml
+place:
+  type: nothing
+```
+
 #### Stack
 
 **Type**: `stack`

--- a/src/main/java/com/ignfab/minalac/generator/parameters/placeables/CustomPlaceableParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/placeables/CustomPlaceableParams.java
@@ -3,6 +3,7 @@ package com.ignfab.minalac.generator.parameters.placeables;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.ignfab.minalac.generator.parameters.placeables.structures.NoVoxelParams;
 import com.ignfab.minalac.generator.parameters.placeables.structures.StackStructureParams;
 
 /**
@@ -13,6 +14,7 @@ import com.ignfab.minalac.generator.parameters.placeables.structures.StackStruct
 @JsonSubTypes({
     // TODO: In another PR, register placeables in main()
     @JsonSubTypes.Type(name = "stack", value = StackStructureParams.class),
+    @JsonSubTypes.Type(name = "nothing", value = NoVoxelParams.class),
 })
 public abstract class CustomPlaceableParams extends PlaceableParams {
 }

--- a/src/main/java/com/ignfab/minalac/generator/parameters/placeables/structures/NoVoxelParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/placeables/structures/NoVoxelParams.java
@@ -1,0 +1,16 @@
+package com.ignfab.minalac.generator.parameters.placeables.structures;
+
+import com.ignfab.minalac.generator.parameters.placeables.CustomPlaceableParams;
+import com.ignfab.minalac.generator.world.NoVoxel;
+import com.ignfab.minalac.generator.world.Placeable;
+import com.ignfab.minalac.generator.world.VoxelWorld;
+
+/**
+ * Places nothing.
+ */
+public class NoVoxelParams extends CustomPlaceableParams {
+    @Override
+    public Placeable create(VoxelWorld world) {
+        return NoVoxel.INSTANCE;
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/parameters/placeables/structures/StackStructureParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/placeables/structures/StackStructureParams.java
@@ -50,7 +50,7 @@ public class StackStructureParams extends CustomPlaceableParams {
     @Override
     public Placeable create(VoxelWorld world) {
         if (layers == null || layers.isEmpty())
-            return new NoVoxel();
+            return NoVoxel.INSTANCE;
 
         SimpleVoxelStructure structure = new SimpleVoxelStructure();
         int z = 0;

--- a/src/main/java/com/ignfab/minalac/generator/world/NoVoxel.java
+++ b/src/main/java/com/ignfab/minalac/generator/world/NoVoxel.java
@@ -4,7 +4,17 @@ package com.ignfab.minalac.generator.world;
  * A placeable placing nothing.
  * Can be convenient to pass as a no-op voxel type to some operation.
  */
-public class NoVoxel implements Placeable {
+public final class NoVoxel implements Placeable {
+    /**
+     * NoVoxel singleton instance.
+     */
+    public static final NoVoxel INSTANCE = new NoVoxel();
+
+    /**
+     * NoVoxel private constructor (use INSTANCE instead).
+     */
+    private NoVoxel() {}
+
     /**
      * Does not place anything at x, y, z.
      *


### PR DESCRIPTION
### Changes

Add a way to instantiate NoVoxel from Yaml.

#### Feature description

This feature allows to skip placement of voxel or structure even when it's required in params.

### Reason

May be convenient.

### Self-checks

- ~~The code has unit tests associated~~
- [x] The code has Javadoc Comments associated
-  ~~Complex / Unexpected code is explained / justified with a small comment~~
- [x] Relevant documentation inside the `/docs` folder has been updated
- [x] All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- ~~The texts have been proofread (documentation, error messages, logs, comments...)~~