### PR TITLE
fix(params): Remove useless and heterogeneous annotation

### DIFF
--- a/src/main/java/com/ignfab/minalac/generator/parameters/placeables/voxels/MTVoxelTypeParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/placeables/voxels/MTVoxelTypeParams.java
@@ -3,7 +3,6 @@ package com.ignfab.minalac.generator.parameters.placeables.voxels;
 import java.beans.ConstructorProperties;
 
 import com.fasterxml.jackson.annotation.JsonSetter;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.Nulls;
 
 import com.ignfab.minalac.generator.outputs.minetest.MTVoxelType;
@@ -14,7 +13,6 @@ import com.ignfab.minalac.generator.world.VoxelWorld;
 /**
  * A voxel type parameters for Minetest voxel types with only node type name.
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NONE) // Prevents default deserializer from requiring type when using "default" placeable param structure
 public class MTVoxelTypeParams extends VoxelParams {
     /**
      * Node type name (required).


### PR DESCRIPTION
This is a very simple fix PR. It just removes a Jackson annotation that was present on `MTVoxelTypeParams` and absent from `MCVoxelTypeParams`. It seems to be totally useless now as we don't use `JsonTypeInfo.Id.NAME` for this part of params.

## How to test

Test both Minetest and Minecraft formats, add some *full voxel descriptions* like, for Minecraft :
```yaml
place:
  block: oak_leaves
  properties:
    persistent: true
```
or, for Minetest:
```yaml
place:
  node: stairs:stair_stone
  param2: 2
```

