### PR TITLE
Added a GitHub Action to test the example parameter files in the generator

### DIFF
--- a/.github/workflows/parameters-tests.yml
+++ b/.github/workflows/parameters-tests.yml
@@ -1,0 +1,53 @@
+name: Validating example parameters
+on:
+  push:
+    paths:
+      - src/main/**
+      - examples/**
+      - pom.xml
+      - .github/workflows/parameters-tests.yml
+
+jobs:
+  test-parameters:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Build with Maven
+        run: |
+          mvn --batch-mode --no-transfer-progress --update-snapshots -Dmaven.test.skip=true package
+
+      - name: Run generator to validate example parameters
+        run: |
+          FORMATS=$(./generate.sh -l formats)
+          PLACES=$(./generate.sh -l places)
+          PROCESSES=$(./generate.sh -l processes)
+
+          error=0
+          set +e
+          for FORMAT in $FORMATS; do
+            for PLACE in $PLACES; do
+              for PROCESS in $PROCESSES; do
+                output=$(./generate.sh -g $FORMAT $PROCESS $PLACE 2>&1)
+                if [ $? -ne 0 ]; then
+                  echo "::group::Error parsing parameters: format=$FORMAT, place=$PLACE, process=$PROCESS"
+                  echo "Parameters used:"
+                  ./generate.sh -y $FORMAT $PROCESS $PLACE
+                  echo
+                  echo "Java output:"
+                  echo "$output"
+                  echo "::endgroup::"
+                  error=1
+                fi
+              done
+            done
+          done
+          set -e
+          exit $error

--- a/docs/tools/GitHub-workflows.md
+++ b/docs/tools/GitHub-workflows.md
@@ -91,3 +91,14 @@ This workflow triggers when a push on any branch modifies the Java main or test 
 It consists of a single job, executing the [unit tests](JUnit.md). It currently does not report details other than in the workflow logs.
 
 The workflow fails if any unit test does not pass, or if the project does not compile.
+
+### Parameters tests
+
+> [!TIP]
+> See the [`parameters-tests.yml`](../../.github/workflows/parameters-tests.yml) file.
+
+This workflow triggers when a push on any branch modifies example files or Java main source files.
+
+It consists of a single job, executing the `generate.sh` script multiple times to find errors present in example files. It tries every possible combination of parameters.
+
+The workflow fails if any example file is incorrect, or if the project does not compile.

--- a/generate.sh
+++ b/generate.sh
@@ -10,6 +10,10 @@ FORMATS_DIR=$PARAMS_DIR/formats
 PROCESSES_DIR=$PARAMS_DIR/processes
 PLACES_DIR=$PARAMS_DIR/places
 
+list_yaml_files() {
+    ls -1 $1 | grep '.yaml$' | sed -r "s/(.*)\.yaml$/$2\1/"
+}
+
 usage() {
     echo "$0 [options] <format> <process> <place> [<outputdir>]"
     echo "available options:"
@@ -17,11 +21,11 @@ usage() {
     echo "-s Stops before saving"
     echo "-y Display Yaml configuration only"
     echo "formats:"
-    ls -1 $FORMATS_DIR | grep '.yaml$' | sed -r 's/(.*)\.yaml$/\t\1/'
+    list_yaml_files $FORMATS_DIR "\t"
     echo "processes:"
-    ls -1 $PROCESSES_DIR | grep '.yaml$' | sed -r 's/(.*)\.yaml$/\t\1/'
+    list_yaml_files $PROCESSES_DIR "\t"
     echo "places:"
-    ls -1 $PLACES_DIR | grep '.yaml$' | sed -r 's/(.*)\.yaml$/\t\1/'
+    list_yaml_files $PLACES_DIR "\t"
     echo "outputdir is required if no option given (if directory exists, it will be emptied)"
 }
 
@@ -43,6 +47,25 @@ while [[ "$1" == "-"* ]]; do
         -y)
             display_only=1
             unset output_dir_needed
+            ;;
+        -l)
+            case $1 in
+                formats)
+                    list_yaml_files $FORMATS_DIR
+                    ;;
+                processes)
+                    list_yaml_files $PROCESSES_DIR
+                    ;;
+                places)
+                    list_yaml_files $PLACES_DIR
+                    ;;
+                *)
+                    echo "Unknown -l option $1"
+                    usage
+                    exit 1
+                    ;;
+            esac
+            exit 0 
             ;;
         *)
             echo "Unknown option $opt"


### PR DESCRIPTION
### Type of modification

Types:
- CI/CD

### Changes

Add a CI/CD to tests parameter files from "exemples" directory

#### Feature description

Run the generator with `--generation-disabled` argument to validate example parameter files.

#### Showcase

![image](https://github.com/user-attachments/assets/5712672f-0c6a-4018-bed9-ccc1cf7ff9fd)

### Self-checks

~~- [ ] The code has unit tests associated~~
~~- [ ] The code has Javadoc Comments associated~~
~~- [ ] Complex / Unexpected code is explained / justified with a small comment~~
- [ ] Relevant documentation inside the `/docs` folder has been updated
~~- [ ] All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)~~
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [ ] The texts have been proofread (documentation, error messages, logs, comments...)
