### PR TITLE
Hacky fix for missing WFS metadata using geotools

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <geotools.version>31.0</geotools.version>
+        <geotools.version>32.2</geotools.version>
         <jackson.version>2.17.2</jackson.version>
     </properties>
 

--- a/src/main/java/com/ignfab/minalac/generator/inputs/WFS1_1_GML3_1_DataProvider.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/WFS1_1_GML3_1_DataProvider.java
@@ -2,12 +2,19 @@ package com.ignfab.minalac.generator.inputs;
 
 import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
 import com.ignfab.minalac.generator.exceptions.RetryableException;
+
 import org.geotools.api.feature.simple.SimpleFeature;
+import org.geotools.api.feature.type.FeatureType;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.data.DataUtilities;
+import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.data.simple.SimpleFeatureIterator;
 import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.gml2.FeatureTypeCache;
 import org.geotools.referencing.CRS;
-import org.geotools.wfs.GML;
+import org.geotools.xsd.Parser;
+import org.geotools.xsd.impl.ParserHandler.ContextCustomizer;
+import org.picocontainer.MutablePicoContainer;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;
@@ -87,15 +94,86 @@ public class WFS1_1_GML3_1_DataProvider implements Provider<SimpleFeature> {
         // Invalidate schema declaration because GML version 3.1 is not used in this schema (version is unspecified, defaulting to 3.2)
         String string = new String(bytes).replace("http://BDTOPO_V3", "explicitly-invalid");
         InputStream replacedStream = new ByteArrayInputStream(string.getBytes());
-
         try {
-            return new FeaturesResult(new GML(GML.Version.GML3).decodeFeatureCollection(replacedStream).features(), replacedStream);
+            // This is the "clean but not working" (see below) way to do things:
+            // return new FeaturesResult(new GML(GML.Version.GML3).decodeFeatureCollection(replacedStream).features(), replacedStream);
+
+            // This is the "dirty but working" way:
+            return new FeaturesResult(decodeFeatureCollection(replacedStream).features(), replacedStream);
         } catch (IOException e) {
             throw new RetryableException("Error fetching data", e);
         } catch (ParserConfigurationException | SAXException e) {
             throw new GenerationFailedException("Unable to decode features", e);
         }
     }
+
+    ///////////////////////////
+    // Hacky part starts here
+    //
+    // Geotools has a problem with variable feature types (feature type = set of available metadata).
+    // WFS from IGN could send various feature types (ie not with the same metadata set) in a response to a query.
+    //
+    // Using GML::decodeFeatureCollection with a single parameter (the input stream) will take the first feature
+    // as template for all feature types. So if a metadata is absent from this first feature, it will be removed
+    // from all features of the response set.
+    //
+    // Using GML::decodeFeatureCollection with an aditional parameter set to `true` is supposed to build a type
+    // covering all encountered feature metadata (if a metadata appears once, it will be set for all features).
+    // But this gives an exception about "retyping" features.
+    //
+    // Actually, we'll be totally ok to have features with various types. Post-processing mechanism will be
+    // able to handle that correctly. The solution here has been to copy and simplify decodeFeatureCollection so
+    // it will return features with their type as in XML.
+
+    /**
+     * This is a hack to circumvent Geotools problem with variable type features.
+     *
+     * This version of SimpleFeatureCollection will return features with heterogeneous set of metadata.
+     *
+     * For simplicity, it has been narrowed down to SimpleFeatureCollection and SimpleFeature cases
+     * and will not work if parser returns something else.
+     *
+     * @param in Input stream providing WFS XML
+     * @return Collection of features
+     */
+    private SimpleFeatureCollection decodeFeatureCollection(InputStream in)
+        throws IOException, SAXException, ParserConfigurationException {
+        Parser parser = new Parser(new org.geotools.gml3.GMLConfiguration());
+        parser.setContextCustomizer(new NoFeatureTypeCacheCustomizer());
+        Object obj = parser.parse(in);
+        // Here we suppose obj to be a SimpleFeatureCollection or a SimpleFeature
+        // but there may be other cases (see `toFeatureCollection` from `GML.class`)
+        if (obj instanceof SimpleFeatureCollection collection) {
+            return collection;
+        }
+        if (obj instanceof SimpleFeature feature) {
+            return DataUtilities.collection(feature);
+        }
+        throw new ClassCastException("Unexpected " + obj.getClass() + " produced from WFS data");
+    }
+
+    /**
+     * A feature type cache customizer that does no caching.
+     *
+     * If lack of type caching causes performances issue, `DynamicFeatureTypeCacheCustomizer` from `GML.class`
+     * could be used instead (as it is private, it will have to be copied here).
+     */
+    private static final class NoFeatureTypeCacheCustomizer implements ContextCustomizer {
+        @Override
+        public void customizeContext(MutablePicoContainer context) {
+            Object instance = context.getComponentInstanceOfType(FeatureTypeCache.class);
+            context.unregisterComponentByInstance(instance);
+            // This disables feature type caching
+            context.registerComponentInstance(new FeatureTypeCache() {
+                @Override
+                public void put(FeatureType type) { }
+            });
+        }
+    }
+
+    //
+    // Hacky part ends here
+    ////////////////////////
 
     private record FeaturesResult(SimpleFeatureIterator features, InputStream stream) implements Result<SimpleFeature> {
         @Override


### PR DESCRIPTION
### Issue
Some metadata seems randomly removed from WFS Feature retrieved using Geotools while present in WFS XML stream.

This is due to what GeoTools calls "FeatureType". Feature type is the set of available metadata for a given feature set.

By default, feature type is guessed from first fetched feature. If other features have metadata not present in first feature, these metadata are removed. Features in IGN WFS have various types (ie various set of metadata).

Another mode (using an extra `true` parameter in `GML::decodeFeatureCollection`) creates a FeatureType including all possible metadata from all features in the response. This would be ok for us but it throws an exception, failing to "retype" features (maybe same metadata name with incompatible value types?).

We just need to have metadata as they are in XML stream. We are totally able to manage their presence or absence with post-processor.

### Changes

This PR proposes a hack that bypasses Geotools FeatureType detection/creation and avoid metadata from being dropped during decoding.

#### Feature description

This PR adds:
- a new `decodeFeatureCollection()` method, copied from Geotools `GML` and simplified.
- a new class implementing `ContextCustomizer`, required by `decodeFeatureCollection()`.

Geotools version have been upgraded (but problem not fixed).

### Self-checks

- ~~[ ] The code has unit tests associated~~
- ~~[ ] The code has Javadoc Comments associated~~
- [x] Complex / Unexpected code is explained / justified with a small comment
- ~~[ ] Relevant documentation inside the `/docs` folder has been updated~~
- [x] All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR) -> Works better !
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- ~~[ ] The texts have been proofread (documentation, error messages, logs, comments...)~~
