### PR TITLE
Fix generator not parsing some anchors

### DIFF
--- a/src/main/java/com/ignfab/minalac/generator/parameters/ParamsParser.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/ParamsParser.java
@@ -11,8 +11,10 @@ import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.composer.ComposerException;
 import org.yaml.snakeyaml.constructor.DuplicateKeyException;
 
 /**
@@ -44,16 +46,21 @@ public class ParamsParser {
         GenerationParams params;
         SimpleModule module;
 
-        // Resolve yaml references and pick up format
+        // Resolve Yaml anchors and pick up format
         // (Jackson is not able to do it by itself but it is still very good at deserializing)
-        LoaderOptions options = new LoaderOptions();
-        options.setAllowDuplicateKeys(false);
-        Yaml yaml = new Yaml(options);
+
+        LoaderOptions loaderOptions = new LoaderOptions();
+        loaderOptions.setAllowDuplicateKeys(false);
+
+        DumperOptions dumperOptions = new DumperOptions();
+        dumperOptions.setDereferenceAliases(true); // Prevents new anchor generation on dumping
+
+        Yaml yaml = new Yaml(loaderOptions, dumperOptions);
 
         Map<Object, Object> document;
         try {
             document = yaml.load(serialized);
-        } catch (DuplicateKeyException e) {
+        } catch (DuplicateKeyException | ComposerException e) {
             throw new ParseException(e);
         }
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/ParamsParserTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/ParamsParserTest.java
@@ -135,6 +135,44 @@ public class ParamsParserTest {
     }
 
     @Test
+    public void testAnchors() {
+        assertDoesNotThrow(() -> newParser().parse("""
+            references:
+              - &area
+                center:
+                  latitude: 5.8
+                  longitude: 2.4
+                extentX: 500
+                extentY: 2500
+                angle: 30
+              - &format minetest
+            area: *area
+            format: *format
+            """
+        ), "Anchors should be resolved");
+
+        assertThrows(ParseException.class, () -> newParser().parse("""
+            area: *area
+            format: *format
+            """
+        ), "Unresolved anchors should throw an exception");
+
+        ParamsParser parser = newParser();
+        parser.registerParams("customIdentifier", TestingRendererParams.class);
+
+        assertDoesNotThrow(() -> parser.parse("""
+            renderers:
+              smeargle1: &rdr
+                type: customIdentifier
+                requiredField: sketch
+              smeargle2: *rdr
+              smeargle3: *rdr
+            """
+            + MINIMAL_YAML
+        ), "Repeating Yaml parameters should be parsed without generating anchors");
+    }
+
+    @Test
     public void testParseHeightmaps() {
         // By default, jackson doesn't check the existence of duplicates keys: last occurrence takes precedence.
         // Checks if configuration was properly done so an exception is thrown.


### PR DESCRIPTION
### Issue

Trying to use some anchors for structure, I got a strange behavior: SnakeYaml was passing Yaml with anchors still present in it but renamed.

Actually there was no connection between using anchor and that bug. It happened that Yaml.dump was smartly creating anchors for repeated content that Jackson was not able to handle.

### Changes

* Disable anchors creation in Yaml dump.
* Adding some missing tests about anchor parsing.

### How to test

Unit tests do test the fix.

### Self-checks

- [x] The code has unit tests associated
- ~~The code has Javadoc Comments associated~~
- [x] Complex / Unexpected code is explained / justified with a small comment
- ~~Relevant documentation inside the `/docs` folder has been updated~~
- [x] All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- ~~The texts have been proofread (documentation, error messages, logs, comments...)~~
