### PR TITLE
Make vector renderer great again

### DIFF
--- a/docs/usage/GenerationParameters.md
+++ b/docs/usage/GenerationParameters.md
@@ -26,10 +26,11 @@ renderers:
     after:
       - source:bati
     type: vector
-    modelType: building
+    models:
+      type: building
     heightmap: ground
     inside: default:cobble
-    edge: default:stone
+    borders: default:stone
 area:
   center:
     latitude: 48.845
@@ -232,13 +233,15 @@ Each renderer has a field `type` which is used to identify it.
 
 This renderer places a column of voxels under a heightmap.
 
-**Type**: ground
+#### Type `ground`
 
-**Extra parameters**:
+#### Extra parameters
+
 - `heightmap`: Name of the heightmap to use
 - `place`: [Placeable](Placeables.md) to place at each heightmap voxel.
 
-Example:
+#### Example
+
 ```yaml
 type: ground
 heightmap: altitude
@@ -248,33 +251,61 @@ This will put a grass voxel at heightmap altitude. For better rendering, place v
 
 ### Vector renderer
 
+This renderer draws 2-D geometries (points, linear things and surfaces) on a given heightmap.
+
+#### Type `vector`
+
+#### Extra parameters
+
+- `models`: [Selection of models](#model-selections) to render (required, models must be voxelizable in 2d)
+- `heightmap`: Name of the ground heightmap to use (required)
+- `place`: [Placeable](Placeables.md) to place on each voxel of shapes (optional)
+- `inside`: [Placeable](Placeables.md) to place on each voxel inside shapes (optional)
+- `borders`: [Placeable](Placeables.md) to place on each voxel of shapes borders (optional)
+
+**NOTE**: `place` cannot be used with `inside` or `borders` (`inside` and `borders` may be used together).
+
+#### Examples
+
+Draw "building" shapes with cobble on ground:
 ```yaml
 type: vector
-modelType: building
+models:
+  type: building
 heightmap: ground
-inside: default:coble
-edge: default:stone
+place: default:cobble
 ```
 
-Fields:
-- `type`: Must be the value `vector`.
-- `modelType`: the type of models to render
-- `heightmap`: the name of the ground heightmap to use. It must exist.
-- `inside`: [Placeable](Placeables.md) to place on each inside voxel
-- `edge`: [Placeable](Placeables.md) to place on each edge voxel
+Draw same shapes but with wooden borders and glass inside:
+```yaml
+type: vector
+models:
+  type: building
+heightmap: ground
+borders: default:wood
+inside: default:glass
+```
+
 
 ### Heightmap renderer
 
+This renderer populates a heightmap with models data. Existing data is overwritten.
+
+#### Type `heightmap`
+
+#### Extra parameters
+
+- `models`: [Selection of models](#model-selections) to render (required, models must be float matrices)
+- `heightmap`: Name of the heightmap to populate (required, updated)
+
+#### Example
+
 ```yaml
 type: heightmap
-modelType: mnt
+models:
+  type: altitude
 heightmap: ground
 ```
-
-Fields:
-- `type`: Must be the value `heightmap`
-- `modelType`: the type of models to render
-- `heightmap`: the name of the heightmap to use. It must exist.
 
 ### Leveling renderer
 
@@ -282,11 +313,22 @@ Levels ground under selected models.
 
 Ground height is given by `heightmap`. If it's not flat under a model, it will be risen enough to be flat over model surface. `filling` voxels will be added to world and `heightmap` will be updated accordingly.
 
-Fields:
-- `type`: Must be the value `leveling`
-- `models`: Type of models to render
-- `heightmap`: Heightmap of the ground, will be updated according to leveling.
+#### Type `leveling`
+
+#### Extra parameters
+- `models`: [Selection of models](#model-selections) to render (required, models must be voxelizable in 2d)
+- `heightmap`: Name of the ground heightmap (required, updated according to leveling)
 - `filling`: [Placeable](Placeables.md) placed beneath the model, ensuring it connects to the ground and does not appear to float.
+
+#### Example
+
+```yaml
+type: leveling
+models:
+  type: buildings
+heightmap: ground
+filling: default:cobble
+```
 
 ### Building renderer
 
@@ -294,16 +336,31 @@ Renders buildings using selected models as buildings footprint.
 
 Building height is given by `height` metadata (the behavior of this renderer is undefined if value is missing, negative or zero).
 
-Fields:
-- `type`: Must be the value `building`
-- `models`: Type of models to render.
-- `heightmap`: Name of the heightmap to use. It must exist.
+#### Type `building`
+
+#### Extra parameters
+
+- `models`: [Selection of models](#model-selections) to render (required, models must be voxelizable in 2d)
+- `heightmap`: Name of the heightmap to use (required)
 - `roof`: [Placeable](Placeables.md) used to render roofs.
 - `wall`: [Placeable](Placeables.md) used to render walls.
 - `window`: [Placeable](Placeables.md) used to render windows.
 
 #### Required model metadata
+
 - `height`: Height of building to render (must be a positive integer)
+
+#### Example
+
+```yaml
+type: building
+models:
+  type: buildings
+heightmap: ground
+roof: default:cobble
+wall: default:brick
+window: default:glass
+```
 
 ## Model selections
 

--- a/examples/formats/minecraft.yaml
+++ b/examples/formats/minecraft.yaml
@@ -5,4 +5,4 @@ references:
   - &voxel-cobble minecraft:cobblestone
   - &voxel-grass minecraft:grass_block
   - &voxel-glass minecraft:glass
-
+  - &voxel-forest-ground minecraft:podzol

--- a/examples/formats/minetest.yaml
+++ b/examples/formats/minetest.yaml
@@ -5,3 +5,4 @@ references:
   - &voxel-cobble default:cobble
   - &voxel-grass default:dirt_with_grass
   - &voxel-glass default:glass
+  - &voxel-forest-ground default:dirt_with_rainforest_litter

--- a/examples/processes/full.yaml
+++ b/examples/processes/full.yaml
@@ -32,6 +32,14 @@ sources:
         metadata: height
         value: 5
         as: integer
+  vegetation:
+    modelType: vegetation
+    provider:
+      type: wfs
+      url: https://data.geopf.fr/wfs/wfs
+      features: BDTOPO_V3:zone_de_vegetation
+    processor:
+      type: geoToolsVector
 renderers:
   altitude:
     after:
@@ -75,3 +83,12 @@ renderers:
     roof: *voxel-cobble
     wall: *voxel-stone
     window: *voxel-glass
+  vegetation:
+    after:
+      - renderer:ground
+      - source:vegetation
+    type: vector
+    models:
+      type: vegetation
+    heightmap: ground
+    place: *voxel-forest-ground

--- a/src/main/java/com/ignfab/minalac/generator/parameters/renderers/VectorRendererParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/renderers/VectorRendererParams.java
@@ -2,11 +2,16 @@ package com.ignfab.minalac.generator.parameters.renderers;
 
 import java.beans.ConstructorProperties;
 
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.parameters.models.ModelSelectionParams;
 import com.ignfab.minalac.generator.parameters.placeables.PlaceableParams;
 import com.ignfab.minalac.generator.renderers.Renderer;
 import com.ignfab.minalac.generator.renderers.VectorRenderer;
+import com.ignfab.minalac.generator.world.NoVoxel;
+import com.ignfab.minalac.generator.world.Placeable;
 
 /**
  * Concrete class of {@link RendererParams} representing the parameters of a {@link VectorRenderer}.
@@ -19,48 +24,79 @@ public class VectorRendererParams extends RendererParams {
     /**
      * The name of the ground heightmap to use (required).
      */
+    @JsonSetter(nulls = Nulls.FAIL)
     public String heightmap;
     /**
-     * What to place inside shapes (required).
+     * What to place on shapes (optional).
      */
+    @JsonSetter(nulls = Nulls.SKIP)
+    public PlaceableParams place;
+    /**
+     * What to place inside shapes only (optional).
+     */
+    @JsonSetter(nulls = Nulls.SKIP)
     public PlaceableParams inside;
     /**
-     * What to place on shapes edges (required).
+     * What to place on shapes borders only (optional).
      */
-    public PlaceableParams edge;
+    @JsonSetter(nulls = Nulls.SKIP)
+    public PlaceableParams borders;
 
     /**
      * Constructor used to ensure that the required fields are present during deserialization.
      *
      * @param models models selection to render.
      * @param heightmap the name of the ground heightmap to use.
-     * @param inside what to place on inside shapes
-     * @param edge what to place on shapes edges
      */
-    @ConstructorProperties({"models", "heightmap", "inside", "edge"})
-    public VectorRendererParams(ModelSelectionParams models, String heightmap, PlaceableParams inside, PlaceableParams edge) {
+    @ConstructorProperties({"models", "heightmap"})
+    public VectorRendererParams(ModelSelectionParams models, String heightmap) {
         this.models = models;
         this.heightmap = heightmap;
-        this.inside = inside;
-        this.edge = edge;
     }
 
     @Override
     public void validate() throws IllegalArgumentException {
+        models.validate();
+
         if (heightmap.isEmpty())
             throw new IllegalArgumentException("The field heightmap cannot be empty");
-        inside.validate();
-        edge.validate();
-        models.validate();
+
+        if (place == null && inside == null && borders == null)
+            throw new IllegalArgumentException("At least one of 'place', 'inside' or 'borders' should be specified");
+
+        if (place != null) {
+            if (inside != null || borders != null)
+                throw new IllegalArgumentException("Incompatible fields: 'place' can't be present along with 'inside' or 'borders'");
+            place.validate();
+        }
+
+        if (inside != null)
+           inside.validate();
+
+        if (borders != null)
+            borders.validate();
     }
 
     @Override
     public Renderer create(Generation generation) {
+        Placeable insidePlaceable = NoVoxel.INSTANCE;
+        Placeable bordersPlaceable = NoVoxel.INSTANCE;
+
+        if (place != null) {
+            insidePlaceable = place.create(generation.world());
+            bordersPlaceable = insidePlaceable;
+        } else {
+            if (inside != null)
+                insidePlaceable = inside.create(generation.world());
+            if (borders != null)
+                bordersPlaceable = borders.create(generation.world());
+        }
+
         return new VectorRenderer(
             models.create(generation.models()),
             generation.heightmaps().get(heightmap),
-            inside.create(generation.world()),
-            edge.create(generation.world())
+            insidePlaceable,
+            bordersPlaceable
         );
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/renderers/VectorRenderer.java
+++ b/src/main/java/com/ignfab/minalac/generator/renderers/VectorRenderer.java
@@ -8,6 +8,7 @@ import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.voxelization.shape2d.LineVoxel2d;
 import com.ignfab.minalac.generator.voxelization.shape2d.ShapesVoxelizer2d;
+import com.ignfab.minalac.generator.world.NoVoxel;
 import com.ignfab.minalac.generator.world.Placeable;
 
 /**
@@ -18,7 +19,7 @@ public class VectorRenderer extends ModelRenderer<ShapesVoxelizable2d> {
 
     // What to place inside and on edges of geometries
     private final Placeable inside;
-    private final Placeable edge;
+    private final Placeable borders;
 
     /**
      * Creates a new VectorRenderer.
@@ -26,27 +27,41 @@ public class VectorRenderer extends ModelRenderer<ShapesVoxelizable2d> {
      * @param selection the model selection containing the wanted models to render (only ShapesVoxelizable2d ones will be)
      * @param heightmap Heightmap of the ground (on which features will be placed)
      * @param inside What to place inside geometries
-     * @param edge What to place on geometries edges
+     * @param borders What to place on geometries borders
      */
-    public VectorRenderer(ModelSelection selection, Heightmap heightmap, Placeable inside, Placeable edge) {
+    public VectorRenderer(ModelSelection selection, Heightmap heightmap, Placeable inside, Placeable borders) {
         super(ShapesVoxelizable2d.class, selection);
         this.heightmap = heightmap;
         this.inside = inside;
-        this.edge = edge;
+        this.borders = borders;
     }
 
     @Override
     protected void render(ShapesVoxelizable2d model, WorldBBox3d bbox) {
         ShapesVoxelizer2d voxelizer = model.voxelize2d(bbox.to2d());
 
-        // Iterate over objects and place voxels on map at heightmap altitude
-        for (Positioned2d voxel : voxelizer) {
-            WorldCoords2d c = voxel.coords();
-            inside.place(c.x(), c.y(), heightmap.get(c) + 1);
+        if (inside != NoVoxel.INSTANCE) {
+            // In case of same border & inside, don't perform two iterations
+            if (inside == borders) {
+                for (Positioned2d voxel : voxelizer) {
+                    WorldCoords2d c = voxel.coords();
+                    inside.place(c.x(), c.y(), heightmap.get(c));
+                }
+                return;
+            }
+
+            // Iteration over inside voxels
+            for (Positioned2d voxel : voxelizer.inside()) {
+                WorldCoords2d c = voxel.coords();
+                inside.place(c.x(), c.y(), heightmap.get(c));
+            }
         }
-        for (LineVoxel2d voxel : voxelizer.borders()) {
-            WorldCoords2d c = voxel.coords();
-            edge.place(c.x(), c.y(), heightmap.get(c) + 1);
-        }
+
+        if (borders != NoVoxel.INSTANCE)
+            // Iteration over border voxels
+            for (LineVoxel2d voxel : voxelizer.borders()) {
+                WorldCoords2d c = voxel.coords();
+                borders.place(c.x(), c.y(), heightmap.get(c));
+            }
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/parameters/placeables/voxels/TestingVoxelTypeParams.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/placeables/voxels/TestingVoxelTypeParams.java
@@ -33,6 +33,12 @@ public class TestingVoxelTypeParams extends VoxelParams {
     }
 
     @Override
+    public void validate() {
+        if (name.isBlank())
+            throw new IllegalArgumentException();
+    }
+
+    @Override
     public Placeable create(VoxelWorld world) {
         if (world instanceof TestingVoxelWorld testingWorld)
             return new TestingVoxelType(testingWorld, name);

--- a/src/test/java/com/ignfab/minalac/generator/parameters/renderers/VectorRendererParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/renderers/VectorRendererParamsTest.java
@@ -3,25 +3,74 @@ package com.ignfab.minalac.generator.parameters.renderers;
 import org.junit.jupiter.api.Test;
 
 import com.ignfab.minalac.generator.parameters.models.ModelSelectionParams;
-import com.ignfab.minalac.generator.parameters.placeables.voxels.MTVoxelTypeParams;
+import com.ignfab.minalac.generator.parameters.placeables.voxels.TestingVoxelTypeParams;
+
 
 import static org.junit.jupiter.api.Assertions.*;
 
 public class VectorRendererParamsTest {
     @Test
     public void testValidate() {
-
-        MTVoxelTypeParams grass = new MTVoxelTypeParams("default:grass");
-        MTVoxelTypeParams brick = new MTVoxelTypeParams("default:stonebrick");
         ModelSelectionParams selection = new ModelSelectionParams("building");
+        VectorRendererParams params;
 
-        VectorRendererParams paramsWithoutType = new VectorRendererParams(new ModelSelectionParams(""), "ground", grass, brick);
-        assertThrows(IllegalArgumentException.class, paramsWithoutType::validate);
+        // Test required arguments
+        params = new VectorRendererParams(new ModelSelectionParams(""), "ground");
+        params.place = new TestingVoxelTypeParams("A");
+        assertThrows(IllegalArgumentException.class, params::validate);
 
-        VectorRendererParams paramsWithoutHeightmap = new VectorRendererParams(selection, "", grass, brick);
-        assertThrows(IllegalArgumentException.class, paramsWithoutHeightmap::validate);
+        params = new VectorRendererParams(selection, "");
+        params.place = new TestingVoxelTypeParams("A");
+        assertThrows(IllegalArgumentException.class, params::validate);
 
-        VectorRendererParams params = new VectorRendererParams(selection, "ground", grass, brick);
+        params = new VectorRendererParams(selection, "ground");
+        assertThrows(IllegalArgumentException.class, params::validate);
+
+        params = new VectorRendererParams(selection, "ground");
+        params.borders = new TestingVoxelTypeParams("A");
         assertDoesNotThrow(params::validate);
+
+        // Test optional arguments
+        params = new VectorRendererParams(selection, "ground");
+        params.borders = new TestingVoxelTypeParams("A");
+        params.inside = new TestingVoxelTypeParams("B");
+        assertDoesNotThrow(params::validate);
+
+        params = new VectorRendererParams(selection, "ground");
+        params.inside = new TestingVoxelTypeParams("B");
+        assertDoesNotThrow(params::validate);
+
+        params = new VectorRendererParams(selection, "ground");
+        params.borders = new TestingVoxelTypeParams("A");
+        assertDoesNotThrow(params::validate);
+
+        params = new VectorRendererParams(selection, "ground");
+        params.place = new TestingVoxelTypeParams("C");
+        assertDoesNotThrow(params::validate);
+
+        // Test incompatible arguments
+        params = new VectorRendererParams(selection, "ground");
+        params.place = new TestingVoxelTypeParams("C");
+        params.borders = new TestingVoxelTypeParams("A");
+        assertThrows(IllegalArgumentException.class, params::validate);
+
+        params = new VectorRendererParams(selection, "ground");
+        params.place = new TestingVoxelTypeParams("C");
+        params.inside = new TestingVoxelTypeParams("B");
+        assertThrows(IllegalArgumentException.class, params::validate);
+
+        // Test invalid arguments
+        params = new VectorRendererParams(selection, "ground");
+        params.borders = new TestingVoxelTypeParams("");
+        assertThrows(IllegalArgumentException.class, params::validate);
+
+        params = new VectorRendererParams(selection, "ground");
+        params.inside = new TestingVoxelTypeParams("");
+        assertThrows(IllegalArgumentException.class, params::validate);
+
+        params = new VectorRendererParams(selection, "ground");
+        params.place = new TestingVoxelTypeParams("");
+        assertThrows(IllegalArgumentException.class, params::validate);
+
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/renderers/VectorRendererTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/renderers/VectorRendererTest.java
@@ -27,13 +27,11 @@ class VectorRendererTest {
     private VoxelType inside;
     private VoxelType edge;
 
-
-
     @BeforeEach
     public void setUp() {
         bbox = new WorldBBox3d(-1, -2, -3, 4, 5, 6);
         world = new TestingVoxelWorld(bbox);
-        heightmap = new Heightmap(bbox.to2d(), -1);
+        heightmap = new Heightmap(bbox.to2d(), 0);
         store = new ModelStore();
         modelSelection = new ModelSelection(store, "testing", null);
         inside = new TestingVoxelType(world, "INSIDE");
@@ -106,7 +104,7 @@ class VectorRendererTest {
         new VectorRenderer(modelSelection, heightmap, inside, edge).render(bbox);
 
         for (WorldCoords3d pos : bbox) {
-            if (pos.z() == (pos.x() + pos.y()) / 2 + 1) // + 1 because vector renderer places voxels 1 pos above heightmap
+            if (pos.z() == (pos.x() + pos.y()) / 2)
                 world.assertVoxelNotNull(pos);
             else
                 world.assertVoxelNull(pos);
@@ -128,7 +126,7 @@ class VectorRendererTest {
         new VectorRenderer(modelSelection, heightmap, inside, edge).render(bbox);
 
         for (WorldCoords3d pos : bbox) {
-            if (pos.z() == pos.x() + pos.y() * 2 + 1)
+            if (pos.z() == pos.x() + pos.y() * 2)
                 world.assertVoxelNotNull(pos);
             else
                 world.assertVoxelNull(pos);


### PR DESCRIPTION
### Changes

Remove 1 block vertical offset & add `place` param.

#### Feature description

Vector renderer was first developed for demonstration purposes but did not evolved since. It may now be used for various purposes: vegetation, cemeteries, car parks, and so on.

This PR makes tree changes:
- Remove an obsolete 1 block vertical offset on placed stuff;
- Make `inside` and `borders` (formerly `edge`) optional;
- Add a simple `place` parameter for placing both inside and on borders;

+ some documentation style for renderers (soon they'll have their own page)

### Self-checks

- [x] The code has unit tests associated
- ~~The code has Javadoc Comments associated~~
- ~~Complex / Unexpected code is explained / justified with a small comment~~
- [x] Relevant documentation inside the `/docs` folder has been updated
- [x] All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [ ] The texts have been proofread (documentation, error messages, logs, comments...)
