### PR TITLE
Fix id creation of voxel type not being threadsafe

### DIFF
--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/Block.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/Block.java
@@ -42,16 +42,33 @@ public class Block {
         // Node location on arrays
         // https://github.com/minetest/minetest/blob/master/doc/world_format.md#node-data
         int i = z << 8 | y << 4 | x;
+        param0[i] = getOrCreateIdForType(voxel.getType());
         param1[i] = voxel.getParam1();
         param2[i] = voxel.getParam2();
+    }
 
-        if (idNameMapping.containsKey(voxel.getType())) {
-            param0[i] = idNameMapping.get(voxel.getType()).shortValue();
-        } else {
+    /**
+     * Gets or creates a new id for given type name.
+     * This ensure a threadsafe id creation.
+     *
+     * @param name type name
+     * @return identfier for the given type name
+     */
+    private short getOrCreateIdForType(String name) {
+        // Search first in case we already have that name (most likely)
+        if (idNameMapping.containsKey(name))
+            return idNameMapping.get(name).shortValue();
+
+        synchronized (idNameMapping) {
+            // Check again to be sure name has not been created since previous check
+            if (idNameMapping.containsKey(name))
+                return idNameMapping.get(name).shortValue();
+
+            // Create a new Id for that name
             int newId = nameIdMapping.size();
-            nameIdMapping.put(newId, voxel.getType());
-            idNameMapping.put(voxel.getType(), newId);
-            param0[i] = (short) newId;
+            nameIdMapping.put(newId, name);
+            idNameMapping.put(name, newId);
+            return (short) newId;
         }
     }
 


### PR DESCRIPTION
### Changes

Fix id creation of voxel types in MTVoxelWorld not being threadsafe.

#### Technical changes

Fix very similar to commit 6fb0b8d67045892fb7dfbe47089e8c806845a4cd :

- A first search outside synchronized block to get a quick response;
- If not found, a second search in synchronized block to ensure it has not been created meanwhile;
- Creation in synchronized block.

### Reason

With heavy parallel rendering, more and more buggy maps where generated, making Minetest client crash.

### Self-checks

- ~~The code has unit tests associated~~
- [X] The code has Javadoc Comments associated
- [X] Complex / Unexpected code is explained / justified with a small comment
- ~~Relevant documentation inside the `/docs` folder has been updated~~
- [X] All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)
- [X] Git history is clean (each commit accomplish a single task and describe it accordingly)
- ~~The texts have been proofread (documentation, error messages, logs, comments...)~~
