### PR TITLE
Imports ordering rules

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -132,8 +132,14 @@
     </module>
     <module name="IllegalImport"/> <!-- defaults to sun.* packages -->
     <module name="RedundantImport"/>
-    <module name="UnusedImports">
-      <property name="processJavadoc" value="false"/>
+    <module name="UnusedImports"/>
+    <module name="ImportOrder">
+      <property name="groups" value="/javax?/,*,com.ignfab.minalac.generator"/>
+      <property name="ordered" value="true"/>
+      <property name="separated" value="true"/>
+      <property name="separatedStaticGroups" value="true"/>
+      <property name="option" value="bottom"/>
+      <property name="sortStaticImportsAlphabetically" value="true"/>
     </module>
 
     <!-- Checks for Size Violations.                    -->

--- a/src/main/java/com/ignfab/minalac/generator/MinalacGeneratorCLI.java
+++ b/src/main/java/com/ignfab/minalac/generator/MinalacGeneratorCLI.java
@@ -1,5 +1,11 @@
 package com.ignfab.minalac.generator;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
@@ -7,12 +13,6 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.InvalidPathException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /**
  * A command line parser and basic processor.

--- a/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
+++ b/src/main/java/com/ignfab/minalac/generator/SampleImplementation.java
@@ -1,5 +1,12 @@
 package com.ignfab.minalac.generator;
 
+import java.io.File;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+
+import org.geotools.api.referencing.FactoryException;
+
 import com.ignfab.minalac.generator.exceptions.TransformException;
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.outputs.minecraft.MCVoxelWorld;
@@ -18,8 +25,8 @@ import com.ignfab.minalac.generator.parameters.providers.GeoPackageProviderParam
 import com.ignfab.minalac.generator.parameters.providers.ShapefileProviderParams;
 import com.ignfab.minalac.generator.parameters.providers.WFSProviderParams;
 import com.ignfab.minalac.generator.parameters.providers.WMSFloatBilProviderParams;
-import com.ignfab.minalac.generator.parameters.renderers.GroundRendererParams;
 import com.ignfab.minalac.generator.parameters.renderers.BuildingRendererParams;
+import com.ignfab.minalac.generator.parameters.renderers.GroundRendererParams;
 import com.ignfab.minalac.generator.parameters.renderers.HeightmapRendererParams;
 import com.ignfab.minalac.generator.parameters.renderers.LevelingRendererParams;
 import com.ignfab.minalac.generator.parameters.renderers.VectorRendererParams;
@@ -29,12 +36,6 @@ import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
 import com.ignfab.minalac.generator.world.MapWriteException;
 import com.ignfab.minalac.generator.world.VoxelWorldMetadata;
-import org.geotools.api.referencing.FactoryException;
-
-import java.io.File;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.concurrent.TimeUnit;
 
 /**
  * This is a temporary class to have an idea of how the program works.

--- a/src/main/java/com/ignfab/minalac/generator/generation/DataSource.java
+++ b/src/main/java/com/ignfab/minalac/generator/generation/DataSource.java
@@ -1,5 +1,9 @@
 package com.ignfab.minalac.generator.generation;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
 import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
 import com.ignfab.minalac.generator.exceptions.IgnorableException;
 import com.ignfab.minalac.generator.exceptions.RetryableException;
@@ -8,10 +12,6 @@ import com.ignfab.minalac.generator.models.Model;
 import com.ignfab.minalac.generator.models.ModelStore;
 import com.ignfab.minalac.generator.processors.Processor;
 import com.ignfab.minalac.generator.processors.post.PostProcessor;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * A data source with a provider, a processor and some (or no) post-processors.

--- a/src/main/java/com/ignfab/minalac/generator/generation/Generation.java
+++ b/src/main/java/com/ignfab/minalac/generator/generation/Generation.java
@@ -1,23 +1,22 @@
 package com.ignfab.minalac.generator.generation;
 
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.CRS;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.util.AffineTransformation;
+
 import com.ignfab.minalac.generator.exceptions.TransformException;
 import com.ignfab.minalac.generator.models.ModelStore;
 import com.ignfab.minalac.generator.utils.coordinates.MapToWorldConverter;
 import com.ignfab.minalac.generator.utils.coordinates.WorldToMapConverter;
 import com.ignfab.minalac.generator.utils.execution.Scheduler;
+import com.ignfab.minalac.generator.utils.random.Seed;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.world.VoxelWorld;
-import com.ignfab.minalac.generator.utils.random.Seed;
-
-import org.geotools.api.referencing.FactoryException;
-import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
-import org.geotools.geometry.jts.ReferencedEnvelope;
-import org.geotools.referencing.CRS;
-
-import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.Geometry;
-import org.locationtech.jts.geom.GeometryFactory;
-import org.locationtech.jts.geom.util.AffineTransformation;
 
 /**
  * This {@code Generation} class contains information about the ongoing generation

--- a/src/main/java/com/ignfab/minalac/generator/generation/Heightmap.java
+++ b/src/main/java/com/ignfab/minalac/generator/generation/Heightmap.java
@@ -1,10 +1,10 @@
 package com.ignfab.minalac.generator.generation;
 
+import java.util.Arrays;
+
 import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
 import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
 import com.ignfab.minalac.generator.utils.world2d.WorldSize2d;
-
-import java.util.Arrays;
 
 /**
  * A 2d heightmap in voxel world units.

--- a/src/main/java/com/ignfab/minalac/generator/inputs/GeoPackageDataProvider.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/GeoPackageDataProvider.java
@@ -1,11 +1,12 @@
 package com.ignfab.minalac.generator.inputs;
 
-import com.ignfab.minalac.generator.utils.coordinates.EnvelopeProvider;
+import java.io.File;
+import java.util.Map;
+
 import org.geotools.api.data.DataStore;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 
-import java.io.File;
-import java.util.Map;
+import com.ignfab.minalac.generator.utils.coordinates.EnvelopeProvider;
 
 /**
  * Data provider using GeoPackage.

--- a/src/main/java/com/ignfab/minalac/generator/inputs/GeoToolsDataStoreProvider.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/GeoToolsDataStoreProvider.java
@@ -1,9 +1,8 @@
 package com.ignfab.minalac.generator.inputs;
 
-import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
-import com.ignfab.minalac.generator.exceptions.RetryableException;
-import com.ignfab.minalac.generator.exceptions.TransformException;
-import com.ignfab.minalac.generator.utils.coordinates.EnvelopeProvider;
+import java.io.IOException;
+import java.util.Map;
+
 import org.geotools.api.data.DataStore;
 import org.geotools.api.data.DataStoreFinder;
 import org.geotools.api.data.FeatureReader;
@@ -19,8 +18,10 @@ import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 
-import java.io.IOException;
-import java.util.Map;
+import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
+import com.ignfab.minalac.generator.exceptions.RetryableException;
+import com.ignfab.minalac.generator.exceptions.TransformException;
+import com.ignfab.minalac.generator.utils.coordinates.EnvelopeProvider;
 
 /**
  * Data provider using GeoTools {@link DataStore}.

--- a/src/main/java/com/ignfab/minalac/generator/inputs/Provider.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/Provider.java
@@ -1,10 +1,11 @@
 package com.ignfab.minalac.generator.inputs;
 
-import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
-import com.ignfab.minalac.generator.exceptions.RetryableException;
+import java.io.Closeable;
+
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 
-import java.io.Closeable;
+import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
+import com.ignfab.minalac.generator.exceptions.RetryableException;
 
 /**
  * A provider is responsible for acquiring data.

--- a/src/main/java/com/ignfab/minalac/generator/inputs/ShapefileDataProvider.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/ShapefileDataProvider.java
@@ -1,15 +1,16 @@
 package com.ignfab.minalac.generator.inputs;
 
-import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
-import com.ignfab.minalac.generator.exceptions.RetryableException;
-import com.ignfab.minalac.generator.utils.coordinates.EnvelopeProvider;
-import org.geotools.api.data.DataStore;
-import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.util.Map;
+
+import org.geotools.api.data.DataStore;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+
+import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
+import com.ignfab.minalac.generator.exceptions.RetryableException;
+import com.ignfab.minalac.generator.utils.coordinates.EnvelopeProvider;
 
 /**
  * Data provider using Shapefile.

--- a/src/main/java/com/ignfab/minalac/generator/inputs/WFS1_1_GML3_1_DataProvider.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/WFS1_1_GML3_1_DataProvider.java
@@ -1,7 +1,14 @@
 package com.ignfab.minalac.generator.inputs;
 
-import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
-import com.ignfab.minalac.generator.exceptions.RetryableException;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.util.NoSuchElementException;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+
 import org.geotools.api.feature.simple.SimpleFeature;
 import org.geotools.api.feature.type.FeatureType;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
@@ -18,14 +25,8 @@ import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
 
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.parsers.SAXParser;
-import javax.xml.parsers.SAXParserFactory;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.MalformedURLException;
-import java.util.NoSuchElementException;
+import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
+import com.ignfab.minalac.generator.exceptions.RetryableException;
 
 /**
  * Data provider using WFS 1.1 and GML 3.1.

--- a/src/main/java/com/ignfab/minalac/generator/inputs/WMSFloatBilDataProvider.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/WMSFloatBilDataProvider.java
@@ -1,18 +1,19 @@
 package com.ignfab.minalac.generator.inputs;
 
-import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
-import com.ignfab.minalac.generator.exceptions.RetryableException;
-import com.ignfab.minalac.generator.utils.iterator.Iterators;
-import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
-import org.geotools.geometry.jts.ReferencedEnvelope;
-import org.geotools.referencing.CRS;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Iterator;
+
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.CRS;
+
+import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
+import com.ignfab.minalac.generator.exceptions.RetryableException;
+import com.ignfab.minalac.generator.utils.iterator.Iterators;
 
 /**
  * Data provider for Web Map Service (raster data).

--- a/src/main/java/com/ignfab/minalac/generator/models/JTSGeometryModel.java
+++ b/src/main/java/com/ignfab/minalac/generator/models/JTSGeometryModel.java
@@ -1,5 +1,16 @@
 package com.ignfab.minalac.generator.models;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryCollection;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.Polygon;
+
 import com.ignfab.minalac.generator.exceptions.TransformException;
 import com.ignfab.minalac.generator.utils.coordinates.MapToWorldConverter;
 import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
@@ -14,17 +25,6 @@ import com.ignfab.minalac.generator.voxelization.shape3d.Point3d;
 import com.ignfab.minalac.generator.voxelization.shape3d.Polygon3d;
 import com.ignfab.minalac.generator.voxelization.shape3d.Polyline3d;
 import com.ignfab.minalac.generator.voxelization.shape3d.ShapesVoxelizer3d;
-
-import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.Envelope;
-import org.locationtech.jts.geom.Geometry;
-import org.locationtech.jts.geom.GeometryCollection;
-import org.locationtech.jts.geom.LineString;
-import org.locationtech.jts.geom.Point;
-import org.locationtech.jts.geom.Polygon;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Model represented by a JTS Geometry.

--- a/src/main/java/com/ignfab/minalac/generator/models/ModelStore.java
+++ b/src/main/java/com/ignfab/minalac/generator/models/ModelStore.java
@@ -1,10 +1,10 @@
 package com.ignfab.minalac.generator.models;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Collections;
 
 /**
  * A basic model store, storing and retrieving models by type.

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCBlockEntityVoxelType.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCBlockEntityVoxelType.java
@@ -1,8 +1,8 @@
 package com.ignfab.minalac.generator.outputs.minecraft;
 
-import net.querz.nbt.tag.CompoundTag;
-
 import java.util.Map;
+
+import net.querz.nbt.tag.CompoundTag;
 
 /**
  * {@code MCBlockEntityVoxelType} abstract class represents a Minecraft block with additional data associated with it.

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelType.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelType.java
@@ -1,9 +1,10 @@
 package com.ignfab.minalac.generator.outputs.minecraft;
 
-import com.ignfab.minalac.generator.world.VoxelType;
+import java.util.Map;
+
 import net.querz.nbt.tag.CompoundTag;
 
-import java.util.Map;
+import com.ignfab.minalac.generator.world.VoxelType;
 
 /**
  * {@code MCVoxelType} class provides the necessary structure and mechanism in order to implement {@link VoxelType} for Minecraft.

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelWorld.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelWorld.java
@@ -1,11 +1,12 @@
 package com.ignfab.minalac.generator.outputs.minecraft;
 
-import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
-import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
-import com.ignfab.minalac.generator.utils.world3d.WorldSize3d;
-import com.ignfab.minalac.generator.world.MapWriteException;
-import com.ignfab.minalac.generator.world.VoxelWorld;
-import com.ignfab.minalac.generator.world.VoxelWorldMetadata;
+import java.io.File;
+import java.io.IOException;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+
 import net.querz.mca.Chunk;
 import net.querz.mca.MCAUtil;
 import net.querz.nbt.io.NBTUtil;
@@ -16,12 +17,12 @@ import net.querz.nbt.tag.IntTag;
 import net.querz.nbt.tag.ListTag;
 import net.querz.nbt.tag.StringTag;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Random;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
+import com.ignfab.minalac.generator.utils.world3d.WorldSize3d;
+import com.ignfab.minalac.generator.world.MapWriteException;
+import com.ignfab.minalac.generator.world.VoxelWorld;
+import com.ignfab.minalac.generator.world.VoxelWorldMetadata;
 
 /**
  * Implementation of {@link VoxelWorld} that creates a playable world specifically for Minecraft.

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/Region.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/Region.java
@@ -1,11 +1,11 @@
 package com.ignfab.minalac.generator.outputs.minecraft;
 
+import java.io.File;
+import java.io.IOException;
+
 import net.querz.mca.Chunk;
 import net.querz.mca.MCAFile;
 import net.querz.mca.MCAUtil;
-
-import java.io.File;
-import java.io.IOException;
 
 /**
  * Represents a Minecraft region.

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelWorld.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelWorld.java
@@ -1,18 +1,18 @@
 package com.ignfab.minalac.generator.outputs.minetest;
 
-import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
-import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
-import com.ignfab.minalac.generator.world.MapWriteException;
-import com.ignfab.minalac.generator.world.VoxelWorld;
-import com.ignfab.minalac.generator.outputs.minetest.utils.SQLiteMapWriter;
-import com.ignfab.minalac.generator.world.VoxelWorldMetadata;
-
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.HashMap;
 import java.util.Map;
+
+import com.ignfab.minalac.generator.outputs.minetest.utils.SQLiteMapWriter;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
+import com.ignfab.minalac.generator.world.MapWriteException;
+import com.ignfab.minalac.generator.world.VoxelWorld;
+import com.ignfab.minalac.generator.world.VoxelWorldMetadata;
 
 /**
  * Implementation of {@link VoxelWorld} that creates a playable world specifically for Minetest.

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/utils/SQLiteMapWriter.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/utils/SQLiteMapWriter.java
@@ -1,8 +1,5 @@
 package com.ignfab.minalac.generator.outputs.minetest.utils;
 
-import com.ignfab.minalac.generator.outputs.minetest.Block;
-import com.ignfab.minalac.generator.world.MapWriteException;
-
 import java.io.File;
 import java.io.IOException;
 import java.sql.Connection;
@@ -10,6 +7,9 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
+
+import com.ignfab.minalac.generator.outputs.minetest.Block;
+import com.ignfab.minalac.generator.world.MapWriteException;
 
 /**
  * {@code SQLiteMapWriter} is responsible for creating and updating the {@code map.sqlite} file,

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/utils/Serializer.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/utils/Serializer.java
@@ -1,18 +1,18 @@
 package com.ignfab.minalac.generator.outputs.minetest.utils;
 
-import com.ignfab.minalac.generator.outputs.minetest.Block;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Map;
-import java.util.zip.DeflaterOutputStream;
 import java.util.zip.Deflater;
+import java.util.zip.DeflaterOutputStream;
+
+import com.ignfab.minalac.generator.outputs.minetest.Block;
 
 /**
  * This class is responsible for providing the serialized {@code Block} needed by the {@code map.sqlite} file.
  * @see SQLiteMapWriter
- * @see com.ignfab.minalac.generator.outputs.minetest.MTVoxelWorld#save(File)
+ * @see com.ignfab.minalac.generator.outputs.minetest.MTVoxelWorld#save(java.io.File)
  */
 public class Serializer {
 

--- a/src/main/java/com/ignfab/minalac/generator/parameters/DataSourceParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/DataSourceParams.java
@@ -1,7 +1,12 @@
 package com.ignfab.minalac.generator.parameters;
 
+import java.beans.ConstructorProperties;
+import java.util.ArrayList;
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
+
 import com.ignfab.minalac.generator.generation.DataSource;
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.inputs.Provider;
@@ -10,10 +15,6 @@ import com.ignfab.minalac.generator.parameters.processors.post.PostProcessorPara
 import com.ignfab.minalac.generator.parameters.providers.ProviderParams;
 import com.ignfab.minalac.generator.processors.Processor;
 import com.ignfab.minalac.generator.processors.post.PostProcessor;
-
-import java.beans.ConstructorProperties;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Represents the parameters used for {@link DataSource} creation.

--- a/src/main/java/com/ignfab/minalac/generator/parameters/GenerationCreator.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/GenerationCreator.java
@@ -1,10 +1,5 @@
 package com.ignfab.minalac.generator.parameters;
 
-import com.ignfab.minalac.generator.generation.DataSource;
-import com.ignfab.minalac.generator.generation.Generation;
-import com.ignfab.minalac.generator.utils.random.Seed;
-import com.ignfab.minalac.generator.renderers.Renderer;
-
 import org.geotools.api.geometry.Position;
 import org.geotools.api.referencing.FactoryException;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
@@ -13,6 +8,11 @@ import org.geotools.api.referencing.operation.TransformException;
 import org.geotools.geometry.Position2D;
 import org.geotools.referencing.CRS;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
+
+import com.ignfab.minalac.generator.generation.DataSource;
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.renderers.Renderer;
+import com.ignfab.minalac.generator.utils.random.Seed;
 
 /**
  * This class is used to create a new {@link Generation} from {@link GenerationParams} parameters.

--- a/src/main/java/com/ignfab/minalac/generator/parameters/GenerationParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/GenerationParams.java
@@ -1,14 +1,15 @@
 package com.ignfab.minalac.generator.parameters;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonSetter;
-import com.fasterxml.jackson.annotation.Nulls;
-import com.ignfab.minalac.generator.generation.Generation;
-import com.ignfab.minalac.generator.parameters.renderers.RendererParams;
-
 import java.beans.ConstructorProperties;
 import java.util.LinkedHashMap;
 import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.parameters.renderers.RendererParams;
 
 /**
  * GenerationParams represents the parameters used during the generation.

--- a/src/main/java/com/ignfab/minalac/generator/parameters/HeightmapParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/HeightmapParams.java
@@ -1,9 +1,9 @@
 package com.ignfab.minalac.generator.parameters;
 
+import java.beans.ConstructorProperties;
+
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.generation.Heightmap;
-
-import java.beans.ConstructorProperties;
 
 /**
  * Represents the parameters of a type of {@link Heightmap}.

--- a/src/main/java/com/ignfab/minalac/generator/parameters/OutputFormat.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/OutputFormat.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+
 import com.ignfab.minalac.generator.parameters.placeables.PlaceableParams;
 import com.ignfab.minalac.generator.world.VoxelWorld;
 

--- a/src/main/java/com/ignfab/minalac/generator/parameters/models/ModelSelectionParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/models/ModelSelectionParams.java
@@ -4,6 +4,7 @@ import java.beans.ConstructorProperties;
 
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
+
 import com.ignfab.minalac.generator.models.ModelSelection;
 import com.ignfab.minalac.generator.models.ModelStore;
 import com.ignfab.minalac.generator.parameters.models.filters.ModelFilterParams;

--- a/src/main/java/com/ignfab/minalac/generator/parameters/models/filters/ModelFilterAndParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/models/filters/ModelFilterAndParams.java
@@ -7,6 +7,7 @@ import java.util.function.Predicate;
 
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
+
 import com.ignfab.minalac.generator.models.Model;
 
 /**

--- a/src/main/java/com/ignfab/minalac/generator/parameters/models/filters/ModelFilterHasMetadataParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/models/filters/ModelFilterHasMetadataParams.java
@@ -8,6 +8,7 @@ import java.util.function.Predicate;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
+
 import com.ignfab.minalac.generator.models.Model;
 import com.ignfab.minalac.generator.models.filters.ModelFilterHasMetadata;
 

--- a/src/main/java/com/ignfab/minalac/generator/parameters/models/filters/ModelFilterMetadataEqualsParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/models/filters/ModelFilterMetadataEqualsParams.java
@@ -6,6 +6,7 @@ import java.util.function.Predicate;
 
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
+
 import com.ignfab.minalac.generator.models.Model;
 import com.ignfab.minalac.generator.models.filters.ModelFilterMetadataIn;
 import com.ignfab.minalac.generator.parameters.ValueParser;

--- a/src/main/java/com/ignfab/minalac/generator/parameters/models/filters/ModelFilterMetadataInParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/models/filters/ModelFilterMetadataInParams.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
+
 import com.ignfab.minalac.generator.models.Model;
 import com.ignfab.minalac.generator.models.filters.ModelFilterMetadataIn;
 import com.ignfab.minalac.generator.parameters.ValueParser;

--- a/src/main/java/com/ignfab/minalac/generator/parameters/models/filters/ModelFilterMetadataLowerThanParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/models/filters/ModelFilterMetadataLowerThanParams.java
@@ -5,6 +5,7 @@ import java.util.function.Predicate;
 
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
+
 import com.ignfab.minalac.generator.models.Model;
 import com.ignfab.minalac.generator.models.filters.ModelFilterMetadataLowerThan;
 

--- a/src/main/java/com/ignfab/minalac/generator/parameters/models/filters/ModelFilterNotParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/models/filters/ModelFilterNotParams.java
@@ -5,6 +5,7 @@ import java.util.function.Predicate;
 
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
+
 import com.ignfab.minalac.generator.models.Model;
 
 

--- a/src/main/java/com/ignfab/minalac/generator/parameters/models/filters/ModelFilterOrParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/models/filters/ModelFilterOrParams.java
@@ -7,6 +7,7 @@ import java.util.function.Predicate;
 
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
+
 import com.ignfab.minalac.generator.models.Model;
 
 /**

--- a/src/main/java/com/ignfab/minalac/generator/parameters/models/filters/ModelFilterParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/models/filters/ModelFilterParams.java
@@ -4,6 +4,7 @@ import java.util.function.Predicate;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
 import com.ignfab.minalac.generator.models.Model;
 
 /**

--- a/src/main/java/com/ignfab/minalac/generator/parameters/placeables/CustomPlaceableParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/placeables/CustomPlaceableParams.java
@@ -3,6 +3,7 @@ package com.ignfab.minalac.generator.parameters.placeables;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
 import com.ignfab.minalac.generator.parameters.placeables.structures.NoVoxelParams;
 import com.ignfab.minalac.generator.parameters.placeables.structures.StackStructureParams;
 

--- a/src/main/java/com/ignfab/minalac/generator/parameters/placeables/PlaceableParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/placeables/PlaceableParams.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.core.exc.InputCoercionException;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
+
 import com.ignfab.minalac.generator.parameters.OutputFormat;
 import com.ignfab.minalac.generator.world.Placeable;
 import com.ignfab.minalac.generator.world.VoxelWorld;

--- a/src/main/java/com/ignfab/minalac/generator/parameters/placeables/minecraft/MCVoxelTypeParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/placeables/minecraft/MCVoxelTypeParams.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.Nulls;
+
 import com.ignfab.minalac.generator.outputs.minecraft.MCVoxelType;
 import com.ignfab.minalac.generator.outputs.minecraft.MCVoxelWorld;
 import com.ignfab.minalac.generator.parameters.placeables.PlaceableParams;

--- a/src/main/java/com/ignfab/minalac/generator/parameters/placeables/minetest/MTVoxelTypeParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/placeables/minetest/MTVoxelTypeParams.java
@@ -5,8 +5,9 @@ import java.beans.ConstructorProperties;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.Nulls;
-import com.ignfab.minalac.generator.outputs.minetest.MTVoxelWorld;
+
 import com.ignfab.minalac.generator.outputs.minetest.MTVoxelType;
+import com.ignfab.minalac.generator.outputs.minetest.MTVoxelWorld;
 import com.ignfab.minalac.generator.parameters.placeables.CustomPlaceableParams;
 import com.ignfab.minalac.generator.world.Placeable;
 import com.ignfab.minalac.generator.world.VoxelWorld;

--- a/src/main/java/com/ignfab/minalac/generator/parameters/placeables/structures/StackStructureParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/placeables/structures/StackStructureParams.java
@@ -7,6 +7,7 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
+
 import com.ignfab.minalac.generator.parameters.placeables.CustomPlaceableParams;
 import com.ignfab.minalac.generator.parameters.placeables.PlaceableParams;
 import com.ignfab.minalac.generator.world.NoVoxel;

--- a/src/main/java/com/ignfab/minalac/generator/parameters/processors/GeoToolsVectorProcessorParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/processors/GeoToolsVectorProcessorParams.java
@@ -1,10 +1,11 @@
 package com.ignfab.minalac.generator.parameters.processors;
 
+import org.geotools.api.feature.simple.SimpleFeature;
+
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.models.JTSGeometryModel;
 import com.ignfab.minalac.generator.processors.GeoToolsVectorProcessor;
 import com.ignfab.minalac.generator.processors.Processor;
-import org.geotools.api.feature.simple.SimpleFeature;
 
 /**
  * Parameters for GeoTools vector processors.

--- a/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/FailurePolicyParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/FailurePolicyParams.java
@@ -1,6 +1,7 @@
 package com.ignfab.minalac.generator.parameters.processors.post;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import com.ignfab.minalac.generator.processors.post.MetadataParsePostProcessor.ParsingFailurePolicy;
 
 /**

--- a/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataCopyPostProcessorParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataCopyPostProcessorParams.java
@@ -2,11 +2,12 @@ package com.ignfab.minalac.generator.parameters.processors.post;
 
 import java.beans.ConstructorProperties;
 
-import com.ignfab.minalac.generator.processors.post.PostProcessor;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
+
 import com.ignfab.minalac.generator.models.Model;
 import com.ignfab.minalac.generator.processors.post.MetadataCopyPostProcessor;
+import com.ignfab.minalac.generator.processors.post.PostProcessor;
 
 /**
  * Parameters for {@link MetadataCopyPostProcessor}.

--- a/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataDefaultPostProcessorParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataDefaultPostProcessorParams.java
@@ -4,10 +4,11 @@ import java.beans.ConstructorProperties;
 
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
+
 import com.ignfab.minalac.generator.models.Model;
 import com.ignfab.minalac.generator.parameters.ValueParser;
-import com.ignfab.minalac.generator.processors.post.PostProcessor;
 import com.ignfab.minalac.generator.processors.post.MetadataDefaultPostProcessor;
+import com.ignfab.minalac.generator.processors.post.PostProcessor;
 
 /**
  * Parameters for {@link MetadataDefaultPostProcessor}.

--- a/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataParsePostProcessorParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataParsePostProcessorParams.java
@@ -1,13 +1,14 @@
 package com.ignfab.minalac.generator.parameters.processors.post;
 
+import java.beans.ConstructorProperties;
+
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
+
 import com.ignfab.minalac.generator.models.Model;
 import com.ignfab.minalac.generator.parameters.ValueParser;
 import com.ignfab.minalac.generator.processors.post.MetadataParsePostProcessor;
 import com.ignfab.minalac.generator.processors.post.PostProcessor;
-
-import java.beans.ConstructorProperties;
 
 /**
  * Parameters for {@link MetadataParsePostProcessor}.

--- a/src/main/java/com/ignfab/minalac/generator/parameters/providers/GeoPackageProviderParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/providers/GeoPackageProviderParams.java
@@ -1,17 +1,18 @@
 package com.ignfab.minalac.generator.parameters.providers;
 
+import java.beans.ConstructorProperties;
+import java.io.File;
+
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
-import com.ignfab.minalac.generator.generation.Generation;
-import com.ignfab.minalac.generator.inputs.GeoPackageDataProvider;
-import com.ignfab.minalac.generator.inputs.Provider;
 import org.geotools.api.feature.simple.SimpleFeature;
 import org.geotools.api.referencing.FactoryException;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.referencing.CRS;
 
-import java.beans.ConstructorProperties;
-import java.io.File;
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.inputs.GeoPackageDataProvider;
+import com.ignfab.minalac.generator.inputs.Provider;
 
 /**
  * Parameters for GeoPackage providers.

--- a/src/main/java/com/ignfab/minalac/generator/parameters/providers/ShapefileProviderParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/providers/ShapefileProviderParams.java
@@ -1,17 +1,18 @@
 package com.ignfab.minalac.generator.parameters.providers;
 
+import java.beans.ConstructorProperties;
+import java.io.File;
+
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
-import com.ignfab.minalac.generator.generation.Generation;
-import com.ignfab.minalac.generator.inputs.Provider;
-import com.ignfab.minalac.generator.inputs.ShapefileDataProvider;
 import org.geotools.api.feature.simple.SimpleFeature;
 import org.geotools.api.referencing.FactoryException;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.referencing.CRS;
 
-import java.beans.ConstructorProperties;
-import java.io.File;
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.inputs.Provider;
+import com.ignfab.minalac.generator.inputs.ShapefileDataProvider;
 
 /**
  * Parameters for Shapefile providers.

--- a/src/main/java/com/ignfab/minalac/generator/parameters/providers/WFSProviderParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/providers/WFSProviderParams.java
@@ -2,14 +2,14 @@ package com.ignfab.minalac.generator.parameters.providers;
 
 import java.beans.ConstructorProperties;
 
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 import org.geotools.api.feature.simple.SimpleFeature;
 import org.geotools.api.referencing.FactoryException;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.CRS;
 
-import com.fasterxml.jackson.annotation.JsonSetter;
-import com.fasterxml.jackson.annotation.Nulls;
 import com.ignfab.minalac.generator.exceptions.TransformException;
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.inputs.Provider;

--- a/src/main/java/com/ignfab/minalac/generator/parameters/renderers/BuildingRendererParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/renderers/BuildingRendererParams.java
@@ -1,14 +1,15 @@
 package com.ignfab.minalac.generator.parameters.renderers;
 
+import java.beans.ConstructorProperties;
+
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
+
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.parameters.models.ModelSelectionParams;
 import com.ignfab.minalac.generator.parameters.placeables.PlaceableParams;
-import com.ignfab.minalac.generator.renderers.Renderer;
 import com.ignfab.minalac.generator.renderers.BuildingRenderer;
-
-import java.beans.ConstructorProperties;
+import com.ignfab.minalac.generator.renderers.Renderer;
 
 /**
  * Parameters for {@link BuildingRenderer}.

--- a/src/main/java/com/ignfab/minalac/generator/parameters/renderers/HeightmapRendererParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/renderers/HeightmapRendererParams.java
@@ -1,11 +1,11 @@
 package com.ignfab.minalac.generator.parameters.renderers;
 
+import java.beans.ConstructorProperties;
+
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.parameters.models.ModelSelectionParams;
 import com.ignfab.minalac.generator.renderers.HeightmapRenderer;
 import com.ignfab.minalac.generator.renderers.Renderer;
-
-import java.beans.ConstructorProperties;
 
 /**
  * Concrete class of {@link RendererParams} representing the parameters of a {@link HeightmapRenderer}.

--- a/src/main/java/com/ignfab/minalac/generator/parameters/renderers/LevelingRendererParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/renderers/LevelingRendererParams.java
@@ -4,11 +4,12 @@ import java.beans.ConstructorProperties;
 
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
+
 import com.ignfab.minalac.generator.generation.Generation;
-import com.ignfab.minalac.generator.renderers.LevelingRenderer;
-import com.ignfab.minalac.generator.renderers.Renderer;
 import com.ignfab.minalac.generator.parameters.models.ModelSelectionParams;
 import com.ignfab.minalac.generator.parameters.placeables.PlaceableParams;
+import com.ignfab.minalac.generator.renderers.LevelingRenderer;
+import com.ignfab.minalac.generator.renderers.Renderer;
 
 /**
  * Parameters for {@link LevelingRenderer}.

--- a/src/main/java/com/ignfab/minalac/generator/parameters/renderers/VectorRendererParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/renderers/VectorRendererParams.java
@@ -1,12 +1,12 @@
 package com.ignfab.minalac.generator.parameters.renderers;
 
+import java.beans.ConstructorProperties;
+
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.parameters.models.ModelSelectionParams;
 import com.ignfab.minalac.generator.parameters.placeables.PlaceableParams;
 import com.ignfab.minalac.generator.renderers.Renderer;
 import com.ignfab.minalac.generator.renderers.VectorRenderer;
-
-import java.beans.ConstructorProperties;
 
 /**
  * Concrete class of {@link RendererParams} representing the parameters of a {@link VectorRenderer}.

--- a/src/main/java/com/ignfab/minalac/generator/processors/FloatMatrixProcessor.java
+++ b/src/main/java/com/ignfab/minalac/generator/processors/FloatMatrixProcessor.java
@@ -1,5 +1,8 @@
 package com.ignfab.minalac.generator.processors;
 
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+
 import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
 import com.ignfab.minalac.generator.exceptions.IgnorableException;
 import com.ignfab.minalac.generator.exceptions.TransformException;
@@ -7,8 +10,6 @@ import com.ignfab.minalac.generator.inputs.FloatGeographicDataMatrix2d;
 import com.ignfab.minalac.generator.models.FloatMatrixModel;
 import com.ignfab.minalac.generator.utils.coordinates.CoordsConverterProvider;
 import com.ignfab.minalac.generator.utils.coordinates.MapToWorldConverter;
-import org.geotools.api.referencing.FactoryException;
-import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 
 /**
  * Processor transforming {@link FloatGeographicDataMatrix2d} into a

--- a/src/main/java/com/ignfab/minalac/generator/processors/GeoToolsVectorProcessor.java
+++ b/src/main/java/com/ignfab/minalac/generator/processors/GeoToolsVectorProcessor.java
@@ -1,16 +1,17 @@
 package com.ignfab.minalac.generator.processors;
 
+import org.geotools.api.feature.Property;
+import org.geotools.api.feature.simple.SimpleFeature;
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.locationtech.jts.geom.Geometry;
+
 import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
 import com.ignfab.minalac.generator.exceptions.IgnorableException;
 import com.ignfab.minalac.generator.exceptions.TransformException;
 import com.ignfab.minalac.generator.models.JTSGeometryModel;
 import com.ignfab.minalac.generator.utils.coordinates.CoordsConverterProvider;
 import com.ignfab.minalac.generator.utils.coordinates.MapToWorldConverter;
-import org.geotools.api.feature.Property;
-import org.geotools.api.feature.simple.SimpleFeature;
-import org.geotools.api.referencing.FactoryException;
-import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
-import org.locationtech.jts.geom.Geometry;
 
 /**
  * Processor transforming {@link SimpleFeature} GeoTools object

--- a/src/main/java/com/ignfab/minalac/generator/processors/Processor.java
+++ b/src/main/java/com/ignfab/minalac/generator/processors/Processor.java
@@ -1,9 +1,10 @@
 package com.ignfab.minalac.generator.processors;
 
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+
 import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
 import com.ignfab.minalac.generator.exceptions.IgnorableException;
 import com.ignfab.minalac.generator.models.Model;
-import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 
 /**
  * A processor is responsible for transforming elements coming from

--- a/src/main/java/com/ignfab/minalac/generator/processors/post/MetadataParsePostProcessor.java
+++ b/src/main/java/com/ignfab/minalac/generator/processors/post/MetadataParsePostProcessor.java
@@ -1,10 +1,10 @@
 package com.ignfab.minalac.generator.processors.post;
 
+import java.util.function.Function;
+
 import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
 import com.ignfab.minalac.generator.exceptions.IgnorableException;
 import com.ignfab.minalac.generator.models.Model;
-
-import java.util.function.Function;
 
 /**
  * Post-processor parsing a metadata value in-place.

--- a/src/main/java/com/ignfab/minalac/generator/renderers/BuildingRenderer.java
+++ b/src/main/java/com/ignfab/minalac/generator/renderers/BuildingRenderer.java
@@ -3,11 +3,11 @@ package com.ignfab.minalac.generator.renderers;
 import com.ignfab.minalac.generator.generation.Heightmap;
 import com.ignfab.minalac.generator.models.ModelSelection;
 import com.ignfab.minalac.generator.models.ShapesVoxelizable2d;
+import com.ignfab.minalac.generator.utils.world2d.Positioned2d;
+import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.voxelization.shape2d.LineVoxel2d;
 import com.ignfab.minalac.generator.voxelization.shape2d.ShapesVoxelizer2d;
-import com.ignfab.minalac.generator.utils.world2d.Positioned2d;
-import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
 import com.ignfab.minalac.generator.world.Placeable;
 
 /**

--- a/src/main/java/com/ignfab/minalac/generator/utils/coordinates/EnvelopeProvider.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/coordinates/EnvelopeProvider.java
@@ -1,9 +1,10 @@
 package com.ignfab.minalac.generator.utils.coordinates;
 
-import com.ignfab.minalac.generator.exceptions.TransformException;
 import org.geotools.api.referencing.FactoryException;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.geometry.jts.ReferencedEnvelope;
+
+import com.ignfab.minalac.generator.exceptions.TransformException;
 
 /**
  * An {@code EnvelopeProvider} computes envelope in a given CRS.

--- a/src/main/java/com/ignfab/minalac/generator/utils/network/HttpTrustAllSSL.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/network/HttpTrustAllSSL.java
@@ -1,15 +1,15 @@
 package com.ignfab.minalac.generator.utils.network;
 
-import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLEngine;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509ExtendedTrustManager;
 import java.net.Socket;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509ExtendedTrustManager;
 
 /**
  * Trust manager that does not validate certificate chains.

--- a/src/main/java/com/ignfab/minalac/generator/utils/world2d/WorldBBox2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world2d/WorldBBox2d.java
@@ -1,10 +1,10 @@
 package com.ignfab.minalac.generator.utils.world2d;
 
+import java.util.Iterator;
+
 import com.ignfab.minalac.generator.utils.iterator.Iterators;
 import com.ignfab.minalac.generator.utils.world2d.iterator.WorldBBox2dIterator;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
-
-import java.util.Iterator;
 
 /**
  * The {@code WorldBBox2d} class represents a two-dimensional bounding box that surrounds an area on the surface (xy-plane) of the voxel world.

--- a/src/main/java/com/ignfab/minalac/generator/utils/world2d/iterator/WorldBBox2dIterator.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world2d/iterator/WorldBBox2dIterator.java
@@ -1,10 +1,10 @@
 package com.ignfab.minalac.generator.utils.world2d.iterator;
 
-import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
-import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
-
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+
+import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
+import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
 
 /**
  * An iterator over all coordinates in a {@code WorldBBox2d}.

--- a/src/main/java/com/ignfab/minalac/generator/utils/world3d/WorldBBox3d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world3d/WorldBBox3d.java
@@ -1,10 +1,10 @@
 package com.ignfab.minalac.generator.utils.world3d;
 
+import java.util.Iterator;
+
 import com.ignfab.minalac.generator.utils.iterator.Iterators;
 import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
 import com.ignfab.minalac.generator.utils.world3d.iterator.WorldBBox3dIterator;
-
-import java.util.Iterator;
 
 /**
  * The {@code WorldBBox3d} class represents a three-dimensional bounding box that surrounds an area of the voxel world.

--- a/src/main/java/com/ignfab/minalac/generator/utils/world3d/iterator/WorldBBox3dIterator.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world3d/iterator/WorldBBox3dIterator.java
@@ -1,10 +1,10 @@
 package com.ignfab.minalac.generator.utils.world3d.iterator;
 
-import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
-import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
-
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
 
 /**
  * An iterator over all coordinates in a {@link WorldBBox3d}.

--- a/src/main/java/com/ignfab/minalac/generator/voxelization/shape2d/Polyline2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/voxelization/shape2d/Polyline2d.java
@@ -1,14 +1,14 @@
 package com.ignfab.minalac.generator.voxelization.shape2d;
 
-import com.ignfab.minalac.generator.utils.iterator.Iterables;
-import com.ignfab.minalac.generator.utils.world2d.Bounded2d;
-import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
-import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+
+import com.ignfab.minalac.generator.utils.iterator.Iterables;
+import com.ignfab.minalac.generator.utils.world2d.Bounded2d;
+import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
+import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
 
 /**
  * Represents a 2d polyline in the voxel world.

--- a/src/main/java/com/ignfab/minalac/generator/voxelization/shape2d/ShapesVoxelizer2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/voxelization/shape2d/ShapesVoxelizer2d.java
@@ -1,14 +1,14 @@
 package com.ignfab.minalac.generator.voxelization.shape2d;
 
-import com.ignfab.minalac.generator.utils.iterator.Iterables;
-import com.ignfab.minalac.generator.utils.world2d.Positioned2d;
-import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
-import com.ignfab.minalac.generator.voxelization.Voxelizer2d;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+
+import com.ignfab.minalac.generator.utils.iterator.Iterables;
+import com.ignfab.minalac.generator.utils.world2d.Positioned2d;
+import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
+import com.ignfab.minalac.generator.voxelization.Voxelizer2d;
 
 /**
  * A voxelizer based on 2d shapes.

--- a/src/main/java/com/ignfab/minalac/generator/voxelization/shape2d/iterator/Line2dIterator.java
+++ b/src/main/java/com/ignfab/minalac/generator/voxelization/shape2d/iterator/Line2dIterator.java
@@ -1,10 +1,10 @@
 package com.ignfab.minalac.generator.voxelization.shape2d.iterator;
 
-import com.ignfab.minalac.generator.voxelization.shape2d.Line2d;
-import com.ignfab.minalac.generator.voxelization.shape2d.LineVoxel2d;
-
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+
+import com.ignfab.minalac.generator.voxelization.shape2d.Line2d;
+import com.ignfab.minalac.generator.voxelization.shape2d.LineVoxel2d;
 
 /**
  * An iterator returning voxels of each position on a 2d line.

--- a/src/main/java/com/ignfab/minalac/generator/voxelization/shape2d/iterator/Polygon2dIterator.java
+++ b/src/main/java/com/ignfab/minalac/generator/voxelization/shape2d/iterator/Polygon2dIterator.java
@@ -1,14 +1,14 @@
 package com.ignfab.minalac.generator.voxelization.shape2d.iterator;
 
-import com.ignfab.minalac.generator.utils.world2d.Positioned2d;
-import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
-import com.ignfab.minalac.generator.voxelization.shape2d.Line2d;
-import com.ignfab.minalac.generator.voxelization.shape2d.Polygon2d;
-
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+
+import com.ignfab.minalac.generator.utils.world2d.Positioned2d;
+import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
+import com.ignfab.minalac.generator.voxelization.shape2d.Line2d;
+import com.ignfab.minalac.generator.voxelization.shape2d.Polygon2d;
 
 /**
  * An iterator returning voxels of each position inside a 2d polygon.

--- a/src/main/java/com/ignfab/minalac/generator/voxelization/shape3d/Polygon3d.java
+++ b/src/main/java/com/ignfab/minalac/generator/voxelization/shape3d/Polygon3d.java
@@ -1,12 +1,12 @@
 package com.ignfab.minalac.generator.voxelization.shape3d;
 
+import java.util.Collection;
+import java.util.LinkedList;
+
 import com.ignfab.minalac.generator.utils.iterator.Iterables;
 import com.ignfab.minalac.generator.utils.world3d.Bounded3d;
 import com.ignfab.minalac.generator.utils.world3d.Positioned3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
-
-import java.util.Collection;
-import java.util.LinkedList;
 
 /**
  * Represents a 3d polygon with holes in the voxel world.

--- a/src/main/java/com/ignfab/minalac/generator/voxelization/shape3d/Polyline3d.java
+++ b/src/main/java/com/ignfab/minalac/generator/voxelization/shape3d/Polyline3d.java
@@ -1,14 +1,14 @@
 package com.ignfab.minalac.generator.voxelization.shape3d;
 
-import com.ignfab.minalac.generator.utils.iterator.Iterables;
-import com.ignfab.minalac.generator.utils.world3d.Bounded3d;
-import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
-import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+
+import com.ignfab.minalac.generator.utils.iterator.Iterables;
+import com.ignfab.minalac.generator.utils.world3d.Bounded3d;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
 
 /**
  * Represents a 3d polyline in the voxel world.

--- a/src/main/java/com/ignfab/minalac/generator/voxelization/shape3d/ShapesVoxelizer3d.java
+++ b/src/main/java/com/ignfab/minalac/generator/voxelization/shape3d/ShapesVoxelizer3d.java
@@ -1,14 +1,14 @@
 package com.ignfab.minalac.generator.voxelization.shape3d;
 
-import com.ignfab.minalac.generator.utils.iterator.Iterables;
-import com.ignfab.minalac.generator.utils.world3d.Positioned3d;
-import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
-import com.ignfab.minalac.generator.voxelization.Voxelizer3d;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+
+import com.ignfab.minalac.generator.utils.iterator.Iterables;
+import com.ignfab.minalac.generator.utils.world3d.Positioned3d;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+import com.ignfab.minalac.generator.voxelization.Voxelizer3d;
 
 /**
  * A voxelizer based on 3d shapes.

--- a/src/main/java/com/ignfab/minalac/generator/voxelization/shape3d/iterator/Line3dIterator.java
+++ b/src/main/java/com/ignfab/minalac/generator/voxelization/shape3d/iterator/Line3dIterator.java
@@ -1,10 +1,10 @@
 package com.ignfab.minalac.generator.voxelization.shape3d.iterator;
 
-import com.ignfab.minalac.generator.voxelization.shape3d.Line3d;
-import com.ignfab.minalac.generator.voxelization.shape3d.LineVoxel3d;
-
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+
+import com.ignfab.minalac.generator.voxelization.shape3d.Line3d;
+import com.ignfab.minalac.generator.voxelization.shape3d.LineVoxel3d;
 
 /**
  * An iterator returning voxels of each position on a 3d line.

--- a/src/main/java/com/ignfab/minalac/generator/world/MapWriteException.java
+++ b/src/main/java/com/ignfab/minalac/generator/world/MapWriteException.java
@@ -3,7 +3,7 @@ package com.ignfab.minalac.generator.world;
 /**
  * Exception thrown if a problem occurs when saving a {@link VoxelWorld}.
  *
- * @see VoxelWorld#save(File)
+ * @see VoxelWorld#save(java.io.File)
  */
 public class MapWriteException extends Exception {
     /**

--- a/src/main/java/com/ignfab/minalac/generator/world/SimpleVoxelStructure.java
+++ b/src/main/java/com/ignfab/minalac/generator/world/SimpleVoxelStructure.java
@@ -1,10 +1,10 @@
 package com.ignfab.minalac.generator.world;
 
-import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
-import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
-
 import java.util.HashMap;
 import java.util.Map;
+
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
 
 /**
  * {@code SimpleVoxelStructure} is a {@link Placeable} consisting of placeables at given coordinate offsets.

--- a/src/main/java/com/ignfab/minalac/generator/world/VoxelWorld.java
+++ b/src/main/java/com/ignfab/minalac/generator/world/VoxelWorld.java
@@ -1,8 +1,8 @@
 package com.ignfab.minalac.generator.world;
 
-import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
-
 import java.io.File;
+
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 
 /**
  * The {@code VoxelWorld} abstract class represents a three-dimensional world with voxels as the fundamental unit.

--- a/src/test/java/com/ignfab/minalac/generator/generation/HeightmapTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/generation/HeightmapTest.java
@@ -1,8 +1,8 @@
 package com.ignfab.minalac.generator.generation;
 
-import org.junit.jupiter.api.Test;
-
 import java.lang.reflect.Field;
+
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/ignfab/minalac/generator/generation/TestGeneration.java
+++ b/src/test/java/com/ignfab/minalac/generator/generation/TestGeneration.java
@@ -1,5 +1,17 @@
 package com.ignfab.minalac.generator.generation;
 
+import java.io.File;
+
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.referencing.CRS;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+
 import com.ignfab.minalac.generator.exceptions.TransformException;
 import com.ignfab.minalac.generator.utils.coordinates.MapToWorldConverter;
 import com.ignfab.minalac.generator.utils.random.Seed;
@@ -7,19 +19,6 @@ import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.world.MapWriteException;
 import com.ignfab.minalac.generator.world.VoxelWorld;
 import com.ignfab.minalac.generator.world.VoxelWorldMetadata;
-
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-
-import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
-import org.geotools.api.referencing.FactoryException;
-import org.geotools.referencing.CRS;
-import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.Envelope;
-import org.locationtech.jts.geom.Geometry;
-import org.locationtech.jts.geom.GeometryFactory;
-
-import java.io.File;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/ignfab/minalac/generator/generation/TestStore.java
+++ b/src/test/java/com/ignfab/minalac/generator/generation/TestStore.java
@@ -1,8 +1,8 @@
 package com.ignfab.minalac.generator.generation;
 
-import org.junit.jupiter.api.Test;
-
 import java.util.NoSuchElementException;
+
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/ignfab/minalac/generator/inputs/ParameterizedURLTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/inputs/ParameterizedURLTest.java
@@ -1,8 +1,8 @@
 package com.ignfab.minalac.generator.inputs;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ParameterizedURLTest {
 

--- a/src/test/java/com/ignfab/minalac/generator/inputs/TestingProvider.java
+++ b/src/test/java/com/ignfab/minalac/generator/inputs/TestingProvider.java
@@ -1,8 +1,8 @@
 package com.ignfab.minalac.generator.inputs;
 
-import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
-
 import java.util.NoSuchElementException;
+
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 
 public class TestingProvider implements Provider<String> {
     private final CoordinateReferenceSystem crs;

--- a/src/test/java/com/ignfab/minalac/generator/models/FloatMatrixModelTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/models/FloatMatrixModelTest.java
@@ -1,7 +1,5 @@
 package com.ignfab.minalac.generator.models;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import org.geotools.referencing.operation.transform.IdentityTransform;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.util.AffineTransformation;
@@ -11,6 +9,8 @@ import com.ignfab.minalac.generator.inputs.FloatGeographicDataMatrix2d;
 import com.ignfab.minalac.generator.utils.coordinates.MapToWorldConverter;
 import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
 import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class FloatMatrixModelTest {
     @Test

--- a/src/test/java/com/ignfab/minalac/generator/models/ModelSelectionTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/models/ModelSelectionTest.java
@@ -1,14 +1,13 @@
 package com.ignfab.minalac.generator.models;
 
+import java.util.Arrays;
+import java.util.Map;
+
 import org.junit.jupiter.api.Test;
 
 import com.ignfab.minalac.generator.models.filters.ModelFilterHasMetadata;
 
-import java.util.Arrays;
-import java.util.Map;
-
-import static com.ignfab.minalac.generator.utils.iterator.IteratorTester.assertBrowsesAllOnce;
-import static com.ignfab.minalac.generator.utils.iterator.IteratorTester.assertEmpty;
+import static com.ignfab.minalac.generator.utils.iterator.IteratorTester.*;
 
 public class ModelSelectionTest {
 

--- a/src/test/java/com/ignfab/minalac/generator/models/ModelStoreTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/models/ModelStoreTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class ModelStoreTest {
-    class TestModel extends ModelImpl {
+    static class TestModel extends ModelImpl {
         @Override
         public String salt() {
             return "";

--- a/src/test/java/com/ignfab/minalac/generator/models/ModelTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/models/ModelTest.java
@@ -1,11 +1,11 @@
 package com.ignfab.minalac.generator.models;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ModelTest {
     private static final class DummyModel extends ModelImpl {

--- a/src/test/java/com/ignfab/minalac/generator/models/filters/ModelFilterHasMetadataTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/models/filters/ModelFilterHasMetadataTest.java
@@ -1,14 +1,14 @@
 package com.ignfab.minalac.generator.models.filters;
 
+import java.util.Map;
+import java.util.function.Predicate;
+
 import org.junit.jupiter.api.Test;
 
 import com.ignfab.minalac.generator.models.Model;
 import com.ignfab.minalac.generator.models.TestingModel;
 
 import static org.junit.jupiter.api.Assertions.*;
-
-import java.util.Map;
-import java.util.function.Predicate;
 
 public class ModelFilterHasMetadataTest {
 

--- a/src/test/java/com/ignfab/minalac/generator/models/filters/ModelFilterMetadataInTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/models/filters/ModelFilterMetadataInTest.java
@@ -1,15 +1,15 @@
 package com.ignfab.minalac.generator.models.filters;
 
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Predicate;
+
 import org.junit.jupiter.api.Test;
 
 import com.ignfab.minalac.generator.models.Model;
 import com.ignfab.minalac.generator.models.TestingModel;
 
 import static org.junit.jupiter.api.Assertions.*;
-
-import java.util.Arrays;
-import java.util.Map;
-import java.util.function.Predicate;
 
 public class ModelFilterMetadataInTest {
     @Test

--- a/src/test/java/com/ignfab/minalac/generator/models/filters/ModelFilterMetadataLowerThanTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/models/filters/ModelFilterMetadataLowerThanTest.java
@@ -1,8 +1,5 @@
 package com.ignfab.minalac.generator.models.filters;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.util.Map;
 import java.util.function.Predicate;
 
@@ -10,6 +7,8 @@ import org.junit.jupiter.api.Test;
 
 import com.ignfab.minalac.generator.models.Model;
 import com.ignfab.minalac.generator.models.TestingModel;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ModelFilterMetadataLowerThanTest {
     @Test

--- a/src/test/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelTypeTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelTypeTest.java
@@ -1,13 +1,14 @@
 package com.ignfab.minalac.generator.outputs.minecraft;
 
-import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
-import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
+import java.util.HashMap;
+import java.util.Map;
+
 import net.querz.nbt.tag.CompoundTag;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.HashMap;
-import java.util.Map;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelWorldTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelWorldTest.java
@@ -1,14 +1,15 @@
 package com.ignfab.minalac.generator.outputs.minecraft;
 
-import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
-import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
 import net.querz.nbt.tag.CompoundTag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import java.io.File;
-import java.util.Arrays;
-import java.util.List;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/ignfab/minalac/generator/outputs/testing/TestingVoxelWorld.java
+++ b/src/test/java/com/ignfab/minalac/generator/outputs/testing/TestingVoxelWorld.java
@@ -1,16 +1,13 @@
 package com.ignfab.minalac.generator.outputs.testing;
 
+import java.io.File;
+
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
 import com.ignfab.minalac.generator.world.MapWriteException;
-
 import com.ignfab.minalac.generator.world.VoxelWorld;
 
-import java.io.File;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Testing purpose voxel world output.

--- a/src/test/java/com/ignfab/minalac/generator/outputs/testing/TestingVoxelWorldTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/outputs/testing/TestingVoxelWorldTest.java
@@ -1,13 +1,14 @@
 package com.ignfab.minalac.generator.outputs.testing;
 
-import org.junit.jupiter.api.Test;
+import java.io.File;
+
 import org.junit.jupiter.api.DisplayName;
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.world.VoxelType;
 
-import java.io.File;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestingVoxelWorldTest {
     @Test

--- a/src/test/java/com/ignfab/minalac/generator/parameters/GenerationParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/GenerationParamsTest.java
@@ -1,5 +1,10 @@
 package com.ignfab.minalac.generator.parameters;
 
+import java.util.HashMap;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.generation.Heightmap;
 import com.ignfab.minalac.generator.outputs.minetest.MTVoxelWorld;
@@ -8,13 +13,8 @@ import com.ignfab.minalac.generator.parameters.placeables.TestingVoxelTypeParams
 import com.ignfab.minalac.generator.parameters.placeables.minetest.MTVoxelTypeParams;
 import com.ignfab.minalac.generator.parameters.processors.TestingProcessorParams;
 import com.ignfab.minalac.generator.parameters.providers.TestingProviderParams;
-import com.ignfab.minalac.generator.parameters.renderers.TestingRendererParams;
 import com.ignfab.minalac.generator.parameters.renderers.BuildingRendererParams;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import java.util.HashMap;
+import com.ignfab.minalac.generator.parameters.renderers.TestingRendererParams;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/HeightmapParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/HeightmapParamsTest.java
@@ -1,13 +1,14 @@
 package com.ignfab.minalac.generator.parameters;
 
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.referencing.CRS;
+import org.junit.jupiter.api.Test;
+
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.generation.Heightmap;
 import com.ignfab.minalac.generator.outputs.minetest.MTVoxelWorld;
 import com.ignfab.minalac.generator.utils.random.Seed;
 import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
-import org.geotools.api.referencing.FactoryException;
-import org.geotools.referencing.CRS;
-import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/OutputFormatTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/OutputFormatTest.java
@@ -1,15 +1,15 @@
 package com.ignfab.minalac.generator.parameters;
 
-import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.*;
-
-import org.junit.jupiter.api.DisplayName;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
 import com.ignfab.minalac.generator.parameters.placeables.PlaceableParams;
 import com.ignfab.minalac.generator.parameters.placeables.TestingVoxelTypeParams;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class OutputFormatTest {
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/ParamsParserTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/ParamsParserTest.java
@@ -1,12 +1,12 @@
 package com.ignfab.minalac.generator.parameters;
 
-import com.ignfab.minalac.generator.outputs.minetest.MTVoxelWorld;
-import com.ignfab.minalac.generator.parameters.placeables.minetest.MTVoxelTypeParams;
-import com.ignfab.minalac.generator.parameters.renderers.TestingRendererParams;
+import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
+import com.ignfab.minalac.generator.outputs.minetest.MTVoxelWorld;
+import com.ignfab.minalac.generator.parameters.placeables.minetest.MTVoxelTypeParams;
+import com.ignfab.minalac.generator.parameters.renderers.TestingRendererParams;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/ParamsTester.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/ParamsTester.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
 import com.ignfab.minalac.generator.parameters.placeables.TestingVoxelTypeParams;
 
 /**

--- a/src/test/java/com/ignfab/minalac/generator/parameters/ValueParserTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/ValueParserTest.java
@@ -1,10 +1,9 @@
 package com.ignfab.minalac.generator.parameters;
 
-import static org.junit.jupiter.api.Assertions.*;
-
+import com.fasterxml.jackson.databind.JsonMappingException;
 import org.junit.jupiter.api.Test;
 
-import com.fasterxml.jackson.databind.JsonMappingException;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ValueParserTest {
     @Test

--- a/src/test/java/com/ignfab/minalac/generator/parameters/models/filters/ModelFilterAndParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/models/filters/ModelFilterAndParamsTest.java
@@ -1,14 +1,14 @@
 package com.ignfab.minalac.generator.parameters.models.filters;
 
+import java.util.List;
+import java.util.function.Predicate;
+
 import org.junit.jupiter.api.Test;
 
 import com.ignfab.minalac.generator.models.Model;
 import com.ignfab.minalac.generator.models.TestingModel;
 
 import static org.junit.jupiter.api.Assertions.*;
-
-import java.util.List;
-import java.util.function.Predicate;
 
 public class ModelFilterAndParamsTest {
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/models/filters/ModelFilterHasMetadataParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/models/filters/ModelFilterHasMetadataParamsTest.java
@@ -1,10 +1,10 @@
 package com.ignfab.minalac.generator.parameters.models.filters;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
-
-import java.util.List;
 
 public class ModelFilterHasMetadataParamsTest {
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/models/filters/ModelFilterMetadataInParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/models/filters/ModelFilterMetadataInParamsTest.java
@@ -1,12 +1,12 @@
 package com.ignfab.minalac.generator.parameters.models.filters;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import com.ignfab.minalac.generator.models.filters.ModelFilterMetadataIn;
 
 import static org.junit.jupiter.api.Assertions.*;
-
-import java.util.List;
 
 public class ModelFilterMetadataInParamsTest {
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/models/filters/ModelFilterMetadataLowerThanParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/models/filters/ModelFilterMetadataLowerThanParamsTest.java
@@ -1,12 +1,10 @@
 package com.ignfab.minalac.generator.parameters.models.filters;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import org.junit.jupiter.api.Test;
 
 import com.ignfab.minalac.generator.models.filters.ModelFilterMetadataLowerThan;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ModelFilterMetadataLowerThanParamsTest {
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/models/filters/ModelFilterNotParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/models/filters/ModelFilterNotParamsTest.java
@@ -1,13 +1,13 @@
 package com.ignfab.minalac.generator.parameters.models.filters;
 
+import java.util.function.Predicate;
+
 import org.junit.jupiter.api.Test;
 
 import com.ignfab.minalac.generator.models.Model;
 import com.ignfab.minalac.generator.models.TestingModel;
 
 import static org.junit.jupiter.api.Assertions.*;
-
-import java.util.function.Predicate;
 
 public class ModelFilterNotParamsTest {
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/models/filters/ModelFilterOrParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/models/filters/ModelFilterOrParamsTest.java
@@ -1,14 +1,14 @@
 package com.ignfab.minalac.generator.parameters.models.filters;
 
+import java.util.List;
+import java.util.function.Predicate;
+
 import org.junit.jupiter.api.Test;
 
 import com.ignfab.minalac.generator.models.Model;
 import com.ignfab.minalac.generator.models.TestingModel;
 
 import static org.junit.jupiter.api.Assertions.*;
-
-import java.util.List;
-import java.util.function.Predicate;
 
 public class ModelFilterOrParamsTest {
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/placeables/PlaceableParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/placeables/PlaceableParamsTest.java
@@ -1,15 +1,15 @@
 package com.ignfab.minalac.generator.parameters.placeables;
 
-import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.*;
-
-import org.junit.jupiter.api.DisplayName;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
 import com.ignfab.minalac.generator.parameters.OutputFormat;
 import com.ignfab.minalac.generator.parameters.ParamsTester;
 import com.ignfab.minalac.generator.parameters.placeables.structures.StackStructureParams;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class PlaceableParamsTest {
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/placeables/TestingVoxelTypeParams.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/placeables/TestingVoxelTypeParams.java
@@ -5,6 +5,7 @@ import java.beans.ConstructorProperties;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.Nulls;
+
 import com.ignfab.minalac.generator.outputs.testing.TestingVoxelType;
 import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
 import com.ignfab.minalac.generator.world.Placeable;

--- a/src/test/java/com/ignfab/minalac/generator/parameters/placeables/structures/StackStructureParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/placeables/structures/StackStructureParamsTest.java
@@ -1,7 +1,6 @@
 package com.ignfab.minalac.generator.parameters.placeables.structures;
 
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.*;
 
 import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
 import com.ignfab.minalac.generator.parameters.ParamsTester;
@@ -9,6 +8,8 @@ import com.ignfab.minalac.generator.parameters.placeables.TestingVoxelTypeParams
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
 import com.ignfab.minalac.generator.world.Placeable;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class StackStructureParamsTest {
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/processors/FloatMatrixProcessorParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/processors/FloatMatrixProcessorParamsTest.java
@@ -1,12 +1,13 @@
 package com.ignfab.minalac.generator.parameters.processors;
 
-import com.ignfab.minalac.generator.generation.Generation;
-import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
-import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import org.geotools.api.referencing.FactoryException;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.referencing.CRS;
 import org.junit.jupiter.api.Test;
+
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/processors/GeoToolsVectorProcessorParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/processors/GeoToolsVectorProcessorParamsTest.java
@@ -1,12 +1,13 @@
 package com.ignfab.minalac.generator.parameters.processors;
 
-import com.ignfab.minalac.generator.generation.Generation;
-import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
-import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import org.geotools.api.referencing.FactoryException;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.referencing.CRS;
 import org.junit.jupiter.api.Test;
+
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/processors/TestingProcessorParams.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/processors/TestingProcessorParams.java
@@ -1,12 +1,13 @@
 package com.ignfab.minalac.generator.parameters.processors;
 
+import java.beans.ConstructorProperties;
+
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
+
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.processors.Processor;
 import com.ignfab.minalac.generator.processors.TestingProcessor;
-
-import java.beans.ConstructorProperties;
 
 public class TestingProcessorParams extends ProcessorParams {
     /**

--- a/src/test/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataCopyPostProcessorParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataCopyPostProcessorParamsTest.java
@@ -1,18 +1,12 @@
 package com.ignfab.minalac.generator.parameters.processors.post;
 
-import org.junit.jupiter.api.Test;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class MetadataCopyPostProcessorParamsTest {
     private static ObjectMapper mapper;

--- a/src/test/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataDefaultPostProcessorParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataDefaultPostProcessorParamsTest.java
@@ -1,11 +1,10 @@
 package com.ignfab.minalac.generator.parameters.processors.post;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import org.junit.jupiter.api.Test;
 
 import com.ignfab.minalac.generator.parameters.ValueParser;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class MetadataDefaultPostProcessorParamsTest {
     @Test

--- a/src/test/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataParsePostProcessorParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataParsePostProcessorParamsTest.java
@@ -1,16 +1,15 @@
 package com.ignfab.minalac.generator.parameters.processors.post;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
 import com.ignfab.minalac.generator.parameters.ValueParser;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class MetadataParsePostProcessorParamsTest {
     private static ObjectMapper mapper;

--- a/src/test/java/com/ignfab/minalac/generator/parameters/providers/GeoPackageProviderParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/providers/GeoPackageProviderParamsTest.java
@@ -1,16 +1,17 @@
 package com.ignfab.minalac.generator.parameters.providers;
 
-import com.ignfab.minalac.generator.generation.Generation;
-import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
-import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+import java.io.File;
+import java.io.IOException;
+
 import org.geotools.api.referencing.FactoryException;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.referencing.CRS;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import java.io.File;
-import java.io.IOException;
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/providers/ShapefileProviderParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/providers/ShapefileProviderParamsTest.java
@@ -1,16 +1,17 @@
 package com.ignfab.minalac.generator.parameters.providers;
 
-import com.ignfab.minalac.generator.generation.Generation;
-import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
-import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+import java.io.File;
+import java.io.IOException;
+
 import org.geotools.api.referencing.FactoryException;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.referencing.CRS;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import java.io.File;
-import java.io.IOException;
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/providers/TestingProviderParams.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/providers/TestingProviderParams.java
@@ -4,6 +4,7 @@ import java.beans.ConstructorProperties;
 
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
+
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.inputs.Provider;
 import com.ignfab.minalac.generator.inputs.TestingProvider;

--- a/src/test/java/com/ignfab/minalac/generator/parameters/providers/WFSProviderParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/providers/WFSProviderParamsTest.java
@@ -1,8 +1,5 @@
 package com.ignfab.minalac.generator.parameters.providers;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
 import org.geotools.api.referencing.FactoryException;
 import org.geotools.api.referencing.NoSuchAuthorityCodeException;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
@@ -12,6 +9,8 @@ import org.junit.jupiter.api.Test;
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class WFSProviderParamsTest {
     @Test

--- a/src/test/java/com/ignfab/minalac/generator/parameters/providers/WMSFloatBilProviderParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/providers/WMSFloatBilProviderParamsTest.java
@@ -1,7 +1,5 @@
 package com.ignfab.minalac.generator.parameters.providers;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import org.geotools.api.referencing.FactoryException;
 import org.geotools.api.referencing.NoSuchAuthorityCodeException;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
@@ -11,6 +9,8 @@ import org.junit.jupiter.api.Test;
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class WMSFloatBilProviderParamsTest {
     @Test

--- a/src/test/java/com/ignfab/minalac/generator/parameters/renderers/BuildingRendererParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/renderers/BuildingRendererParamsTest.java
@@ -5,15 +5,13 @@ import com.fasterxml.jackson.databind.exc.InvalidNullException;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.junit.jupiter.api.Test;
+
 import com.ignfab.minalac.generator.parameters.ParamsTester;
 import com.ignfab.minalac.generator.parameters.models.ModelSelectionParams;
 import com.ignfab.minalac.generator.parameters.placeables.TestingVoxelTypeParams;
-import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class BuildingRendererParamsTest {
     @Test

--- a/src/test/java/com/ignfab/minalac/generator/parameters/renderers/LevelingRendererParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/renderers/LevelingRendererParamsTest.java
@@ -5,15 +5,13 @@ import com.fasterxml.jackson.databind.exc.InvalidNullException;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.junit.jupiter.api.Test;
+
 import com.ignfab.minalac.generator.parameters.ParamsTester;
 import com.ignfab.minalac.generator.parameters.models.ModelSelectionParams;
 import com.ignfab.minalac.generator.parameters.placeables.TestingVoxelTypeParams;
-import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class LevelingRendererParamsTest {
     @Test

--- a/src/test/java/com/ignfab/minalac/generator/parameters/renderers/TestingRendererParams.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/renderers/TestingRendererParams.java
@@ -4,6 +4,7 @@ import java.beans.ConstructorProperties;
 
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
+
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.renderers.Renderer;
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/renderers/VectorRendererParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/renderers/VectorRendererParamsTest.java
@@ -5,8 +5,7 @@ import org.junit.jupiter.api.Test;
 import com.ignfab.minalac.generator.parameters.models.ModelSelectionParams;
 import com.ignfab.minalac.generator.parameters.placeables.minetest.MTVoxelTypeParams;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class VectorRendererParamsTest {
     @Test

--- a/src/test/java/com/ignfab/minalac/generator/processors/GeoToolsVectorProcessorTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/processors/GeoToolsVectorProcessorTest.java
@@ -1,11 +1,8 @@
 package com.ignfab.minalac.generator.processors;
 
-import com.ignfab.minalac.generator.models.JTSGeometryModel;
-import com.ignfab.minalac.generator.utils.coordinates.MapToWorldConverter;
-import com.ignfab.minalac.generator.utils.iterator.Iterables;
-import com.ignfab.minalac.generator.utils.world2d.Positioned2d;
-import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
-import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.geotools.api.feature.simple.SimpleFeature;
 import org.geotools.api.feature.simple.SimpleFeatureType;
 import org.geotools.api.referencing.FactoryException;
@@ -17,10 +14,14 @@ import org.geotools.referencing.operation.transform.IdentityTransform;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.util.AffineTransformation;
 
-import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
+import com.ignfab.minalac.generator.models.JTSGeometryModel;
+import com.ignfab.minalac.generator.utils.coordinates.MapToWorldConverter;
+import com.ignfab.minalac.generator.utils.iterator.Iterables;
+import com.ignfab.minalac.generator.utils.world2d.Positioned2d;
+import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
+import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
 
-import static com.ignfab.minalac.generator.utils.iterator.IteratorTester.assertBrowsesAllOnce;
+import static com.ignfab.minalac.generator.utils.iterator.IteratorTester.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class GeoToolsVectorProcessorTest {

--- a/src/test/java/com/ignfab/minalac/generator/processors/TestingProcessor.java
+++ b/src/test/java/com/ignfab/minalac/generator/processors/TestingProcessor.java
@@ -1,7 +1,8 @@
 package com.ignfab.minalac.generator.processors;
 
-import com.ignfab.minalac.generator.models.TestingModel;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+
+import com.ignfab.minalac.generator.models.TestingModel;
 
 public class TestingProcessor implements Processor<String, TestingModel> {
 

--- a/src/test/java/com/ignfab/minalac/generator/processors/post/MetadataCopyPostProcessorTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/processors/post/MetadataCopyPostProcessorTest.java
@@ -1,12 +1,12 @@
 package com.ignfab.minalac.generator.processors.post;
 
-import com.ignfab.minalac.generator.models.Model;
-import com.ignfab.minalac.generator.models.TestingModel;
+import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.Map;
+import com.ignfab.minalac.generator.models.Model;
+import com.ignfab.minalac.generator.models.TestingModel;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/ignfab/minalac/generator/processors/post/MetadataDefaultPostProcessorTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/processors/post/MetadataDefaultPostProcessorTest.java
@@ -1,10 +1,10 @@
 package com.ignfab.minalac.generator.processors.post;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-
 import org.junit.jupiter.api.Test;
 
 import com.ignfab.minalac.generator.models.TestingModel;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class MetadataDefaultPostProcessorTest {
     @Test

--- a/src/test/java/com/ignfab/minalac/generator/processors/post/MetadataParsePostProcessorTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/processors/post/MetadataParsePostProcessorTest.java
@@ -1,16 +1,16 @@
 package com.ignfab.minalac.generator.processors.post;
 
-import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
-import com.ignfab.minalac.generator.exceptions.IgnorableException;
-import com.ignfab.minalac.generator.models.Model;
-import com.ignfab.minalac.generator.models.TestingModel;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.Map;
-import java.util.Objects;
-import java.util.function.Function;
+import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
+import com.ignfab.minalac.generator.exceptions.IgnorableException;
+import com.ignfab.minalac.generator.models.Model;
+import com.ignfab.minalac.generator.models.TestingModel;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/ignfab/minalac/generator/renderers/ModelRendererTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/renderers/ModelRendererTest.java
@@ -1,15 +1,16 @@
 package com.ignfab.minalac.generator.renderers;
 
-import com.ignfab.minalac.generator.models.ModelImpl;
-import com.ignfab.minalac.generator.models.ModelSelection;
-import com.ignfab.minalac.generator.models.ModelStore;
-import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
-import org.junit.jupiter.api.Test;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+
+import org.junit.jupiter.api.Test;
+
+import com.ignfab.minalac.generator.models.ModelImpl;
+import com.ignfab.minalac.generator.models.ModelSelection;
+import com.ignfab.minalac.generator.models.ModelStore;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/ignfab/minalac/generator/renderers/VectorRendererTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/renderers/VectorRendererTest.java
@@ -1,5 +1,9 @@
 package com.ignfab.minalac.generator.renderers;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
 import com.ignfab.minalac.generator.generation.Heightmap;
 import com.ignfab.minalac.generator.models.ModelSelection;
 import com.ignfab.minalac.generator.models.ModelStore;
@@ -11,10 +15,6 @@ import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
 import com.ignfab.minalac.generator.world.VoxelType;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/ignfab/minalac/generator/utils/coordinates/MapToMapConverterTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/coordinates/MapToMapConverterTest.java
@@ -1,7 +1,5 @@
 package com.ignfab.minalac.generator.utils.coordinates;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import org.geotools.api.referencing.FactoryException;
 import org.geotools.api.referencing.operation.MathTransform;
 import org.geotools.referencing.CRS;
@@ -14,6 +12,8 @@ import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.util.AffineTransformation;
 
 import com.ignfab.minalac.generator.exceptions.TransformException;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class MapToMapConverterTest {
 

--- a/src/test/java/com/ignfab/minalac/generator/utils/execution/SchedulerTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/execution/SchedulerTest.java
@@ -1,14 +1,14 @@
 package com.ignfab.minalac.generator.utils.execution;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/ignfab/minalac/generator/utils/iterator/IterablesTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/iterator/IterablesTest.java
@@ -1,13 +1,13 @@
 package com.ignfab.minalac.generator.utils.iterator;
 
-import static com.ignfab.minalac.generator.utils.iterator.IteratorTester.*;
-
-import org.junit.jupiter.api.Test;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static com.ignfab.minalac.generator.utils.iterator.IteratorTester.*;
 
 public class IterablesTest {
 

--- a/src/test/java/com/ignfab/minalac/generator/utils/iterator/IteratorTester.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/iterator/IteratorTester.java
@@ -1,11 +1,11 @@
 package com.ignfab.minalac.generator.utils.iterator;
 
-import static org.junit.jupiter.api.Assertions.fail;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * A test facility for iterators.

--- a/src/test/java/com/ignfab/minalac/generator/utils/iterator/IteratorTesterTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/iterator/IteratorTesterTest.java
@@ -1,13 +1,13 @@
 package com.ignfab.minalac.generator.utils.iterator;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.opentest4j.AssertionFailedError;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class IteratorTesterTest {
 

--- a/src/test/java/com/ignfab/minalac/generator/utils/iterator/IteratorsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/iterator/IteratorsTest.java
@@ -1,14 +1,14 @@
 package com.ignfab.minalac.generator.utils.iterator;
 
-import static com.ignfab.minalac.generator.utils.iterator.IteratorTester.*;
-
-import org.junit.jupiter.api.Test;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static com.ignfab.minalac.generator.utils.iterator.IteratorTester.*;
 
 public class IteratorsTest {
     @Test

--- a/src/test/java/com/ignfab/minalac/generator/utils/random/SeedTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/random/SeedTest.java
@@ -1,11 +1,11 @@
 package com.ignfab.minalac.generator.utils.random;
 
+import java.util.Arrays;
+import java.util.Random;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
-
-import java.util.Arrays;
-import java.util.Random;
 
 public class SeedTest {
 

--- a/src/test/java/com/ignfab/minalac/generator/utils/world2d/WorldBBox2dTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/world2d/WorldBBox2dTest.java
@@ -1,16 +1,16 @@
 package com.ignfab.minalac.generator.utils.world2d;
 
-import static com.ignfab.minalac.generator.utils.iterator.IteratorTester.*;
-
-import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.*;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+
+import static com.ignfab.minalac.generator.utils.iterator.IteratorTester.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class WorldBBox2dTest {
     @Test

--- a/src/test/java/com/ignfab/minalac/generator/utils/world2d/iterator/WorldBBox2dIteratorTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/world2d/iterator/WorldBBox2dIteratorTest.java
@@ -1,12 +1,13 @@
 package com.ignfab.minalac.generator.utils.world2d.iterator;
 
-import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
-import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
+import java.util.NoSuchElementException;
+
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
+import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
 
-import java.util.NoSuchElementException;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class WorldBBox2dIteratorTest {
     @Test

--- a/src/test/java/com/ignfab/minalac/generator/utils/world3d/WorldBBox3dTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/world3d/WorldBBox3dTest.java
@@ -1,16 +1,16 @@
 package com.ignfab.minalac.generator.utils.world3d;
 
-import static com.ignfab.minalac.generator.utils.iterator.IteratorTester.*;
-
-import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.*;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
+
+import static com.ignfab.minalac.generator.utils.iterator.IteratorTester.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class WorldBBox3dTest {
     @Test

--- a/src/test/java/com/ignfab/minalac/generator/utils/world3d/iterator/WorldBBox3dIteratorTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/world3d/iterator/WorldBBox3dIteratorTest.java
@@ -1,10 +1,11 @@
 package com.ignfab.minalac.generator.utils.world3d.iterator;
 
-import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
-import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
+import java.util.NoSuchElementException;
+
 import org.junit.jupiter.api.Test;
 
-import java.util.NoSuchElementException;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/ignfab/minalac/generator/voxelization/shape2d/iterator/Line2dIteratorTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/voxelization/shape2d/iterator/Line2dIteratorTest.java
@@ -1,6 +1,6 @@
 package com.ignfab.minalac.generator.voxelization.shape2d.iterator;
 
-import static com.ignfab.minalac.generator.utils.iterator.IteratorTester.*;
+import java.util.Arrays;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -10,7 +10,7 @@ import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
 import com.ignfab.minalac.generator.voxelization.shape2d.Line2d;
 import com.ignfab.minalac.generator.voxelization.shape2d.LineVoxel2d;
 
-import java.util.Arrays;
+import static com.ignfab.minalac.generator.utils.iterator.IteratorTester.*;
 
 public class Line2dIteratorTest {
     @Test

--- a/src/test/java/com/ignfab/minalac/generator/voxelization/shape2d/iterator/Polygon2dIteratorTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/voxelization/shape2d/iterator/Polygon2dIteratorTest.java
@@ -1,6 +1,11 @@
 package com.ignfab.minalac.generator.voxelization.shape2d.iterator;
 
-import static com.ignfab.minalac.generator.utils.iterator.IteratorTester.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 import com.ignfab.minalac.generator.utils.world2d.Positioned2d;
 import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
@@ -8,13 +13,7 @@ import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
 import com.ignfab.minalac.generator.voxelization.shape2d.Polygon2d;
 import com.ignfab.minalac.generator.voxelization.shape2d.Polyline2d;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedList;
-
+import static com.ignfab.minalac.generator.utils.iterator.IteratorTester.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class Polygon2dIteratorTest {

--- a/src/test/java/com/ignfab/minalac/generator/world/SimpleVoxelStructureTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/world/SimpleVoxelStructureTest.java
@@ -1,9 +1,10 @@
 package com.ignfab.minalac.generator.world;
 
+import org.junit.jupiter.api.Test;
+
 import com.ignfab.minalac.generator.outputs.testing.TestingVoxelType;
 import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
-import org.junit.jupiter.api.Test;
 
 public class SimpleVoxelStructureTest {
 

--- a/src/test/java/com/ignfab/minalac/generator/world/VoxelWorldTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/world/VoxelWorldTest.java
@@ -1,13 +1,13 @@
 package com.ignfab.minalac.generator.world;
 
-import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
-import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
-import org.junit.jupiter.api.Test;
-
 import java.io.File;
 
+import org.junit.jupiter.api.Test;
+
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
+
 import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class VoxelWorldTest {
     @Test


### PR DESCRIPTION
### Changes

This PR adds checkstyle rules to validate imports ordering.

#### Feature description

The order of imports was not enforced. Now, it is validated by checktyle, according to the following layout:
- `java` / `javax` imports
- All other imports
- `com.ignfab.minalac.generator` imports
- Static imports

Imports within each groups must be ordered alphabetically. Groups are separated by a blank line, but no blank should be present within a group.

See below (in Reason) for a discussion about this layout.

#### Technical changes

See checkstyle's official documentation to understand the config: https://checkstyle.org/checks/imports/importorder.html

### Reason

Not having a fixed code-style about imports ordering caused trouble in PRs if not paying attention about the IDE re-ordering them, and at the end can cause unnecessary conflicts when merging.

This layout was inspired by what I saw in some std Java files. Now that we have the proof-of-concept of this, we can adapt the layout and try to find one that make sense for us, if we want to change.

### Self-checks

- ~~The code has unit tests associated~~
- ~~The code has Javadoc Comments associated~~
- ~~Complex / Unexpected code is explained / justified with a small comment~~
- ~~Relevant documentation inside the `/docs` folder has been updated~~
- ~~All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)~~
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [x] The texts have been proofread (documentation, error messages, logs, comments...)
