### PR TITLE
feat(tiles): Add tiles generator - MINALAC-122

### DIFF
--- a/docs/usage/Generator.md
+++ b/docs/usage/Generator.md
@@ -21,13 +21,25 @@ java -jar Generator.jar [OPTIONS] <outputPath>
 
 Options:
 - `-h` or `--help` display command usage.
-- `-p <path>` or `--param-file <path>` read generation parameters from given path. If omitted, parameters are read from `MINALAC_PARAMS` environment variable.
+- `-p <path>` or `--param-file <path>` read generation parameters from given path. If omitted, parameters are read from [`MINALAC_PARAMS`](#minalac_params) environment variable.
 - `--generation-disabled` Stop before starting generation, after parameters parsed.
 - `--save-disabled` Stop before saving output file, after generation done.
+- `--max-tile-size <size>` Perform tiled generation with tiles no larger than `size` (positive integer) in both dimensions. See also [`MINALAC_MAX_TILE_SIZE`](#minalac_max_tile_size) environment variable.
+
 
 `<outputPath>`: generation output path (must be an existing and writable directory).
 
 Output path and generation parameters have to be provided.
+
+## Environment variables
+
+### `MINALAC_PARAMS`
+
+If set, may contain generation parameters to use when `--param-file` command line option is absent.
+
+### `MINALAC_MAX_TILE_SIZE`
+
+If set to a positive integer, perform tiled generation with tiles no larger than this number. Overridden by `--max-tile-size` command line option.
 
 ## Compile and run
 

--- a/docs/usage/Run.md
+++ b/docs/usage/Run.md
@@ -39,3 +39,9 @@ Where:
 - `<outputPath>` is where world files will be generated, only required if no option set (if directory exists, it will be emptied).
 
 While many places are available, there are only two formats (`minecraft`, `minetest`) and one process (`full`) for now.
+
+To perform tiled generation, set `MINALAC_MAX_TILE_SIZE` environment variable to the wanted maximum tile size:
+
+```shell
+MINALAC_MAX_TILE_SIZE=512 ./generate.sh minetest full ign $HOME/.minetest/worlds/minalac
+```

--- a/src/main/java/com/ignfab/minalac/generator/MinalacGenerator.java
+++ b/src/main/java/com/ignfab/minalac/generator/MinalacGenerator.java
@@ -78,6 +78,8 @@ public final class MinalacGenerator {
         else
             destination = cli.outputPath().toFile();
 
+        Integer maxTileSize = cli.maxTileSize();
+
         // Generation parsing
         ParamsParser parser = new ParamsParser();
 
@@ -114,40 +116,64 @@ public final class MinalacGenerator {
         parser.registerParams("geometryBuffer", JTSGeometryBufferPostProcessorParams.class);
         parser.registerParams("remap", MetadataValueMappingPostProcessorParams.class);
 
-        Generation generation = parser.parse(cli.readParameters()).create();
+        Generation generation = parser.parse(cli.readParameters()).create(maxTileSize);
 
-        System.out.println("Initialization: " + Duration.between(initializationStart, Instant.now()).toSeconds() + "s");
+        System.out.printf("Generation initialization took %ds.%n", Duration.between(initializationStart, Instant.now()).toSeconds());
         if (cli.generationDisabled()) {
-            System.out.println("Total: " + Duration.between(start, Instant.now()).toSeconds() + "s");
-            System.out.println("Done (stopped before map generation)");
+            System.out.printf("Total: %ds.%nDone (stopped before map generation).%n", Duration.between(start, Instant.now()).toSeconds());
             return;
         }
 
-
-        System.out.println("Creation of the map.");
-        // Start generation duration
-        Instant generationStart = Instant.now();
+        Instant worldInitializationStart = Instant.now();
 
         // Initialize world
         generation.world().initialize();
+        System.out.printf("World initialization took %ds.%n", Duration.between(worldInitializationStart, Instant.now()).toSeconds());
 
-        // One unique tile for now
-        GenerationTile tile = new GenerationTile(generation, generation.world().limits());
+        int numberOfTiles = generation.numberOfTiles();
+        System.out.printf("Generation will be performed in %d tiles of maximum %d voxels by side.%n", numberOfTiles, generation.maxTileSize());
+
+        // Start generating tiles
+        Duration generatingDuration = Duration.ZERO; // This will hold total generation time
+        Duration mapSavingDuration = Duration.ZERO; // This will hold total map saving time
+
+        int currentTile = 0;
+
         try {
-            generation.scheduler().run(tile, 5, TimeUnit.MINUTES);
+            for (GenerationTile tile : generation.tiles()) {
+                currentTile++;
+                String tileString = "%d/%d (x=%d..%d, y=%d..%d)".formatted(currentTile, numberOfTiles, tile.limits().minX(), tile.limits().maxX(), tile.limits().minY(), tile.limits().maxY());
+                System.out.printf("%nTile %s.%n", tileString);
+
+                // Generate tile
+                Instant tileGenerationStart = Instant.now();
+                generation.scheduler().run(tile, 5, TimeUnit.MINUTES);
+                Duration tileGenerationDuration = Duration.between(tileGenerationStart, Instant.now());
+
+                generatingDuration = generatingDuration.plus(tileGenerationDuration);
+                System.out.printf("Tile %s generated in %ds.%n", tileString, tileGenerationDuration.toSeconds());
+
+                // Save tile
+                Instant tileSavingStart = Instant.now();
+                tile.save();
+                Duration tileSavingDuration = Duration.between(tileSavingStart, Instant.now());
+
+                mapSavingDuration = mapSavingDuration.plus(tileSavingDuration);
+                System.out.printf("Tile %s saved in %ds.%n", tileString, tileSavingDuration.toSeconds());
+            }
         } finally {
             generation.scheduler().shutdown();
         }
 
-        System.out.println("Generation: " + Duration.between(generationStart, Instant.now()).toSeconds() + "s");
+        System.out.printf("%nAll %d tiles generated and saved.%nSpent %ds generating and %ds saving.%n", numberOfTiles, generatingDuration.toSeconds(), mapSavingDuration.toSeconds());
 
-        System.out.println("Saving world");
+        Instant finalizationStart = Instant.now();
+
         VoxelWorldMetadata metadata = generation.world().getMetadata();
         metadata.setWorldName("Minalac");
 
-        tile.save();
         generation.world().finalizeAndSave();
-        System.out.println("Total: " + Duration.between(start, Instant.now()).toSeconds() + "s");
-        System.out.println("Done");
+        System.out.printf("Generation finalization took %ds.%n", Duration.between(finalizationStart, Instant.now()).toSeconds());
+        System.out.printf("Total: %ds.%nDone.%n", Duration.between(start, Instant.now()).toSeconds());
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/MinalacGeneratorCLI.java
+++ b/src/main/java/com/ignfab/minalac/generator/MinalacGeneratorCLI.java
@@ -21,12 +21,15 @@ import org.apache.commons.cli.ParseException;
 public class MinalacGeneratorCLI {
 
     private static final String PARAMS_ENVVAR_NAME = "MINALAC_PARAMS";
+    private static final String MAX_TILE_SIZE_ENVVAR_NAME = "MINALAC_MAX_TILE_SIZE";
 
     private Path outputPath;
     private Path parametersPath;
 
     private boolean generationDisabled;
     private boolean saveDisabled;
+
+    private Integer maxTileSize = null;
 
     private final Options options;
 
@@ -39,6 +42,7 @@ public class MinalacGeneratorCLI {
         options.addOption(new Option("p", "param-file", true, "Get generation params from file"));
         options.addOption(new Option(null, "generation-disabled", false, "Stop before starting generation, after parameters parsed"));
         options.addOption(new Option(null, "save-disabled", false, "Stop before saving output file, after generation done"));
+        options.addOption(new Option(null, "max-tile-size", true, "Set maximum tile size (may be passed using %s environment variable)".formatted(MAX_TILE_SIZE_ENVVAR_NAME)));
     }
 
     /**
@@ -52,7 +56,7 @@ public class MinalacGeneratorCLI {
         try {
             cmd = parser.parse(options, args);
         } catch (ParseException e) {
-            System.out.println(e.getMessage());
+            System.err.println(e.getMessage());
             usage();
             System.exit(1);
             return; // Must please linter with uninitialized cmd
@@ -67,9 +71,27 @@ public class MinalacGeneratorCLI {
             try {
                 parametersPath = Paths.get(cmd.getOptionValue("p"));
             } catch (InvalidPathException e) {
-                System.out.println("Invalid parameters file path");
-                System.out.println(e.getMessage());
+                System.err.println("Invalid parameters file path");
+                System.err.println(e.getMessage());
                 System.exit(1);
+            }
+        }
+
+        if (cmd.hasOption("--max-tile-size")) {
+            try {
+                maxTileSize = parseStrictPositiveInteger(cmd.getOptionValue("--max-tile-size"));
+            } catch (NumberFormatException e) {
+                System.err.println("Invalid value for --max-tile-size: should be a positive integer number");
+                System.exit(1);
+            }
+        } else {
+            String envvar = System.getenv(MAX_TILE_SIZE_ENVVAR_NAME);
+            if (envvar != null && !envvar.isBlank()) {
+                try {
+                    maxTileSize = parseStrictPositiveInteger(envvar);
+                } catch (NumberFormatException e) {
+                    System.out.printf("Warning: Omitting invalid value '%s' in %s environment variable (should have been a positive integer number).%n", envvar, MAX_TILE_SIZE_ENVVAR_NAME);
+                }
             }
         }
 
@@ -77,7 +99,7 @@ public class MinalacGeneratorCLI {
         saveDisabled = cmd.hasOption("--save-disabled");
 
         if (cmd.getArgs().length != 1) {
-            System.out.println("Please provide output path");
+            System.err.println("Please provide output path");
             usage();
             System.exit(1);
         }
@@ -85,8 +107,8 @@ public class MinalacGeneratorCLI {
         try {
             outputPath = Paths.get(cmd.getArgs()[0]);
         } catch (InvalidPathException e) {
-            System.out.println("Invalid output path");
-            System.out.println(e.getMessage());
+            System.err.println("Invalid output path");
+            System.err.println(e.getMessage());
             System.exit(1);
         }
     }
@@ -109,24 +131,24 @@ public class MinalacGeneratorCLI {
 
         if (parametersPath != null) {
             if (!Files.exists(parametersPath)) {
-                System.out.printf("%s does not exist%n", parametersPath);
+                System.err.printf("%s does not exist%n", parametersPath);
                 System.exit(1);
             }
 
             if (!Files.isRegularFile(parametersPath)) {
-                System.out.printf("%s is not a regular file%n", parametersPath);
+                System.err.printf("%s is not a regular file%n", parametersPath);
                 System.exit(1);
             }
 
             if (!Files.isReadable(parametersPath)) {
-                System.out.printf("%s is not readable%n", parametersPath);
+                System.err.printf("%s is not readable%n", parametersPath);
                 System.exit(1);
             }
 
             try {
                 parameters = Files.readString(parametersPath);
             } catch (IOException e) {
-                System.out.printf("Error reading parameters from %s%n", parametersPath);
+                System.err.printf("Error reading parameters from %s%n", parametersPath);
                 e.printStackTrace();
                 System.exit(1);
             }
@@ -135,7 +157,7 @@ public class MinalacGeneratorCLI {
         }
 
         if (parameters == null) {
-            System.out.printf("Please provide generation parameters (either with -p option or using %s environment variable)%n", PARAMS_ENVVAR_NAME);
+            System.err.printf("Please provide generation parameters (either with -p option or using %s environment variable)%n", PARAMS_ENVVAR_NAME);
             usage();
             System.exit(1);
         }
@@ -170,5 +192,21 @@ public class MinalacGeneratorCLI {
      */
     public boolean saveDisabled() {
         return saveDisabled;
+    }
+
+    /**
+     * Returns wanted tiles size if any.
+     *
+     * @return tiles maximum
+     */
+    public Integer maxTileSize() {
+        return maxTileSize;
+    }
+
+    private static int parseStrictPositiveInteger(String value) throws NumberFormatException {
+        int result = Integer.parseInt(value);
+        if (result <= 0)
+            throw new NumberFormatException("Not a positive integer");
+        return result;
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/generation/Generation.java
+++ b/src/main/java/com/ignfab/minalac/generator/generation/Generation.java
@@ -11,7 +11,6 @@ import org.locationtech.jts.geom.util.AffineTransformation;
 
 import com.ignfab.minalac.generator.exceptions.TransformException;
 import com.ignfab.minalac.generator.generation.heightmaps.HeightmapDeclarationStore;
-import com.ignfab.minalac.generator.models.ModelStore;
 import com.ignfab.minalac.generator.utils.coordinates.MapToWorldConverter;
 import com.ignfab.minalac.generator.utils.coordinates.WorldToMapConverter;
 import com.ignfab.minalac.generator.utils.execution.Scheduler;
@@ -38,7 +37,6 @@ public class Generation {
     private final AffineTransformation voxelToCrs;
 
     private final VoxelWorld world;
-    private final ModelStore models = new ModelStore();
     private final HeightmapDeclarationStore heightmaps = new HeightmapDeclarationStore();
 
     private final Scheduler<GenerationTile> scheduler = new Scheduler<>();
@@ -109,15 +107,7 @@ public class Generation {
     }
 
     /**
-     * Returns the {@link ModelStore}.
-     * @return the model store
-     */
-    public ModelStore models() {
-        return models;
-    }
-
-    /**
-     * Returns the {@link HeightmapDeclarationStore} for the stored heightmaps declarations.
+     * Returns the {@link Store} for the stored heightmaps declarations.
      *
      * @return the heightmap declaration store.
      */

--- a/src/main/java/com/ignfab/minalac/generator/generation/Generation.java
+++ b/src/main/java/com/ignfab/minalac/generator/generation/Generation.java
@@ -1,5 +1,7 @@
 package com.ignfab.minalac.generator.generation;
 
+import java.util.Collection;
+
 import org.geotools.api.referencing.FactoryException;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.geometry.jts.ReferencedEnvelope;
@@ -14,7 +16,9 @@ import com.ignfab.minalac.generator.generation.heightmaps.HeightmapDeclarationSt
 import com.ignfab.minalac.generator.utils.coordinates.MapToWorldConverter;
 import com.ignfab.minalac.generator.utils.coordinates.WorldToMapConverter;
 import com.ignfab.minalac.generator.utils.execution.Scheduler;
+import com.ignfab.minalac.generator.utils.iterator.Iterables;
 import com.ignfab.minalac.generator.utils.random.Seed;
+import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.world.VoxelWorld;
 
@@ -41,6 +45,9 @@ public class Generation {
 
     private final Scheduler<GenerationTile> scheduler = new Scheduler<>();
 
+    private final int maxTileSize;
+    private final Collection<WorldBBox2d> tiles;
+
     /**
      * Constructs a new generation context.
      * It sets {@code VoxelWorld}'s limits in way the center is at {@code WorldCoords2d} (0, 0).
@@ -55,6 +62,7 @@ public class Generation {
      * @param horizontalScale Horizontal size of voxel in CRS units
      * @param verticalScale Vertical size of voxel in CRS units
      * @param angle Rotation angle around center in radians
+     * @param maxTileSize Maximum tile size
      */
     @SuppressWarnings("checkstyle:ParameterNumber")
     public Generation(
@@ -67,7 +75,8 @@ public class Generation {
         int extentY,
         double horizontalScale,
         double verticalScale,
-        double angle) {
+        double angle,
+        int maxTileSize) {
 
         this.seed = seed;
 
@@ -82,6 +91,10 @@ public class Generation {
         ));
 
         this.world = world;
+
+        this.maxTileSize = maxTileSize;
+        tiles = world.tiles(maxTileSize);
+
         this.crs = crs;
         this.verticalScale = verticalScale;
 
@@ -107,7 +120,7 @@ public class Generation {
     }
 
     /**
-     * Returns the {@link Store} for the stored heightmaps declarations.
+     * Returns the {@link HeightmapDeclarationStore} for the stored heightmaps.
      *
      * @return the heightmap declaration store.
      */
@@ -186,5 +199,34 @@ public class Generation {
      */
     public CoordinateReferenceSystem crs() {
         return crs;
+    }
+
+    /**
+     * Returns maximum generation tile size.
+     *
+     * @return maximum generation tile size
+     */
+    public int maxTileSize() {
+        return this.maxTileSize;
+    }
+
+    /**
+     * Returns number of generation tiles.
+     *
+     * @return number of generation tiles
+     */
+    public int numberOfTiles() {
+        return this.tiles.size();
+    }
+
+    /**
+     * Returns an itereable over generation tiles.
+     *
+     * @return an itereable over generation tiles
+     */
+    public Iterable<GenerationTile> tiles() {
+        return Iterables.remap(tiles,
+            bbox -> new GenerationTile(this, bbox.to3d(world.limits().minZ(), world.limits().sizeZ()))
+        );
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/generation/GenerationTile.java
+++ b/src/main/java/com/ignfab/minalac/generator/generation/GenerationTile.java
@@ -1,6 +1,7 @@
 package com.ignfab.minalac.generator.generation;
 
 import com.ignfab.minalac.generator.generation.heightmaps.HeightmapStore;
+import com.ignfab.minalac.generator.models.ModelStore;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.world.MapWriteException;
 import com.ignfab.minalac.generator.world.VoxelTile;
@@ -12,6 +13,7 @@ public class GenerationTile {
     private final Generation generation;
     private final VoxelTile voxels;
     private final HeightmapStore heightmaps;
+    private final ModelStore models = new ModelStore();
 
     /**
      * Creates a new {@code GenerationTile} for a generation and a volume.
@@ -36,6 +38,14 @@ public class GenerationTile {
      */
     public Generation generation() {
         return generation;
+    }
+
+    /**
+     * Returns the {@link ModelStore}.
+     * @return the model store
+     */
+    public ModelStore models() {
+        return models;
     }
 
     /**

--- a/src/main/java/com/ignfab/minalac/generator/generation/SquareUnitsTileGenerator.java
+++ b/src/main/java/com/ignfab/minalac/generator/generation/SquareUnitsTileGenerator.java
@@ -1,0 +1,115 @@
+package com.ignfab.minalac.generator.generation;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+import com.ignfab.minalac.generator.utils.IntegerInterval;
+import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
+
+/**
+ * A tile generator for worlds with square map units.
+ * <p>
+ * It will create tiles:
+ * <ul>
+ *   <li>No larger than the given size;</li>
+ *   <li>Covering the whole given area;</li>
+ *   <li>Not sharing any map unit;</li>
+ * </ul>
+ * <p>
+ * Map units are minimal parts of the world that shouldn't be generated separately
+ * (i.e. map blocks or regions depending on output format terminology).
+ * In this tile generator, map units are fixed size squares, aligned at (0, 0).
+ *
+ * It is suitable for both Luanti and Minecraft output formats.
+ */
+public class SquareUnitsTileGenerator {
+
+    private final int unitSize;
+    private final WorldBBox2d bbox;
+
+    /**
+     * Creates a new {@code SquareUnitsTileGenerator} instance.
+     *
+     * @param unitSize size in voxel of square map units edges
+     * @param bbox box to be tiled
+     */
+    public SquareUnitsTileGenerator(int unitSize, WorldBBox2d bbox) {
+        this.unitSize = unitSize;
+        this.bbox = bbox;
+    }
+
+    // Computes smallest coordinate of map unit containing pos.
+    private int unitFloor(int pos) {
+        return pos - Math.floorMod(pos, unitSize);
+    }
+
+    // Computes fairly sized slices smaller than maxSize, covering min to max (inclusive).
+    private List<IntegerInterval> slices(int min, int max, int maxSize) {
+        if (maxSize < unitSize)
+            throw new IllegalArgumentException("maxSize should be larger than unitSize");
+
+        List<Integer> sizes = new LinkedList<>();
+
+        // Basic silly slicing
+        int pos = min;
+        while (pos + maxSize < max) {
+            int newpos = unitFloor(pos + maxSize);
+            sizes.add(newpos - pos - 1);
+            pos = newpos;
+        }
+        sizes.add(max - pos);
+
+        // Adjust slice sizes to distribute fairly
+        while (true) {
+            int smaller = Collections.min(sizes);
+            int larger = Collections.max(sizes);
+
+            if (larger < smaller + unitSize + 1)
+                break;
+
+            int amount = Math.max(unitSize, unitFloor((larger - smaller) / 2));
+
+            sizes.set(sizes.indexOf(smaller), smaller + amount);
+            sizes.set(sizes.indexOf(larger), larger - amount);
+        }
+
+        // Build result as IntegerIntervals
+        pos = min;
+        List<IntegerInterval> result = new LinkedList<>();
+        for (int size : sizes) {
+            result.add(new IntegerInterval(pos, pos + size));
+            pos += size + 1;
+        }
+        return result;
+    }
+
+    /**
+     * Creates tiles respecting given maximum tile size.
+     *
+     * @param maxTileSize maximum tile size (on x and y axes)
+     *
+     * @return a list of boxes representing resulting tiles
+     */
+    public List<WorldBBox2d> getTiles(int maxTileSize) {
+
+        // Impossible case
+        if (maxTileSize < unitSize)
+            throw new IllegalArgumentException("Max tile size must be at least " + unitSize);
+
+        // Obvious case
+        if (maxTileSize > bbox.sizeX() && maxTileSize > bbox.sizeY())
+            return Collections.singletonList(bbox);
+
+        List<WorldBBox2d> result = new LinkedList<>();
+
+        List<IntegerInterval> xs = slices(bbox.minX(), bbox.maxX(), maxTileSize);
+        List<IntegerInterval> ys = slices(bbox.minY(), bbox.maxY(), maxTileSize);
+
+        for (IntegerInterval y : ys)
+            for (IntegerInterval x : xs)
+                result.add(new WorldBBox2d(x.begin(), y.begin(), x.size(), y.size()));
+
+        return result;
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/models/ModelSelection.java
+++ b/src/main/java/com/ignfab/minalac/generator/models/ModelSelection.java
@@ -1,41 +1,37 @@
 package com.ignfab.minalac.generator.models;
 
-import java.util.Iterator;
+import java.util.List;
 import java.util.function.Predicate;
 
-import com.ignfab.minalac.generator.utils.iterator.Iterators;
+import com.ignfab.minalac.generator.generation.GenerationTile;
+import com.ignfab.minalac.generator.utils.iterator.Iterables;
 
 /**
  * This class selects the models in the {@link ModelStore} matching a specified type.
  */
-public class ModelSelection implements Iterable<Model> {
-    private final ModelStore store;
+public class ModelSelection {
     private final String type;
     private final Predicate<Model> filter;
 
     /**
      * Constructs a new {@code ModelSelection}.
      *
-     * @param store the store containing the models
      * @param type the type of models to select
      * @param filter a filter on models to narrow down selection
      */
-    public ModelSelection(ModelStore store, String type, Predicate<Model> filter) {
-        this.store = store;
+    public ModelSelection(String type, Predicate<Model> filter) {
         this.type = type;
         this.filter = filter;
     }
 
     /**
-     * Returns an iterator over the models matching the type of this {@code ModelSelection}.
+     * Returns an iterable of the models matching the type of this {@code ModelSelection}.
      *
-     * @return an iterator over the matching models
+     * @param tile the tile to select models from
+     * @return an iterable of the matching models
      */
-    @Override
-    public Iterator<Model> iterator() {
-        if (filter == null)
-            return store.getByType(type).iterator();
-
-        return Iterators.filter(store.getByType(type).iterator(), filter);
+    public Iterable<Model> forTile(GenerationTile tile) {
+        List<Model> models = tile.models().getByType(type);
+        return filter == null ? models : Iterables.filter(models, filter);
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelWorld.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelWorld.java
@@ -2,6 +2,7 @@ package com.ignfab.minalac.generator.outputs.minecraft;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Date;
 import java.util.Random;
 
@@ -14,6 +15,8 @@ import net.querz.nbt.tag.IntTag;
 import net.querz.nbt.tag.ListTag;
 import net.querz.nbt.tag.StringTag;
 
+import com.ignfab.minalac.generator.generation.SquareUnitsTileGenerator;
+import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldSize3d;
@@ -472,5 +475,11 @@ public class MCVoxelWorld extends VoxelWorld {
             root.put("Data", data);
         }
         return root;
+    }
+
+    @Override
+    public Collection<WorldBBox2d> tiles(int maxTileSize) {
+        SquareUnitsTileGenerator tileGenerator = new SquareUnitsTileGenerator(Region.SIZE, limits().to2d());
+        return tileGenerator.getTiles(maxTileSize);
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/Region.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/Region.java
@@ -19,6 +19,12 @@ import net.querz.nbt.tag.CompoundTag;
  * @see <a href="https://minecraft.wiki/w/Chunk">Chunk (Minecraft Wiki)</a>
  */
 public record Region(int regionX, int regionZ, MCAFile file) {
+
+    /**
+     * Region size, used for tiling.
+     */
+    public static final int SIZE = 512;
+
     /**
      * Constructs a new {@link Region}.
      *

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/Block.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/Block.java
@@ -9,6 +9,12 @@ import java.util.HashMap;
  * @see <a href="https://github.com/minetest/minetest/blob/master/doc/world_format.md#map-file-format">Minetest world format</a>
  */
 public class Block {
+
+    /**
+     * Block size, used for tiling.
+     */
+    public static final int SIZE = 16;
+
     private short[] param0;
     private byte[] param1;
     private byte[] param2;

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelTile.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelTile.java
@@ -51,7 +51,7 @@ public class MTVoxelTile extends VoxelTile {
     private long coordsToPos(int blockX, int blockY, int blockZ) {
         // See position hashing algorithm on world format documentation
         // https://github.com/minetest/minetest/blob/master/doc/world_format.md#position-hashing
-        return blockZ * 16777216L + blockY * 4096 + blockX;
+        return blockZ * 16777216L + blockY * 4096L + blockX;
     }
 
     /**

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelTile.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelTile.java
@@ -16,7 +16,7 @@ import com.ignfab.minalac.generator.world.VoxelTile;
 public class MTVoxelTile extends VoxelTile {
     private final File destination;
 
-    private final HashMap<Integer, Block> blocks = new HashMap<>();
+    private final HashMap<Long, Block> blocks = new HashMap<>();
 
     /**
      * Creates a new {@code MTVoxelTile}.
@@ -31,8 +31,7 @@ public class MTVoxelTile extends VoxelTile {
 
     // Retrieves or creates the mapblock corresponding to given voxel position.
     private Block getOrCreateBlock(int blockX, int blockY, int blockZ) {
-        Integer pos = coordsToPos(blockX, blockY, blockZ);
-
+        Long pos = coordsToPos(blockX, blockY, blockZ);
         Block block = blocks.get(pos);
         if (block == null)
             synchronized (blocks) {
@@ -49,10 +48,10 @@ public class MTVoxelTile extends VoxelTile {
         return blocks.get(coordsToPos(blockX, blockY, blockZ));
     }
 
-    private Integer coordsToPos(int blockX, int blockY, int blockZ) {
+    private long coordsToPos(int blockX, int blockY, int blockZ) {
         // See position hashing algorithm on world format documentation
         // https://github.com/minetest/minetest/blob/master/doc/world_format.md#position-hashing
-        return blockZ * 16777216 + blockY * 4096 + blockX;
+        return blockZ * 16777216L + blockY * 4096 + blockX;
     }
 
     /**
@@ -84,7 +83,7 @@ public class MTVoxelTile extends VoxelTile {
             return; // Save disabled if null destination
 
         SQLiteMapWriter database = new SQLiteMapWriter(destination);
-        for (Map.Entry<Integer, Block> entry : blocks.entrySet()) {
+        for (Map.Entry<Long, Block> entry : blocks.entrySet()) {
             database.insertBlock(entry.getKey(), entry.getValue());
         }
     }

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelWorld.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelWorld.java
@@ -4,8 +4,11 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.Collection;
 
+import com.ignfab.minalac.generator.generation.SquareUnitsTileGenerator;
 import com.ignfab.minalac.generator.outputs.minetest.utils.SQLiteMapWriter;
+import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
 import com.ignfab.minalac.generator.world.MapWriteException;
@@ -104,5 +107,11 @@ public class MTVoxelWorld extends VoxelWorld {
         } catch (IOException e) {
             throw new MapWriteException(e);
         }
+    }
+
+    @Override
+    public Collection<WorldBBox2d> tiles(int maxTileSize) {
+        SquareUnitsTileGenerator tileGenerator = new SquareUnitsTileGenerator(Block.SIZE, limits().to2d());
+        return tileGenerator.getTiles(maxTileSize);
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/utils/SQLiteMapWriter.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/utils/SQLiteMapWriter.java
@@ -59,14 +59,14 @@ public class SQLiteMapWriter {
      * @param block the {@link Block} to be inserted
      * @throws MapWriteException if an {@link SQLException} or {@link IOException} occurs during insertion
      */
-    public void insertBlock(int pos, Block block) throws MapWriteException {
+    public void insertBlock(long pos, Block block) throws MapWriteException {
         try {
             PreparedStatement statement = connection.prepareStatement("INSERT INTO blocks VALUES (?,?)");
-            statement.setInt(1, pos);
+            statement.setLong(1, pos);
             statement.setBytes(2, this.serializer.serialize(block));
             statement.execute();
         } catch (SQLException | IOException e) {
-            throw new MapWriteException("Failed to insert blocks into map", e);
+            throw new MapWriteException("Failed to insert blocks %d into map".formatted(pos), e);
         }
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/parameters/GenerationCreator.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/GenerationCreator.java
@@ -24,9 +24,10 @@ public final class GenerationCreator {
      * Creates a new {@code Generation} from the specified parameters.
      *
      * @param params the parameters
+     * @param maxTileSize max tile size if tiling wanted, else null
      * @return the corresponding generation object
      */
-    static Generation create(GenerationParams params) {
+    static Generation create(GenerationParams params, Integer maxTileSize) {
         // TODO : If not provided its default value should be calculated by finding the appropriated projected CRS for the provided center point.
         // At the moment the default value is EPSG:2154
         CoordinateReferenceSystem targetCrs;
@@ -52,7 +53,8 @@ public final class GenerationCreator {
             params.area.extentY,
             params.horizontalScale,
             params.verticalScale,
-            Math.toRadians(params.area.angle)
+            Math.toRadians(params.area.angle),
+            maxTileSize == null || maxTileSize <= 0 ? Math.max(params.area.extentX, params.area.extentY) : maxTileSize
         );
 
         params.heightmaps.forEach((name, heightmapParams) ->

--- a/src/main/java/com/ignfab/minalac/generator/parameters/GenerationParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/GenerationParams.java
@@ -129,10 +129,11 @@ public class GenerationParams {
     /**
      * Creates the corresponding {@link Generation}.
      *
+     * @param maxTileSize max tile size if tiling wanted, else null
      * @return the corresponding {@code Generation}
      */
-    public Generation create() {
-        return GenerationCreator.create(this);
+    public Generation create(Integer maxTileSize) {
+        return GenerationCreator.create(this, maxTileSize);
     }
 
     /**

--- a/src/main/java/com/ignfab/minalac/generator/parameters/models/ModelSelectionParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/models/ModelSelectionParams.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 
 import com.ignfab.minalac.generator.models.ModelSelection;
-import com.ignfab.minalac.generator.models.ModelStore;
 import com.ignfab.minalac.generator.parameters.models.filters.ModelFilterParams;
 
 /**
@@ -48,11 +47,9 @@ public class ModelSelectionParams {
     /**
      * Creates a new {@link ModelSelection} out of params.
      *
-     * @param store Model store which select models from.
-     *
      * @return a model selection.
      */
-    public ModelSelection create(ModelStore store) {
-        return new ModelSelection(store, type, (filter == null) ? null : filter.create());
+    public ModelSelection create() {
+        return new ModelSelection(type, (filter == null) ? null : filter.create());
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/parameters/tasks/CopyHeightmapTaskParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/tasks/CopyHeightmapTaskParams.java
@@ -58,7 +58,7 @@ public class CopyHeightmapTaskParams extends TileTaskParams {
     @Override
     public TileTask create(Generation generation) {
         return new CopyHeightmapTask(
-            models.create(generation.models()),
+            models.create(),
             from.create(generation.heightmaps()),
             to.create(generation.heightmaps())
         );

--- a/src/main/java/com/ignfab/minalac/generator/parameters/tasks/FetchDataTaskParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/tasks/FetchDataTaskParams.java
@@ -74,7 +74,6 @@ public class FetchDataTaskParams extends TileTaskParams {
      */
     public FetchDataTask create(Generation generation) {
         return new FetchDataTask(
-            generation.models(),
             modelType,
             provider.create(generation),
             processor.create(generation),

--- a/src/main/java/com/ignfab/minalac/generator/parameters/tasks/LevelGroundTaskParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/tasks/LevelGroundTaskParams.java
@@ -64,7 +64,7 @@ public class LevelGroundTaskParams extends TileTaskParams {
     @Override
     public TileTask create(Generation generation) {
         return new LevelGroundTask(
-            models.create(generation.models()),
+            models.create(),
             heightmap.create(generation.heightmaps()),
             filling.create(generation.seed())
         );

--- a/src/main/java/com/ignfab/minalac/generator/parameters/tasks/PopulateHeightmapTaskParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/tasks/PopulateHeightmapTaskParams.java
@@ -47,7 +47,7 @@ public class PopulateHeightmapTaskParams extends TileTaskParams {
     @Override
     public TileTask create(Generation generation) {
         return new PopulateHeightmapTask(
-            models.create(generation.models()),
+            models.create(),
             heightmap.create(generation.heightmaps())
         );
     }

--- a/src/main/java/com/ignfab/minalac/generator/parameters/tasks/RenderBuildingsTaskParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/tasks/RenderBuildingsTaskParams.java
@@ -83,7 +83,7 @@ public class RenderBuildingsTaskParams extends TileTaskParams {
     @Override
     public TileTask create(Generation generation) {
         return new RenderBuildingsTask(
-            models.create(generation.models()),
+            models.create(),
             heightmap.create(generation.heightmaps()),
             roof.create(generation.seed()),
             wall.create(generation.seed()),

--- a/src/main/java/com/ignfab/minalac/generator/parameters/tasks/RenderVectorsTaskParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/tasks/RenderVectorsTaskParams.java
@@ -93,7 +93,7 @@ public class RenderVectorsTaskParams extends TileTaskParams {
         }
 
         return new RenderVectorsTask(
-            models.create(generation.models()),
+            models.create(),
             heightmap.create(generation.heightmaps()),
             insidePlaceable,
             bordersPlaceable

--- a/src/main/java/com/ignfab/minalac/generator/tasks/FetchDataTask.java
+++ b/src/main/java/com/ignfab/minalac/generator/tasks/FetchDataTask.java
@@ -8,7 +8,6 @@ import com.ignfab.minalac.generator.exceptions.RetryableException;
 import com.ignfab.minalac.generator.generation.GenerationTile;
 import com.ignfab.minalac.generator.inputs.Provider;
 import com.ignfab.minalac.generator.models.Model;
-import com.ignfab.minalac.generator.models.ModelStore;
 import com.ignfab.minalac.generator.processors.Processor;
 import com.ignfab.minalac.generator.processors.post.PostProcessor;
 
@@ -16,7 +15,6 @@ import com.ignfab.minalac.generator.processors.post.PostProcessor;
  * A {@link TileTask} fetching data from a provider, processing models with a processor applying a post-processor to each model.
  */
 public class FetchDataTask implements TileTask {
-    private final ModelStore modelStore;
     private final String modelType;
     private final Provider<?> provider;
     private final Processor<Object, ?> processor;
@@ -25,14 +23,12 @@ public class FetchDataTask implements TileTask {
     /**
      * Creates a new {@code FetchDataTask}.
      *
-     * @param modelStore where resulting models shoud be stored
      * @param modelType name of type to be associated with them
      * @param provider data provider
      * @param processor processor converting provided data to models
      * @param postProcessor post-processor to run on created models
      */
     public FetchDataTask(
-        ModelStore modelStore,
         String modelType,
         Provider<?> provider,
         Processor<?, ? extends Model> processor,
@@ -51,7 +47,6 @@ public class FetchDataTask implements TileTask {
         @SuppressWarnings("unchecked") // The model type has been validated above
         PostProcessor<Model, ?> uncheckedPostProcessor = (PostProcessor<Model, ?>) postProcessor;
 
-        this.modelStore = modelStore;
         this.modelType = modelType;
         this.provider = provider;
         this.processor = uncheckedProcessor;
@@ -73,7 +68,7 @@ public class FetchDataTask implements TileTask {
                     if (model != null) {
                         model = postProcessor.process(model);
                         if (model != null)
-                            modelStore.add(modelType, model);
+                            tile.models().add(modelType, model);
                     }
                 } catch (IgnorableException e) {
                     // TODO Add an exception handling policy

--- a/src/main/java/com/ignfab/minalac/generator/tasks/ModelTask.java
+++ b/src/main/java/com/ignfab/minalac/generator/tasks/ModelTask.java
@@ -20,7 +20,7 @@ public abstract class ModelTask<M> implements TileTask {
 
     @Override
     public void run(GenerationTile tile) {
-        for (Model model : selection)
+        for (Model model : selection.forTile(tile))
             if (cls.isInstance(model))
                 run(cls.cast(model), tile);
     }

--- a/src/main/java/com/ignfab/minalac/generator/world/VoxelWorld.java
+++ b/src/main/java/com/ignfab/minalac/generator/world/VoxelWorld.java
@@ -1,5 +1,8 @@
 package com.ignfab.minalac.generator.world;
 
+import java.util.Collection;
+
+import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 
 /**
@@ -99,4 +102,13 @@ public abstract class VoxelWorld {
      * @throws MapWriteException if an error occurs while writing to the destination.
      */
     public abstract void finalizeAndSave() throws MapWriteException;
+
+    /**
+     * Computes tiles of maximum size, covering the whole world.
+     *
+     * @param maxTileSize maximum tile size (on x and y axes)
+     *
+     * @return a list of boxes representing resulting tiles
+     */
+    public abstract Collection<WorldBBox2d> tiles(int maxTileSize);
 }

--- a/src/test/java/com/ignfab/minalac/generator/generation/SquareUnitsTileGeneratorTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/generation/SquareUnitsTileGeneratorTest.java
@@ -1,0 +1,126 @@
+package com.ignfab.minalac.generator.generation;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SquareUnitsTileGeneratorTest {
+
+    private void testConfiguration(String name, int blocksize, WorldBBox2d bbox, int maxTileSize) {
+
+        SquareUnitsTileGenerator tileGenerator = new SquareUnitsTileGenerator(blocksize, bbox);
+        List<WorldBBox2d> tiles = tileGenerator.getTiles(maxTileSize);
+
+        // All tiles shoud be inside bbox
+        for (WorldBBox2d tile : tiles)
+            assertTrue(bbox.contains(tile), "%s: %s should be contained in bbox(%s)".formatted(name, tile, bbox));
+
+        // No tile should overlap
+        for (WorldBBox2d tile1 : tiles)
+            for (WorldBBox2d tile2 : tiles)
+                if (tile1 != tile2)
+                    assertFalse(tile1.intersects(tile2), "%s: %s and %s should not intersect".formatted(name, tile1, tile2));
+
+        // No tile should be larger than expected
+        for (WorldBBox2d tile : tiles) {
+            assertTrue(tile.size().x() <= maxTileSize, "%s: %s should not be wider that expected (%d)".formatted(name, tile, maxTileSize));
+            assertTrue(tile.size().y() <= maxTileSize, "%s: %s should not be taller that expected (%d)".formatted(name, tile, maxTileSize));
+        }
+
+        // No tile boundary inside a mapblock (except edges)
+        for (WorldBBox2d tile : tiles) {
+            if (tile.minX() != bbox.minX())
+                assertTrue(tile.minX() % blocksize == 0, "%s: %s minX should be aligned to block".formatted(name, tile));
+            if (tile.minY() != bbox.minY())
+                assertTrue(tile.minY() % blocksize == 0, "%s: %s minY should be aligned to block".formatted(name, tile));
+            if (tile.maxX() != bbox.maxX())
+                assertTrue((tile.maxX() + 1) % blocksize == 0, "%s: %s maxX should be aligned to block".formatted(name, tile));
+            if (tile.maxY() != bbox.maxY())
+                assertTrue((tile.maxY() + 1) % blocksize == 0, "%s: %s maxY should be aligned to block".formatted(name, tile));
+        }
+
+        // The whole box should be covered
+        int y = bbox.minY();
+        while (y < bbox.maxY()) {
+
+            // Select tiles intersecting axis at Y
+            List<WorldBBox2d> tilesSelection = new LinkedList<>();
+            int minY = bbox.maxY();
+            for (WorldBBox2d tile : tiles)
+                if (tile.minY() <= y && tile.maxY() >= y) {
+                    minY = Math.min(minY, tile.maxY());
+                    tilesSelection.add(tile);
+                }
+
+            // Sort tiles on X axis now
+            Collections.sort(tilesSelection, (b1, b2) -> b1.minX() - b2.minX());
+
+            // Check that the whole given Y axis is covered
+            // ie: tiles starts at minX, touches each other and ends at maxX
+            int x = bbox.minX();
+            for (WorldBBox2d tile : tilesSelection) {
+                assertTrue(x >= tile.minX(), "%s: All given area should be covered by tiles (found hole starting at x=%d, y=%d)".formatted(name, x, y));
+                x = tile.maxX() + 1;
+            }
+            assertTrue(x > bbox.maxX(), "%s: All given area should be covered by tiles (found hole starting at x=%d, y=%d)".formatted(name, x, y));
+
+            // We can now jump to next Y
+            // ie: smallest maxY of all tiles previously selected
+            y = minY + 1;
+        }
+    }
+
+    @Test
+    public void variousCasesTest() {
+        // Random cases
+        testConfiguration("random1", 16, new WorldBBox2d(-23, -76, 123, 153), 50);
+        testConfiguration("random2", 32, new WorldBBox2d(-56, -23, 435, 345), 75);
+
+        // Aligned cases
+        testConfiguration("aligned0", 10, new WorldBBox2d(10, 10, 199, 199), 50);
+        testConfiguration("aligned1", 10, new WorldBBox2d(10, 10, 200, 199), 50);
+        testConfiguration("aligned2", 10, new WorldBBox2d(10, 10, 199, 200), 50);
+        testConfiguration("aligned3", 10, new WorldBBox2d(10, 19, 199, 199), 50);
+        testConfiguration("aligned4", 10, new WorldBBox2d(19, 10, 199, 199), 50);
+
+        // Block sized tiles
+        testConfiguration("block", 10, new WorldBBox2d(10, 10, 99, 99), 10);
+    }
+
+    @Test
+    public void singleTileCaseTest() {
+        // If bbox is smaller than wanted size, only one tile should be returned
+        WorldBBox2d bbox = new WorldBBox2d(-2, -7, 12, 15);
+        SquareUnitsTileGenerator tileGenerator = new SquareUnitsTileGenerator(16, bbox);
+        List<WorldBBox2d> tiles = tileGenerator.getTiles(30);
+        assertEquals(1, tiles.size());
+        assertEquals(bbox, tiles.get(0));
+    }
+
+    @Test
+    public void distributionTest() {
+        // Hard to check surface is "fairly" distributed but some obvious cases could be tested
+        WorldBBox2d bbox = new WorldBBox2d(0, 0, 180, 100);
+        SquareUnitsTileGenerator tileGenerator = new SquareUnitsTileGenerator(10, bbox);
+        List<WorldBBox2d> tiles = tileGenerator.getTiles(70);
+        assertEquals(6, tiles.size());
+        assertEquals(tiles.get(0).size().area(), tiles.get(1).size().area());
+        assertEquals(tiles.get(1).size().area(), tiles.get(2).size().area());
+        assertEquals(tiles.get(2).size().area(), tiles.get(3).size().area());
+        assertEquals(tiles.get(3).size().area(), tiles.get(4).size().area());
+        assertEquals(tiles.get(4).size().area(), tiles.get(5).size().area());
+    }
+
+    @Test
+    public void getTilesTest() {
+        WorldBBox2d bbox = new WorldBBox2d(10, 20, 30, 40);
+        SquareUnitsTileGenerator tileGenerator = new SquareUnitsTileGenerator(16, bbox);
+        assertThrows(IllegalArgumentException.class, () -> tileGenerator.getTiles(8));
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/generation/TestGeneration.java
+++ b/src/test/java/com/ignfab/minalac/generator/generation/TestGeneration.java
@@ -1,5 +1,8 @@
 package com.ignfab.minalac.generator.generation;
 
+import java.util.Collection;
+import java.util.Collections;
+
 import org.geotools.api.referencing.FactoryException;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.referencing.CRS;
@@ -13,6 +16,7 @@ import org.locationtech.jts.geom.GeometryFactory;
 import com.ignfab.minalac.generator.exceptions.TransformException;
 import com.ignfab.minalac.generator.utils.coordinates.MapToWorldConverter;
 import com.ignfab.minalac.generator.utils.random.Seed;
+import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.world.MapWriteException;
 import com.ignfab.minalac.generator.world.VoxelTile;
@@ -43,7 +47,7 @@ public class TestGeneration {
     public void testGeneration() throws FactoryException, TransformException {
         VoxelWorld world = new EmptyVoxelWorld(500, 500);
 
-        Generation generation = new Generation(world, seed, crs2154, x2154, y2154, 500, 500, 2.0, 3.0, 0.5 * Math.PI);
+        Generation generation = new Generation(world, seed, crs2154, x2154, y2154, 500, 500, 2.0, 3.0, 0.5 * Math.PI, 500);
 
         assertEquals(seed, generation.seed());
         WorldBBox3d box = generation.world().limits();
@@ -81,6 +85,10 @@ public class TestGeneration {
         geometry = converter.convert(geometry);
         assertEquals(0.0, geometry.getCoordinate().x, 0.01);
         assertEquals(0.0, geometry.getCoordinate().y, 0.01);
+
+        // Check tiling
+        assertEquals(500, generation.maxTileSize());
+        assertEquals(1, generation.numberOfTiles());
     }
 
     private static class EmptyVoxelWorld extends VoxelWorld {
@@ -109,6 +117,11 @@ public class TestGeneration {
         @Override
         public VoxelTile newTile(WorldBBox3d limits) {
             throw new UnsupportedOperationException("Unimplemented method 'newTile'");
+        }
+
+        @Override
+        public Collection<WorldBBox2d> tiles(int maxTileSize) {
+            return Collections.singleton(maxLimits().to2d());
         }
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/generation/TestingGenerationTile.java
+++ b/src/test/java/com/ignfab/minalac/generator/generation/TestingGenerationTile.java
@@ -34,7 +34,8 @@ public class TestingGenerationTile extends GenerationTile {
                 limits.sizeY(), // extentY
                 1.0, // Horizontal scale
                 1.0, // Vertical sclae
-                0 // Angle
+                0, // Angle
+                Math.max(limits.sizeX(), limits.sizeY())
             ),
             limits);
         heightmaps = new TestingHeightmapStore(generation().heightmaps(), limits().to2d());

--- a/src/test/java/com/ignfab/minalac/generator/models/ModelSelectionTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/models/ModelSelectionTest.java
@@ -5,7 +5,9 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
+import com.ignfab.minalac.generator.generation.TestingGenerationTile;
 import com.ignfab.minalac.generator.models.filters.ModelFilterHasMetadata;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 
 import static com.ignfab.minalac.generator.utils.iterator.IteratorTester.*;
 
@@ -13,26 +15,26 @@ public class ModelSelectionTest {
 
     @Test
     public void testIterator() {
-        ModelStore store = new ModelStore();
+        TestingGenerationTile tile = new TestingGenerationTile(WorldBBox3d.EMPTY);
 
         Model modelA = new TestingModel("A", Map.of("a", 1));
         Model modelB = new TestingModel("B", Map.of("b", 2));
         Model modelC = new TestingModel("C");
 
-        store.add("X", modelA);
-        store.add("Y", modelA);
-        store.add("X", modelB);
-        store.add("X", modelA);
-        store.add("Y", modelC);
+        tile.models().add("X", modelA);
+        tile.models().add("Y", modelA);
+        tile.models().add("X", modelB);
+        tile.models().add("X", modelA);
+        tile.models().add("Y", modelC);
 
-        assertBrowsesAllOnce(Arrays.asList(modelA, modelA, modelB), new ModelSelection(store, "X", null).iterator());
+        assertBrowsesAllOnce(Arrays.asList(modelA, modelA, modelB), new ModelSelection("X", null).forTile(tile));
 
-        assertBrowsesAllOnce(Arrays.asList(modelA, modelA), new ModelSelection(store, "X", new ModelFilterHasMetadata("a")).iterator());
+        assertBrowsesAllOnce(Arrays.asList(modelA, modelA), new ModelSelection("X", new ModelFilterHasMetadata("a")).forTile(tile));
 
-        assertBrowsesAllOnce(Arrays.asList(modelA, modelC), new ModelSelection(store, "Y", null).iterator());
+        assertBrowsesAllOnce(Arrays.asList(modelA, modelC), new ModelSelection("Y", null).forTile(tile));
 
-        assertEmpty(new ModelSelection(store, "Y", new ModelFilterHasMetadata("b")));
+        assertEmpty(new ModelSelection("Y", new ModelFilterHasMetadata("b")).forTile(tile));
 
-        assertEmpty(new ModelSelection(store, "Z", null));
+        assertEmpty(new ModelSelection("Z", null).forTile(tile));
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/outputs/testing/TestingVoxelWorld.java
+++ b/src/test/java/com/ignfab/minalac/generator/outputs/testing/TestingVoxelWorld.java
@@ -1,5 +1,9 @@
 package com.ignfab.minalac.generator.outputs.testing;
 
+import java.util.Collection;
+import java.util.Collections;
+
+import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
 import com.ignfab.minalac.generator.world.MapWriteException;
@@ -48,5 +52,10 @@ public class TestingVoxelWorld extends VoxelWorld {
     @Override
     public WorldBBox3d maxLimits() {
         return MAX_LIMIT;
+    }
+
+    @Override
+    public Collection<WorldBBox2d> tiles(int maxTileSize) {
+        return Collections.singleton(maxLimits().to2d());
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/parameters/GenerationParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/GenerationParamsTest.java
@@ -124,7 +124,7 @@ public class GenerationParamsTest {
             placeable,
             placeable
         ));
-        Generation generation = params.create();
+        Generation generation = params.create(100);
 
         assertNotNull(generation);
         assertEquals(50, generation.world().limits().sizeX());

--- a/src/test/java/com/ignfab/minalac/generator/parameters/heightmaps/CappedManhattanHeightmapParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/heightmaps/CappedManhattanHeightmapParamsTest.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class CappedManhattanHeightmapParamsTest {
     @Test
     public void testDeserialize() {
-        Generation generation = new Generation(new TestingVoxelWorld(), TestingSeed.UNUSED, null, 0, 0, 1, 1, 1.0, 1.0, 0.0);
+        Generation generation = new Generation(new TestingVoxelWorld(), TestingSeed.UNUSED, null, 0, 0, 1, 1, 1.0, 1.0, 0.0, 100);
         generation.heightmaps().add(new HeightmapDeclaration("ground", 0));
 
         CappedManhattanHeightmapParams params = assertDoesNotThrow(() -> ParamsTester.deserialize(

--- a/src/test/java/com/ignfab/minalac/generator/parameters/heightmaps/ConstantHeightmapParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/heightmaps/ConstantHeightmapParamsTest.java
@@ -14,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 public class ConstantHeightmapParamsTest {
     @Test
     public void testDeserialize() {
-        Generation generation = new Generation(new TestingVoxelWorld(), TestingSeed.UNUSED, null, 0, 0, 1, 1, 1.0, 1.0, 0.0);
+        Generation generation = new Generation(new TestingVoxelWorld(), TestingSeed.UNUSED, null, 0, 0, 1, 1, 1.0, 1.0, 0.0, 100);
 
         ReadableHeightmapParams params = assertDoesNotThrow(() -> ParamsTester.deserialize(
             ReadableHeightmapParams.class,

--- a/src/test/java/com/ignfab/minalac/generator/parameters/heightmaps/LocalMinimumHeightmapParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/heightmaps/LocalMinimumHeightmapParamsTest.java
@@ -18,7 +18,7 @@ public class LocalMinimumHeightmapParamsTest {
 
     @Test
     public void testDeserialize() {
-        Generation generation = new Generation(new TestingVoxelWorld(), TestingSeed.UNUSED, null, 0, 0, 1, 1, 1.0, 1.0, 0.0);
+        Generation generation = new Generation(new TestingVoxelWorld(), TestingSeed.UNUSED, null, 0, 0, 1, 1, 1.0, 1.0, 0.0, 100);
         generation.heightmaps().add(new HeightmapDeclaration("ground", 0));
 
         LocalMinimumHeightmapParams params = assertDoesNotThrow(() -> ParamsTester.deserialize(

--- a/src/test/java/com/ignfab/minalac/generator/parameters/heightmaps/MultiOperandsHeightmapParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/heightmaps/MultiOperandsHeightmapParamsTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class MultiOperandsHeightmapParamsTest {
     @Test
     public void testDeserializeSum() {
-        Generation generation = new Generation(new TestingVoxelWorld(), TestingSeed.UNUSED, null, 0, 0, 1, 1, 1.0, 1.0, 0.0);
+        Generation generation = new Generation(new TestingVoxelWorld(), TestingSeed.UNUSED, null, 0, 0, 1, 1, 1.0, 1.0, 0.0, 100);
         HeightmapDeclaration heightmapSpec = (new HeightmapDeclaration("ground", 0));
         generation.heightmaps().add(heightmapSpec);
 
@@ -54,7 +54,7 @@ public class MultiOperandsHeightmapParamsTest {
 
     @Test
     public void testDeserializeProduct() {
-        Generation generation = new Generation(new TestingVoxelWorld(), TestingSeed.UNUSED, null, 0, 0, 1, 1, 1.0, 1.0, 0.0);
+        Generation generation = new Generation(new TestingVoxelWorld(), TestingSeed.UNUSED, null, 0, 0, 1, 1, 1.0, 1.0, 0.0, 100);
         HeightmapDeclaration heightmapSpec = (new HeightmapDeclaration("ground", 0));
         generation.heightmaps().add(heightmapSpec);
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/heightmaps/RemapHeightmapParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/heightmaps/RemapHeightmapParamsTest.java
@@ -25,7 +25,7 @@ public class RemapHeightmapParamsTest {
 
     @Test
     public void testDeserialize() {
-        Generation generation = new Generation(new TestingVoxelWorld(), TestingSeed.UNUSED, null, 0, 0, 1, 1, 1.0, 1.0, 0.0);
+        Generation generation = new Generation(new TestingVoxelWorld(), TestingSeed.UNUSED, null, 0, 0, 1, 1, 1.0, 1.0, 0.0, 100);
         HeightmapDeclaration heightmapSpec = (new HeightmapDeclaration("lotad", 0));
         generation.heightmaps().add(heightmapSpec);
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/models/ModelSelectionParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/models/ModelSelectionParamsTest.java
@@ -3,7 +3,6 @@ package com.ignfab.minalac.generator.parameters.models;
 import org.junit.jupiter.api.Test;
 
 import com.ignfab.minalac.generator.models.ModelSelection;
-import com.ignfab.minalac.generator.models.ModelStore;
 import com.ignfab.minalac.generator.parameters.models.filters.TestingModelFilterParams;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -34,12 +33,11 @@ public class ModelSelectionParamsTest {
     @Test
     public void testCreate() {
         ModelSelectionParams params;
-        ModelStore store = new ModelStore();
 
         params = new ModelSelectionParams("aa");
-        assertInstanceOf(ModelSelection.class, assertDoesNotThrow(() -> params.create(store)));
+        assertInstanceOf(ModelSelection.class, assertDoesNotThrow(params::create));
 
         params.filter = TestingModelFilterParams.VALID;
-        assertInstanceOf(ModelSelection.class, assertDoesNotThrow(() -> params.create(store)));
+        assertInstanceOf(ModelSelection.class, assertDoesNotThrow(params::create));
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/parameters/processors/FloatMatrixProcessorParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/processors/FloatMatrixProcessorParamsTest.java
@@ -16,7 +16,7 @@ public class FloatMatrixProcessorParamsTest {
     public void testCreate() throws FactoryException {
         CoordinateReferenceSystem crs2154 = CRS.decode("EPSG:2154");
 
-        Generation generation = new Generation(new TestingVoxelWorld(), TestingSeed.UNUSED, crs2154, 0, 0, 20, 20, 1, 1, 0.0);
+        Generation generation = new Generation(new TestingVoxelWorld(), TestingSeed.UNUSED, crs2154, 0, 0, 20, 20, 1, 1, 0.0, 100);
 
         // A simple OK test
         final FloatMatrixProcessorParams params = new FloatMatrixProcessorParams();

--- a/src/test/java/com/ignfab/minalac/generator/parameters/processors/GeoToolsVectorProcessorParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/processors/GeoToolsVectorProcessorParamsTest.java
@@ -16,7 +16,7 @@ public class GeoToolsVectorProcessorParamsTest {
     public void testCreate() throws FactoryException {
         CoordinateReferenceSystem crs2154 = CRS.decode("EPSG:2154");
 
-        Generation generation = new Generation(new TestingVoxelWorld(), TestingSeed.UNUSED, crs2154, 0, 0, 20, 20, 1, 1, 0.0);
+        Generation generation = new Generation(new TestingVoxelWorld(), TestingSeed.UNUSED, crs2154, 0, 0, 20, 20, 1, 1, 0.0, 100);
 
         // A simple OK test
         final GeoToolsVectorProcessorParams params = new GeoToolsVectorProcessorParams();

--- a/src/test/java/com/ignfab/minalac/generator/parameters/providers/GeoPackageProviderParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/providers/GeoPackageProviderParamsTest.java
@@ -19,7 +19,7 @@ public class GeoPackageProviderParamsTest {
     @Test
     public void testCreate(@TempDir File tmp) throws FactoryException, IOException {
         CoordinateReferenceSystem crs = CRS.decode("EPSG:2154");
-        Generation generation = new Generation(new TestingVoxelWorld(), TestingSeed.UNUSED, crs, 0, 0, 20, 20, 1, 1, 0);
+        Generation generation = new Generation(new TestingVoxelWorld(), TestingSeed.UNUSED, crs, 0, 0, 20, 20, 1, 1, 0, 100);
         File file = new File(tmp, "fake.gpkg");
         if (!file.createNewFile())
             fail("Unable to setup test file");

--- a/src/test/java/com/ignfab/minalac/generator/parameters/providers/ShapefileProviderParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/providers/ShapefileProviderParamsTest.java
@@ -19,7 +19,7 @@ public class ShapefileProviderParamsTest {
     @Test
     public void testCreate(@TempDir File tmp) throws FactoryException, IOException {
         CoordinateReferenceSystem crs = CRS.decode("EPSG:2154");
-        Generation generation = new Generation(new TestingVoxelWorld(), TestingSeed.UNUSED, crs, 0, 0, 20, 20, 1, 1, 0);
+        Generation generation = new Generation(new TestingVoxelWorld(), TestingSeed.UNUSED, crs, 0, 0, 20, 20, 1, 1, 0, 100);
         File file = new File(tmp, "fake.shp");
         if (!file.createNewFile())
             fail("Unable to setup test file");

--- a/src/test/java/com/ignfab/minalac/generator/parameters/providers/WFSProviderParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/providers/WFSProviderParamsTest.java
@@ -16,7 +16,7 @@ public class WFSProviderParamsTest {
     @Test
     public void testCreate() throws NoSuchAuthorityCodeException, FactoryException {
         CoordinateReferenceSystem crs = CRS.decode("EPSG:2154");
-        Generation generation = new Generation(new TestingVoxelWorld(), TestingSeed.UNUSED, crs, 0, 0, 20, 20, 1, 1, 0.0);
+        Generation generation = new Generation(new TestingVoxelWorld(), TestingSeed.UNUSED, crs, 0, 0, 20, 20, 1, 1, 0.0, 100);
 
         // A simple OK test
         final WFSProviderParams params = new WFSProviderParams("http://toto.com", "feature1");

--- a/src/test/java/com/ignfab/minalac/generator/parameters/providers/WMSFloatBilProviderParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/providers/WMSFloatBilProviderParamsTest.java
@@ -16,7 +16,7 @@ public class WMSFloatBilProviderParamsTest {
     @Test
     public void testCreate() throws NoSuchAuthorityCodeException, FactoryException {
         CoordinateReferenceSystem crs = CRS.decode("EPSG:2154");
-        Generation generation = new Generation(new TestingVoxelWorld(), TestingSeed.UNUSED, crs, 0, 0, 100, 100, 1, 1, 0.0);
+        Generation generation = new Generation(new TestingVoxelWorld(), TestingSeed.UNUSED, crs, 0, 0, 100, 100, 1, 1, 0.0, 100);
 
         // A simple OK test
         final WMSFloatBilProviderParams params = new WMSFloatBilProviderParams("http://toto.com", "layer1");

--- a/src/test/java/com/ignfab/minalac/generator/parameters/tasks/CopyHeightmapTaskParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/tasks/CopyHeightmapTaskParamsTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class CopyHeightmapTaskParamsTest {
     @Test
     public void testDeserialize() {
-        Generation generation = new Generation(new TestingVoxelWorld(), TestingSeed.UNUSED, null, 0, 0, 1, 1, 1.0, 1.0, 0.0);
+        Generation generation = new Generation(new TestingVoxelWorld(), TestingSeed.UNUSED, null, 0, 0, 1, 1, 1.0, 1.0, 0.0, 100);
         generation.heightmaps().add(new HeightmapDeclaration("ground", 5));
         generation.heightmaps().add(new HeightmapDeclaration("water", 1));
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/tasks/PopulateHeightmapTaskParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/tasks/PopulateHeightmapTaskParamsTest.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class PopulateHeightmapTaskParamsTest {
     @Test
     public void testDeserialize() {
-        Generation generation = new Generation(new TestingVoxelWorld(), TestingSeed.UNUSED, null, 0, 0, 1, 1, 1.0, 1.0, 0.0);
+        Generation generation = new Generation(new TestingVoxelWorld(), TestingSeed.UNUSED, null, 0, 0, 1, 1, 1.0, 1.0, 0.0, 100);
         generation.heightmaps().add(new HeightmapDeclaration("ground", 5));
 
         ObjectMapper mapper = new ObjectMapper(new YAMLFactory());

--- a/src/test/java/com/ignfab/minalac/generator/parameters/tasks/RenderHeightmapTaskParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/tasks/RenderHeightmapTaskParamsTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class RenderHeightmapTaskParamsTest {
     @Test
     public void testDeserializeAt() {
-        Generation generation = new Generation(new TestingVoxelWorld(), TestingSeed.UNUSED, null, 0, 0, 1, 1, 1.0, 1.0, 0.0);
+        Generation generation = new Generation(new TestingVoxelWorld(), TestingSeed.UNUSED, null, 0, 0, 1, 1, 1.0, 1.0, 0.0, 100);
         generation.heightmaps().add(new HeightmapDeclaration("ground", 5));
 
         ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
@@ -47,7 +47,7 @@ public class RenderHeightmapTaskParamsTest {
 
     @Test
     public void testDeserializeMinMax() {
-        Generation generation = new Generation(new TestingVoxelWorld(), TestingSeed.UNUSED, null, 0, 0, 1, 1, 1.0, 1.0, 0.0);
+        Generation generation = new Generation(new TestingVoxelWorld(), TestingSeed.UNUSED, null, 0, 0, 1, 1, 1.0, 1.0, 0.0, 100);
         generation.heightmaps().add(new HeightmapDeclaration("water", 5));
         generation.heightmaps().add(new HeightmapDeclaration("ground", 25));
 

--- a/src/test/java/com/ignfab/minalac/generator/tasks/CopyHeightmapTaskTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/tasks/CopyHeightmapTaskTest.java
@@ -7,12 +7,11 @@ import com.ignfab.minalac.generator.generation.heightmaps.ReadableHeightmap;
 import com.ignfab.minalac.generator.generation.heightmaps.TestingHeightmap;
 import com.ignfab.minalac.generator.models.Model;
 import com.ignfab.minalac.generator.models.ModelSelection;
-import com.ignfab.minalac.generator.models.ModelStore;
 import com.ignfab.minalac.generator.models.TestingRectangleShapeVoxelizable2dModel;
 import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class CopyHeightmapTaskTest {
     @Test
@@ -41,9 +40,8 @@ public class CopyHeightmapTaskTest {
             }
 
         Model model = new TestingRectangleShapeVoxelizable2dModel(new WorldBBox2d(0, 1, 2, 2));
-        ModelStore store = new ModelStore();
-        store.add("square", model);
-        ModelSelection selection = new ModelSelection(store, "square", null);
+        tile.models().add("square", model);
+        ModelSelection selection = new ModelSelection("square", null);
 
         new CopyHeightmapTask(selection, from.spec(), to.spec()).run(tile);
 
@@ -83,9 +81,8 @@ public class CopyHeightmapTaskTest {
         TestingHeightmap to = tile.newStoredHeightmap("to", new WorldBBox2d(-1, -3, 3, 4), 2);
 
         Model model = new TestingRectangleShapeVoxelizable2dModel(new WorldBBox2d(0, 0, 2, 3));
-        ModelStore store = new ModelStore();
-        store.add("rectangle", model);
-        ModelSelection selection = new ModelSelection(store, "rectangle", null);
+        tile.models().add("rectangle", model);
+        ModelSelection selection = new ModelSelection("rectangle", null);
 
         // Below
         //   - 1 represents BBOX of heightmap from

--- a/src/test/java/com/ignfab/minalac/generator/tasks/LevelHeightmapTaskTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/tasks/LevelHeightmapTaskTest.java
@@ -7,7 +7,6 @@ import com.ignfab.minalac.generator.generation.TestingGenerationTile;
 import com.ignfab.minalac.generator.generation.heightmaps.TestingHeightmap;
 import com.ignfab.minalac.generator.models.Model;
 import com.ignfab.minalac.generator.models.ModelSelection;
-import com.ignfab.minalac.generator.models.ModelStore;
 import com.ignfab.minalac.generator.models.TestingRectangleShapeVoxelizable2dModel;
 import com.ignfab.minalac.generator.parameters.placeables.voxels.TestingVoxelParams;
 import com.ignfab.minalac.generator.utils.random.TestingSeed;
@@ -20,12 +19,10 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class LevelHeightmapTaskTest {
     private WorldBBox3d bbox;
-    private ModelStore models;
 
     @BeforeEach
     void setUp() {
         bbox = new WorldBBox3d(-1, -2, -20, 7, 6, 40);
-        models = new ModelStore();
     }
 
     /**
@@ -52,11 +49,11 @@ public class LevelHeightmapTaskTest {
         WorldBBox2d modelBbox = new WorldBBox2d(0, -1, 5, 3);
         int expectedHeight = 1;
         Model model = new TestingRectangleShapeVoxelizable2dModel(modelBbox);
-        models.add("model", model);
+        tile.models().add("model", model);
 
         // Try rendering
         assertDoesNotThrow(() -> new LevelGroundTask(
-            new ModelSelection(models, "model", null),
+            new ModelSelection("model", null),
             ground.spec(),
             placeable.create(TestingSeed.UNUSED)
         ).run(tile));

--- a/src/test/java/com/ignfab/minalac/generator/tasks/ModelTaskTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/tasks/ModelTaskTest.java
@@ -11,7 +11,6 @@ import com.ignfab.minalac.generator.generation.GenerationTile;
 import com.ignfab.minalac.generator.generation.TestingGenerationTile;
 import com.ignfab.minalac.generator.models.ModelImpl;
 import com.ignfab.minalac.generator.models.ModelSelection;
-import com.ignfab.minalac.generator.models.ModelStore;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -21,15 +20,14 @@ public class ModelTaskTest {
     @Test
     public void testRun() {
         GenerationTile tile = new TestingGenerationTile(WorldBBox3d.ORIGIN);
-        ModelStore modelStore = new ModelStore();
 
-        modelStore.add("digit", new ModelImplTester('1'));
-        modelStore.add("digit", new ModelImplTester('1'));
-        modelStore.add("digit", new ModelImplTester('2'));
-        modelStore.add("letter", new ModelImplTester('b'));
-        modelStore.add("letter", new ModelImplTester('a'));
+        tile.models().add("digit", new ModelImplTester('1'));
+        tile.models().add("digit", new ModelImplTester('1'));
+        tile.models().add("digit", new ModelImplTester('2'));
+        tile.models().add("letter", new ModelImplTester('b'));
+        tile.models().add("letter", new ModelImplTester('a'));
 
-        ModelTaksImpl task = new ModelTaksImpl(modelStore, "digit");
+        ModelTaskImpl task = new ModelTaskImpl("digit");
         assertEquals(0, task.modelsRendered.size());
 
         // Not testing rendering area
@@ -41,7 +39,7 @@ public class ModelTaskTest {
         assertEquals(1, Collections.frequency(task.modelsRendered, new ModelImplTester('2')));
         assertEquals(3, task.modelsRendered.size());
 
-        ModelTaksImpl idleTask = new ModelTaksImpl(modelStore, "specialCharacter");
+        ModelTaskImpl idleTask = new ModelTaskImpl("specialCharacter");
         assertEquals(0, idleTask.modelsRendered.size());
 
         idleTask.run(tile);
@@ -49,11 +47,11 @@ public class ModelTaskTest {
         assertEquals(0, idleTask.modelsRendered.size());
     }
 
-    private static class ModelTaksImpl extends ModelTask<ModelImpl> {
+    private static class ModelTaskImpl extends ModelTask<ModelImpl> {
         private final List<ModelImpl> modelsRendered = new ArrayList<>();
 
-        ModelTaksImpl(ModelStore store, String modelType) {
-            super(ModelImpl.class, new ModelSelection(store, modelType, null));
+        ModelTaskImpl(String modelType) {
+            super(ModelImpl.class, new ModelSelection(modelType, null));
         }
 
         @Override

--- a/src/test/java/com/ignfab/minalac/generator/tasks/PopulateHeightmapTaskTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/tasks/PopulateHeightmapTaskTest.java
@@ -11,7 +11,6 @@ import com.ignfab.minalac.generator.generation.heightmaps.TestingHeightmap;
 import com.ignfab.minalac.generator.inputs.FloatGeographicDataMatrix2d;
 import com.ignfab.minalac.generator.models.FloatMatrixModel;
 import com.ignfab.minalac.generator.models.ModelSelection;
-import com.ignfab.minalac.generator.models.ModelStore;
 import com.ignfab.minalac.generator.utils.coordinates.MapToWorldConverter;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 
@@ -35,9 +34,8 @@ public class PopulateHeightmapTaskTest {
         FloatGeographicDataMatrix2d data = new FloatGeographicDataMatrix2d(values, 3, 4, 0, -1, 1.0, 1.0);
         FloatMatrixModel model = new FloatMatrixModel(data, converter);
 
-        ModelStore store = new ModelStore();
-        store.add("matrix", model);
-        ModelSelection selection = new ModelSelection(store, "matrix", null);
+        tile.models().add("matrix", model);
+        ModelSelection selection = new ModelSelection("matrix", null);
 
         new PopulateHeightmapTask(selection, heightmap.spec()).run(tile);
 

--- a/src/test/java/com/ignfab/minalac/generator/tasks/RenderBuildingsTaskTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/tasks/RenderBuildingsTaskTest.java
@@ -7,7 +7,6 @@ import com.ignfab.minalac.generator.generation.TestingGenerationTile;
 import com.ignfab.minalac.generator.generation.heightmaps.TestingHeightmap;
 import com.ignfab.minalac.generator.models.Model;
 import com.ignfab.minalac.generator.models.ModelSelection;
-import com.ignfab.minalac.generator.models.ModelStore;
 import com.ignfab.minalac.generator.models.TestingRectangleShapeVoxelizable2dModel;
 import com.ignfab.minalac.generator.models.filters.ModelFilterHasMetadata;
 import com.ignfab.minalac.generator.parameters.placeables.voxels.TestingVoxelParams;
@@ -20,17 +19,14 @@ import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class RenderBuildingsTaskTest {
-    private WorldBBox3d bbox;
     private TestingGenerationTile tile;
     private TestingHeightmap ground;
-    private ModelStore models;
 
     @BeforeEach
     void setUp() {
-        bbox = new WorldBBox3d(0, 0, 0, 3, 3, 22);
+        WorldBBox3d bbox = new WorldBBox3d(0, 0, 0, 3, 3, 22);
         tile = new TestingGenerationTile(bbox);
         ground = tile.newStoredHeightmap("ground", 0);
-        models = new ModelStore();
     }
 
     /**
@@ -43,10 +39,10 @@ public class RenderBuildingsTaskTest {
 
         int expectedHeight = 20;
         building.setMetadata("height", expectedHeight);
-        models.add("building", building);
+        tile.models().add("building", building);
 
         assertDoesNotThrow(() -> new RenderBuildingsTask(
-            new ModelSelection(models, "building", new ModelFilterHasMetadata("height")),
+            new ModelSelection("building", new ModelFilterHasMetadata("height")),
             ground.spec(),
             new TestingVoxelParams("roof").create(TestingSeed.UNUSED),
             new TestingVoxelParams("wall").create(TestingSeed.UNUSED),
@@ -96,11 +92,11 @@ public class RenderBuildingsTaskTest {
     void testBuildingRenderingWithoutMetadata() {
         WorldBBox2d modelBbox = new WorldBBox2d(0, 0, 3, 3);
         Model building = new TestingRectangleShapeVoxelizable2dModel(modelBbox);
-        models.add("building", building);
+        tile.models().add("building", building);
 
         Placeable placeable = new TestingVoxelParams("voxel").create(TestingSeed.UNUSED);
         assertDoesNotThrow(() -> new RenderBuildingsTask(
-            new ModelSelection(models, "building", new ModelFilterHasMetadata("height")),
+            new ModelSelection("building", new ModelFilterHasMetadata("height")),
             ground.spec(),
             placeable,
             placeable,
@@ -118,11 +114,11 @@ public class RenderBuildingsTaskTest {
         Model building = new TestingRectangleShapeVoxelizable2dModel(modelBbox);
 
         building.setMetadata("height", -20);
-        models.add("building", building);
+        tile.models().add("building", building);
 
         Placeable placeable = new TestingVoxelParams("voxel").create(TestingSeed.UNUSED);
         assertDoesNotThrow(() -> new RenderBuildingsTask(
-            new ModelSelection(models, "building", new ModelFilterHasMetadata("height")),
+            new ModelSelection("building", new ModelFilterHasMetadata("height")),
             ground.spec(),
             placeable,
             placeable,

--- a/src/test/java/com/ignfab/minalac/generator/tasks/RenderVectorsTaskTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/tasks/RenderVectorsTaskTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test;
 import com.ignfab.minalac.generator.generation.TestingGenerationTile;
 import com.ignfab.minalac.generator.generation.heightmaps.TestingHeightmap;
 import com.ignfab.minalac.generator.models.ModelSelection;
-import com.ignfab.minalac.generator.models.ModelStore;
 import com.ignfab.minalac.generator.models.TestingRectangleShapeVoxelizable2dModel;
 import com.ignfab.minalac.generator.outputs.testing.TestingVoxel;
 import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
@@ -20,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.*;
 class RenderVectorsTaskTest {
     private WorldBBox3d bbox;
     private TestingGenerationTile tile;
-    private ModelStore store;
     private ModelSelection modelSelection;
     private TestingHeightmap heightmap;
     private TestingVoxel inside;
@@ -31,8 +29,7 @@ class RenderVectorsTaskTest {
         bbox = new WorldBBox3d(-1, -2, -3, 4, 5, 6);
         tile = new TestingGenerationTile(bbox);
         heightmap = tile.newStoredHeightmap("altitude", 0);
-        store = new ModelStore();
-        modelSelection = new ModelSelection(store, "testing", null);
+        modelSelection = new ModelSelection("testing", null);
 
         inside = new TestingVoxel("INSIDE");
         edge = new TestingVoxel("EDGE");
@@ -51,7 +48,7 @@ class RenderVectorsTaskTest {
         WorldBBox2d modelBbox = new WorldBBox2d(0, -1, 2, 3);
 
         // Add one model covering the whole map with INSIDE voxels
-        store.add("testing", new TestingRectangleShapeVoxelizable2dModel(modelBbox));
+        tile.models().add("testing", new TestingRectangleShapeVoxelizable2dModel(modelBbox));
 
         new RenderVectorsTask(modelSelection, heightmap.spec(), inside, edge).run(tile);
 
@@ -68,7 +65,7 @@ class RenderVectorsTaskTest {
     public void testRenderInsideBorder() {
 
         WorldBBox2d modelBbox = new WorldBBox2d(0, -1, 3, 4);
-        store.add("testing", new TestingRectangleShapeVoxelizable2dModel(modelBbox));
+        tile.models().add("testing", new TestingRectangleShapeVoxelizable2dModel(modelBbox));
 
         new RenderVectorsTask(modelSelection, heightmap.spec(), inside, edge).run(tile);
 
@@ -100,7 +97,7 @@ class RenderVectorsTaskTest {
             heightmap.set(pos, (pos.x() + pos.y()) / 2);
 
         // Add one model covering the whole map
-        store.add("testing", new TestingRectangleShapeVoxelizable2dModel(bbox.to2d()));
+        tile.models().add("testing", new TestingRectangleShapeVoxelizable2dModel(bbox.to2d()));
 
         new RenderVectorsTask(modelSelection, heightmap.spec(), inside, edge).run(tile);
 
@@ -122,7 +119,7 @@ class RenderVectorsTaskTest {
             heightmap.set(pos, pos.x() + pos.y() * 2);
 
         // Add one model covering the whole map with BORDER voxels
-        store.add("testing", new TestingRectangleShapeVoxelizable2dModel(bbox.to2d()));
+        tile.models().add("testing", new TestingRectangleShapeVoxelizable2dModel(bbox.to2d()));
 
         new RenderVectorsTask(modelSelection, heightmap.spec(), inside, edge).run(tile);
 
@@ -139,7 +136,7 @@ class RenderVectorsTaskTest {
     public void testRenderHorizontalOverflow() {
         // Prepare a larger model bbox
         WorldBBox2d modelBbox = new WorldBBox2d(bbox.minX() - 1, bbox.minY() - 1, bbox.sizeX() + 2, bbox.sizeY() + 2);
-        store.add("testing", new TestingRectangleShapeVoxelizable2dModel(modelBbox));
+        tile.models().add("testing", new TestingRectangleShapeVoxelizable2dModel(modelBbox));
 
         new RenderVectorsTask(modelSelection, heightmap.spec(), inside, edge).run(tile);
 

--- a/src/test/java/com/ignfab/minalac/generator/world/VoxelWorldTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/world/VoxelWorldTest.java
@@ -1,5 +1,6 @@
 package com.ignfab.minalac.generator.world;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -8,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import com.ignfab.minalac.generator.outputs.testing.TestingVoxel;
 import com.ignfab.minalac.generator.outputs.testing.TestingVoxelTile;
 import com.ignfab.minalac.generator.placeables.Placeable;
+import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
 
@@ -112,6 +114,11 @@ public class VoxelWorldTest {
         @Override
         public VoxelTile newTile(WorldBBox3d limits) {
             throw new UnsupportedOperationException("Unimplemented method 'newTile'");
+        }
+
+        @Override
+        public Collection<WorldBBox2d> tiles(int maxTileSize) {
+            return Collections.singleton(maxLimits().to2d());
         }
     }
 }


### PR DESCRIPTION
### Issue

MINALAC-122

### Changes

Implementation of tiled generation.


Generation tiling implies these change:
- Move `ModelStore` from `Generation` to `GenerationTile`;
- New `SquareUnitsTileGenerator` able to tile generation with minimal square map units (typically mapblocks/regions not to cut):
- (Big) changes in main loop to perform tiling.
- Addition in command line and environment to manage tiling (not to be included in generation parameters as it depends on environment);


Three different commits:
- *Move model store to tiles to allow parallel generation* by @indyteo : clears models between tiles.
- *Fix error computing mapblock when blockZ is more than 8 bits*: avoids primary key violation when generating big Luanti maps.
- *Add tiles generator and autimatically tile generation*: Performs generation tiling.

These three commits could be reviewed separately.

### Reason

This change makes it possible to create maps as huge as hard disk capacity, with no more memory limitation.

### Self-checks

- [x] The code has unit tests associated
- [x] The code has Javadoc Comments associated
- [x] Complex / Unexpected code is explained / justified with a small comment
- [x] Relevant documentation inside the `/docs` folder has been updated~~
- [x] All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)~~
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [x] The texts have been proofread (documentation, error messages, logs, comments...)~~
 