### PR TITLE
Make sources able to fetch only a given bounding box

### DIFF
--- a/src/main/java/com/ignfab/minalac/generator/generation/DataSource.java
+++ b/src/main/java/com/ignfab/minalac/generator/generation/DataSource.java
@@ -12,6 +12,7 @@ import com.ignfab.minalac.generator.models.Model;
 import com.ignfab.minalac.generator.models.ModelStore;
 import com.ignfab.minalac.generator.processors.Processor;
 import com.ignfab.minalac.generator.processors.post.PostProcessor;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 
 /**
  * A data source with a provider, a processor and some (or no) post-processors.
@@ -65,9 +66,11 @@ public class DataSource {
 
     /**
      * Fetches data from provider, and create and process models.
+     *
+     * @param bbox bounding box of region to fetch data for
      */
-    public void fetch() {
-        try (Provider.Result<?> result = provider.provide()) {
+    public void fetch(WorldBBox3d bbox) {
+        try (Provider.Result<?> result = provider.provide(bbox)) {
             processor.initialize(result.crs());
             while (result.hasNext()) {
                 Object data = result.next();

--- a/src/main/java/com/ignfab/minalac/generator/generation/Generation.java
+++ b/src/main/java/com/ignfab/minalac/generator/generation/Generation.java
@@ -132,19 +132,20 @@ public class Generation {
     }
 
     /**
-     * Returns geographic envelope (bounding box equivalent) of generated world
-     * in a given CRS.
+     * Returns geographic envelope (bounding box equivalent) of a given
+     * bounding box in a given CRS.
      *
      * @param crs Coordinate reference system to get envelope for.
-     * @return ReferencedEnvelope covering generated world in CRS.
+     * @param bbox Bounding box to get envelope for.
+     * @return ReferencedEnvelope covering given bounding box in CRS.
      */
-    public ReferencedEnvelope getEnvelopeForCRS(CoordinateReferenceSystem crs) throws FactoryException, TransformException {
+    public ReferencedEnvelope getEnvelopeForCRS(CoordinateReferenceSystem crs, WorldBBox3d bbox) throws FactoryException, TransformException {
         WorldToMapConverter converter = makeCoordsConverter(crs).inverse();
 
-        int minX = world.limits().minX();
-        int minY = world.limits().minY();
-        int maxX = world.limits().maxX() + 1;
-        int maxY = world.limits().maxY() + 1;
+        int minX = bbox.minX();
+        int minY = bbox.minY();
+        int maxX = bbox.maxX() + 1;
+        int maxY = bbox.maxY() + 1;
         Geometry geom = new GeometryFactory().createLinearRing(new Coordinate[] {
             new Coordinate(minX, minY),
             new Coordinate(maxX, minY),

--- a/src/main/java/com/ignfab/minalac/generator/inputs/GeoToolsDataStoreProvider.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/GeoToolsDataStoreProvider.java
@@ -22,6 +22,7 @@ import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
 import com.ignfab.minalac.generator.exceptions.RetryableException;
 import com.ignfab.minalac.generator.exceptions.TransformException;
 import com.ignfab.minalac.generator.utils.coordinates.EnvelopeProvider;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 
 /**
  * Data provider using GeoTools {@link DataStore}.
@@ -65,7 +66,7 @@ public abstract class GeoToolsDataStoreProvider implements Provider<SimpleFeatur
     }
 
     @Override
-    public Result<SimpleFeature> provide() throws GenerationFailedException, RetryableException {
+    public Result<SimpleFeature> provide(WorldBBox3d bbox) throws GenerationFailedException, RetryableException {
         try {
             // TODO Find a better way to make sure we dispose the store in case of exception
             // (but be careful not to dispose it too early, especially before reading data!)
@@ -78,7 +79,7 @@ public abstract class GeoToolsDataStoreProvider implements Provider<SimpleFeatur
             CoordinateReferenceSystem crs = crsOverride == null ? geom.getCoordinateReferenceSystem() : crsOverride;
             ReferencedEnvelope envelope;
             try {
-                envelope = envelopeProvider.computeForCRS(crs);
+                envelope = envelopeProvider.computeForCRS(crs, bbox);
             } catch (FactoryException | TransformException e) {
                 store.dispose();
                 throw new GenerationFailedException(e);

--- a/src/main/java/com/ignfab/minalac/generator/inputs/Provider.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/Provider.java
@@ -6,11 +6,12 @@ import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 
 import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
 import com.ignfab.minalac.generator.exceptions.RetryableException;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 
 /**
  * A provider is responsible for acquiring data.
  * <p>
- * Its main method is {@link #provide()}, which should return a
+ * Its main method is {@link #provide(WorldBBox3d)}, which should return a
  * {@link Result}. A result is both iterable and closable, which
  * means it must be closed at the end of iteration, or in case
  * an error occurs and no other element will be consumed.
@@ -41,11 +42,12 @@ public interface Provider<T> {
      *  }
      * }</pre>
      *
+     * @param bbox Bbox to get elements for
      * @return A result wrapping elements and close method
      * @throws GenerationFailedException If a fatal error occurs while fetching data
      * @throws RetryableException If an error occurs but retrying may solve the issue
      */
-    Result<T> provide() throws GenerationFailedException, RetryableException;
+    Result<T> provide(WorldBBox3d bbox) throws GenerationFailedException, RetryableException;
 
     /**
      * A result wraps elements and a close method.

--- a/src/main/java/com/ignfab/minalac/generator/inputs/WFS1_1_GML3_1_DataProvider.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/WFS1_1_GML3_1_DataProvider.java
@@ -11,6 +11,7 @@ import javax.xml.parsers.SAXParserFactory;
 
 import org.geotools.api.feature.simple.SimpleFeature;
 import org.geotools.api.feature.type.FeatureType;
+import org.geotools.api.referencing.FactoryException;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.data.DataUtilities;
 import org.geotools.data.simple.SimpleFeatureCollection;
@@ -27,6 +28,9 @@ import org.xml.sax.helpers.DefaultHandler;
 
 import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
 import com.ignfab.minalac.generator.exceptions.RetryableException;
+import com.ignfab.minalac.generator.exceptions.TransformException;
+import com.ignfab.minalac.generator.utils.coordinates.EnvelopeProvider;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 
 /**
  * Data provider using WFS 1.1 and GML 3.1.
@@ -37,25 +41,29 @@ public class WFS1_1_GML3_1_DataProvider implements Provider<SimpleFeature> {
     private static final String VERSION = "2.0.0";
 
     private final ParameterizedURL url;
-    private final ReferencedEnvelope envelope;
+    private final CoordinateReferenceSystem crs;
+    private final EnvelopeProvider envelopeProvider;
     private final int maxFeaturePerQuery;
+    private final String srsName;
 
     /**
      * Constructs a new {@code WFS1_1_GML3_1_DataProvider}.
      *
      * @param baseURL the base URL
      * @param type Name of the WFS feature type to query
-     * @param envelope Limit of area to fetch
+     * @param crs coordinate reference system to use for this source
+     * @param envelopeProvider function to use to compute envelopes from bounding boxes
      * @param maxFeaturePerQuery Maximum number of feature per query
      *
      * @throws IllegalArgumentException if SRS name could not be retrieved from envelope.
      */
-    public WFS1_1_GML3_1_DataProvider(String baseURL, String type, ReferencedEnvelope envelope, int maxFeaturePerQuery) {
+    public WFS1_1_GML3_1_DataProvider(String baseURL, String type, CoordinateReferenceSystem crs, EnvelopeProvider envelopeProvider, int maxFeaturePerQuery) {
         this.maxFeaturePerQuery = maxFeaturePerQuery;
-        this.envelope = envelope;
+        this.crs = crs;
+        this.envelopeProvider = envelopeProvider;
 
-        String srsname = CRS.toSRS(envelope.getCoordinateReferenceSystem());
-        if (srsname == null)
+        srsName = CRS.toSRS(crs);
+        if (srsName == null)
             throw new IllegalArgumentException("Could not retrieve SRS name for layer");
 
         this.url = ParameterizedURL.base(baseURL)
@@ -64,12 +72,8 @@ public class WFS1_1_GML3_1_DataProvider implements Provider<SimpleFeature> {
             .parameter("REQUEST", "GetFeature")
             .parameter("OUTPUTFORMAT", "GML3")
             .parameter("TYPENAMES", type)
-            .parameter("SRSNAME", srsname)
-            .parameter("BBOX", envelope.getMinX()
-                + "," + envelope.getMinY()
-                + "," + envelope.getMaxX()
-                + "," + envelope.getMaxY()
-                + "," + srsname).build();
+            .parameter("SRSNAME", srsName)
+            .build();
     }
 
     @Override
@@ -78,7 +82,22 @@ public class WFS1_1_GML3_1_DataProvider implements Provider<SimpleFeature> {
     }
 
     @Override
-    public Provider.Result<SimpleFeature> provide() throws GenerationFailedException, RetryableException {
+    public Provider.Result<SimpleFeature> provide(WorldBBox3d bbox) throws GenerationFailedException, RetryableException {
+
+        ReferencedEnvelope envelope;
+        try {
+            envelope = envelopeProvider.computeForCRS(crs, bbox);
+        } catch (FactoryException | TransformException e) {
+            throw new GenerationFailedException(e);
+        }
+
+        ParameterizedURL url = this.url.builder()
+            .parameter("BBOX", envelope.getMinX()
+                + "," + envelope.getMinY()
+                + "," + envelope.getMaxX()
+                + "," + envelope.getMaxY()
+                + "," + srsName)
+            .build();
 
         // First we need to know total feature count
         int count;
@@ -107,7 +126,7 @@ public class WFS1_1_GML3_1_DataProvider implements Provider<SimpleFeature> {
         }
 
         // Then we give hand to `Result` class for the rest.
-        return new Result(count);
+        return new Result(url, count);
     }
 
    /**
@@ -115,11 +134,13 @@ public class WFS1_1_GML3_1_DataProvider implements Provider<SimpleFeature> {
      */
     private class Result implements Provider.Result<SimpleFeature> {
 
+        private final ParameterizedURL url;
         private final int total;
         private int remaining;
         private SimpleFeatureIterator iterator;
 
-        Result(int total) {
+        Result(ParameterizedURL url, int total) {
+            this.url = url;
             this.total = total;
             remaining = total;
             iterator = null;
@@ -127,7 +148,7 @@ public class WFS1_1_GML3_1_DataProvider implements Provider<SimpleFeature> {
 
        @Override
        public CoordinateReferenceSystem crs() {
-           return envelope.getCoordinateReferenceSystem();
+           return crs;
        }
 
         /**

--- a/src/main/java/com/ignfab/minalac/generator/inputs/WMSFloatBilDataProvider.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/WMSFloatBilDataProvider.java
@@ -7,13 +7,17 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Iterator;
 
+import org.geotools.api.referencing.FactoryException;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.CRS;
 
 import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
 import com.ignfab.minalac.generator.exceptions.RetryableException;
+import com.ignfab.minalac.generator.exceptions.TransformException;
+import com.ignfab.minalac.generator.utils.coordinates.EnvelopeProvider;
 import com.ignfab.minalac.generator.utils.iterator.Iterators;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 
 /**
  * Data provider for Web Map Service (raster data).
@@ -23,30 +27,24 @@ public class WMSFloatBilDataProvider implements Provider<FloatGeographicDataMatr
     private static final String VERSION = "1.3.0";
 
     private final ParameterizedURL baseURL;
-    private final ReferencedEnvelope envelope;
-
-    private final int width;
-    private final int height;
+    private final CoordinateReferenceSystem crs;
+    private final EnvelopeProvider envelopeProvider;
+    private final String srsName;
 
     /**
      * Creates a new {@code WMSDataProvider}.
      *
      * @param baseURL base URL of the service
      * @param layer name of the WMS layer to query
-     * @param envelope limit of area to fetch
+     * @param crs coordinate reference system to use for this source
+     * @param envelopeProvider function to use to compute envelopes from bounding boxes
      */
-    public WMSFloatBilDataProvider(String baseURL, String layer, ReferencedEnvelope envelope) {
-        this.envelope = envelope;
+    public WMSFloatBilDataProvider(String baseURL, String layer, CoordinateReferenceSystem crs, EnvelopeProvider envelopeProvider) {
+        this.crs = crs;
+        this.envelopeProvider = envelopeProvider;
 
-        // Let's say we want heightmap with 1 map unit precision.
-        // TODO: Should computed from capabilities and voxel size in realworld
-        // (we don't need information more accurate than voxel size neither information more
-        // accurate than capabilities)
-        width  = (int) Math.round(envelope.getMaxX() - envelope.getMinX());
-        height = (int) Math.round(envelope.getMaxY() - envelope.getMinY());
-
-        String srsname = CRS.toSRS(envelope.getCoordinateReferenceSystem());
-        if (srsname == null)
+        srsName = CRS.toSRS(crs);
+        if (srsName == null)
             throw new IllegalArgumentException("Could not retrieve SRS name for layer");
 
         this.baseURL = ParameterizedURL.base(baseURL)
@@ -56,13 +54,6 @@ public class WMSFloatBilDataProvider implements Provider<FloatGeographicDataMatr
             .parameter("LAYERS", layer)
             .parameter("FORMAT", "image/x-bil;bits=32")
             .parameter("STYLES", "")
-            .parameter("CRS", srsname)
-            .parameter("BBOX", envelope.getMinX()
-                + "," + envelope.getMinY()
-                + "," + envelope.getMaxX()
-                + "," + envelope.getMaxY())
-            .parameter("WIDTH", width)
-            .parameter("HEIGHT", height)
             .build();
     }
 
@@ -72,12 +63,35 @@ public class WMSFloatBilDataProvider implements Provider<FloatGeographicDataMatr
     }
 
     @Override
-    public Provider.Result<FloatGeographicDataMatrix2d> provide() throws GenerationFailedException, RetryableException {
+    public Provider.Result<FloatGeographicDataMatrix2d> provide(WorldBBox3d bbox) throws GenerationFailedException, RetryableException {
 
+        ReferencedEnvelope envelope;
+        try {
+            envelope = envelopeProvider.computeForCRS(crs, bbox);
+        } catch (FactoryException | TransformException e) {
+            throw new GenerationFailedException(e);
+        }
+
+        // Let's say we want heightmap with 1 map unit precision.
+        // TODO: Should computed from capabilities and voxel size in realworld
+        // (we don't need information more accurate than voxel size neither information more
+        // accurate than capabilities)
+        int width  = (int) Math.round(envelope.getMaxX() - envelope.getMinX());
+        int height = (int) Math.round(envelope.getMaxY() - envelope.getMinY());
+
+        ParameterizedURL url = baseURL.builder()
+            .parameter("CRS", srsName)
+            .parameter("BBOX", envelope.getMinX()
+                + "," + envelope.getMinY()
+                + "," + envelope.getMaxX()
+                + "," + envelope.getMaxY())
+            .parameter("WIDTH", width)
+            .parameter("HEIGHT", height)
+            .build();
 
         InputStream inputStream;
         try {
-            inputStream = baseURL.toURL().openStream();
+            inputStream = url.toURL().openStream();
         } catch (MalformedURLException e) {
             throw new GenerationFailedException("Invalid URL for layer", e);
         } catch (IOException e) {
@@ -128,7 +142,7 @@ public class WMSFloatBilDataProvider implements Provider<FloatGeographicDataMatr
 
         @Override
         public CoordinateReferenceSystem crs() {
-            return envelope.getCoordinateReferenceSystem();
+            return crs;
         }
 
         @Override

--- a/src/main/java/com/ignfab/minalac/generator/parameters/GenerationCreator.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/GenerationCreator.java
@@ -69,7 +69,7 @@ public final class GenerationCreator {
             DataSource dataSource = dataSourceParams.create(generation);
             generation.scheduler().schedule(
                 "source:" + name,
-                dataSource::fetch,
+                () -> dataSource.fetch(generation.world().limits()),
                 dataSourceParams.after
             );
         });

--- a/src/main/java/com/ignfab/minalac/generator/parameters/providers/WFSProviderParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/providers/WFSProviderParams.java
@@ -7,10 +7,8 @@ import com.fasterxml.jackson.annotation.Nulls;
 import org.geotools.api.feature.simple.SimpleFeature;
 import org.geotools.api.referencing.FactoryException;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
-import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.CRS;
 
-import com.ignfab.minalac.generator.exceptions.TransformException;
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.inputs.Provider;
 import com.ignfab.minalac.generator.inputs.WFS1_1_GML3_1_DataProvider;
@@ -64,13 +62,6 @@ public class WFSProviderParams extends ProviderParams {
         else
             layerCrs = generation.crs();
 
-        ReferencedEnvelope envelope;
-        try {
-            envelope = generation.getEnvelopeForCRS(layerCrs);
-        } catch (FactoryException | TransformException e) {
-            throw new IllegalArgumentException("Unable to compute envelope for given CRS", e);
-        }
-
-        return new WFS1_1_GML3_1_DataProvider(url, features, envelope, maxFeaturesPerQuery);
+        return new WFS1_1_GML3_1_DataProvider(url, features, layerCrs, generation::getEnvelopeForCRS, maxFeaturesPerQuery);
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/parameters/providers/WMSFloatBilProviderParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/providers/WMSFloatBilProviderParams.java
@@ -4,10 +4,8 @@ import java.beans.ConstructorProperties;
 
 import org.geotools.api.referencing.FactoryException;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
-import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.CRS;
 
-import com.ignfab.minalac.generator.exceptions.TransformException;
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.inputs.FloatGeographicDataMatrix2d;
 import com.ignfab.minalac.generator.inputs.Provider;
@@ -56,13 +54,6 @@ public class WMSFloatBilProviderParams extends ProviderParams {
         else
             layerCrs = generation.crs();
 
-        ReferencedEnvelope envelope;
-        try {
-            envelope = generation.getEnvelopeForCRS(layerCrs);
-        } catch (FactoryException | TransformException e) {
-            throw new IllegalArgumentException("Unable to compute envelope for given CRS", e);
-        }
-
-        return new WMSFloatBilDataProvider(url, layer, envelope);
+        return new WMSFloatBilDataProvider(url, layer, layerCrs, generation::getEnvelopeForCRS);
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/utils/coordinates/EnvelopeProvider.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/coordinates/EnvelopeProvider.java
@@ -5,19 +5,21 @@ import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 
 import com.ignfab.minalac.generator.exceptions.TransformException;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 
 /**
  * An {@code EnvelopeProvider} computes envelope in a given CRS.
  * This is useful to get an envelope without knowing the CRS yet.
- * @see #computeForCRS(CoordinateReferenceSystem)
+ * @see #computeForCRS(CoordinateReferenceSystem, WorldBBox3d)
  */
 @FunctionalInterface
 public interface EnvelopeProvider {
     /**
-     * Computes and returns the envelope in the given CRS.
+     * Computes and returns an envelope in the given CRS for a given bounding box.
      * @param crs the CRS to encode coordinates in
+     * @param bbox bounding box (in world coordinates) to create envelope for
      * @return the resulting envelope
-     * @see com.ignfab.minalac.generator.generation.Generation#getEnvelopeForCRS(CoordinateReferenceSystem)
+     * @see com.ignfab.minalac.generator.generation.Generation#getEnvelopeForCRS(CoordinateReferenceSystem, WorldBBox3d)
      */
-    ReferencedEnvelope computeForCRS(CoordinateReferenceSystem crs) throws FactoryException, TransformException;
+    ReferencedEnvelope computeForCRS(CoordinateReferenceSystem crs, WorldBBox3d bbox) throws FactoryException, TransformException;
 }

--- a/src/test/java/com/ignfab/minalac/generator/generation/TestGeneration.java
+++ b/src/test/java/com/ignfab/minalac/generator/generation/TestGeneration.java
@@ -54,14 +54,14 @@ public class TestGeneration {
         assertEquals(249, box.maxY());
 
         // We should have an envelope +/- 500 around center (250 voxel * 2.0 meters/voxels = 500m)
-        Envelope envelope = generation.getEnvelopeForCRS(crs2154);
+        Envelope envelope = generation.getEnvelopeForCRS(crs2154, box);
         assertEquals(657_280.0, envelope.getMinX(), 2);
         assertEquals(6_860_230.0, envelope.getMinY(), 2);
         assertEquals(658_280.0, envelope.getMaxX(), 2);
         assertEquals(6_861_230.0, envelope.getMaxY(), 2);
 
         // Try another CRS
-        envelope = generation.getEnvelopeForCRS(crs4326);
+        envelope = generation.getEnvelopeForCRS(crs4326, box);
         assertEquals(48.8407, envelope.getMinX(), 0.0002);
         assertEquals(2.4179, envelope.getMinY(), 0.0002);
 

--- a/src/test/java/com/ignfab/minalac/generator/inputs/TestingProvider.java
+++ b/src/test/java/com/ignfab/minalac/generator/inputs/TestingProvider.java
@@ -4,6 +4,8 @@ import java.util.NoSuchElementException;
 
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+
 public class TestingProvider implements Provider<String> {
     private final CoordinateReferenceSystem crs;
 
@@ -17,7 +19,7 @@ public class TestingProvider implements Provider<String> {
     }
 
     @Override
-    public Result<String> provide() {
+    public Result<String> provide(WorldBBox3d bbox) {
         return new Result<>() {
             @Override
             public CoordinateReferenceSystem crs() {


### PR DESCRIPTION
### Issue

MINALAC-117

### Changes

Make sources able to fetch only a given bounding box (instead of using world.limits()).

#### Feature description

* Add `bbox` argument to `DataSource::fetch`;
* Add `bbox` argument to `ReferencedEnvelope::computeForCRS`

and make subsequent changes.

### Reason

Prepare merging sources and renderers into one "task" class.

### Self-checks

- [x] The code has unit tests associated
- ~~The code has Javadoc Comments associated~~
- ~~Complex / Unexpected code is explained / justified with a small comment~~
- ~~Relevant documentation inside the `/docs` folder has been updated~~
- [x] All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- ~~The texts have been proofread (documentation, error messages, logs, comments...)~~
