### PR TITLE
New post-processing capabilities

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ insert_final_newline = true
 max_line_length = 120
 tab_width = 4
 
-[{*.json,*.yml,*.yaml}]
+[{*.json,*.yml,*.yaml,*.md}]
 indent_size = 2
 
 [*.java]

--- a/docs/usage/GenerationParameters.md
+++ b/docs/usage/GenerationParameters.md
@@ -17,7 +17,7 @@ sources:
       features: BDTOPO_V3:batiment
     processor:
       type: geoToolsVector
-    postProcessors:
+    postProcessing:
       - type: copy
         metadata: hauteur
         to: height
@@ -59,10 +59,8 @@ format: minetest
     - `processor`: Definition of the data processor to use
       - `type`: Type of data processor
       - Additional parameters specific to the given [type](#processor-parameters)
-    - `postProcessors`: Definition of post processors to use
-      - _List item_:
-        - `type`: Type of post processor
-        - Additional parameters specific to the given [type](#post-processor-parameters)
+    - `postProcessing`: Additional post-processing steps
+      - [Post-processing](PostProcessing.md) definition
 - `renderers`: Renderers used to generate the map
   - _`<name>`_: Unique name of the [renderer](Renderers.md)
     - `after` (list): List of [dependencies](#dependencies)
@@ -178,52 +176,6 @@ Processor translating a float data matrix to a model.
 **Extra parameters**: None
 
 **Suitable providers**: `wmsFloat`
-
-## Post processor parameters
-
-A post-processor alters models so they can comply with renderers requirements.
-
-### Metadata copy
-
-A post-processor copying a metadata into another.
-
-**Type**: copy
-
-**Extra parameters**:
-- `metadata` (required, `text`): Name of the metadata to copy.
-- `to` (required, `text`): Name of destination metadata.
-- `abortIfMetadataIsAbsent` (optional, default `no`): `yes` to stop the copy if the metadata is missing, `no` to allow the copy to proceed even if the metadata is missing (in this case, the metadata value will be empty).
-- `keepExisting` (optional, default `no`): `no` to overwrite existing data, `yes` to keep existing metadata.
-
-### Metadata parse
-
-Post-processor parsing a metadata value in-place.
-
-**Type**: `parse`
-
-**Extra parameters**:
-- `metadata` (required): the name of the metadata to parse.
-- `as` (required): the type of parsed value: `integer`, `decimal`, `boolean`, `text`.
-- `ifMissing` (optional, default `error`): What to do when metadata is absent. See failure policies below.
-- `ifNotParsable` (optional, default `error`): What to do if data parsing fails. See failure policies below.
-
-| Failure policy | Explanation |
-| :--- | :--- |
-| `discardModel` | The model is discarded. |
-| `removeMetadata` | The metadata is removed. |
-| `ignore` | Failure is ignored, nothing is done. |
-| `error` | An error occurs, and the generation stops. |
-
-### Metadata default
-
-Post-processor that applies a default value for a specified metadata.
-
-**Type**: `default`
-
-**Extra parameters**
-- `metadata` (required): the name of the metadata.
-- `value` (required): the default value to use if the metadata is not present.
-- `as` (requires): the type to which the value should be converted:  `integer`, `decimal`, `boolean`, `text`
 
 ## Model selections
 

--- a/docs/usage/PostProcessing.md
+++ b/docs/usage/PostProcessing.md
@@ -11,6 +11,8 @@ Each post-processor has a field `type` which is used to identify it.
   * [Metadata copy](#metadata-copy)
   * [Metadata default](#metadata-default)
   * [Metadata parse](#metadata-parse)
+* [Geometry post-processors](#geometry-post-processors)
+  * [Geometry buffer](#geometry-buffer)
 
 ## Accepted and processed model types
 
@@ -95,3 +97,21 @@ Post-processor parsing a metadata value in-place.
 | `removeMetadata` | The metadata is removed.                   |
 | `ignore`         | Failure is ignored, nothing is done.       |
 | `error`          | An error occurs, and the generation stops. |
+
+## Geometry post-processors
+
+These post-processors can be applied to models resulting from the [`geoToolsVector` processor](GenerationParameters.md#geotools-vector-processor), and they only modifies the model, without changing its type.
+
+**Accepted model type**: Result of `geoToolsVector` processor
+
+**Processed model type**: Same as input
+
+### Geometry buffer
+
+Post-processor that applies a buffer around the geometry of the model.
+
+**Type**: `geometryBuffer`
+
+**Extra parameters**:
+- `buffer` (required): the signed distance of the buffer to apply, can be negative.
+- `discardEmptyResults` (optional, default `no`): `yes` to discard models resulting in an empty geometry, `no` to keep them. This can happen with a negative `buffer` value, when the original geometry was smaller than that value.

--- a/docs/usage/PostProcessing.md
+++ b/docs/usage/PostProcessing.md
@@ -6,8 +6,10 @@ Each post-processor has a field `type` which is used to identify it.
 ## Table of contents
 * [Accepted and processed model types](#accepted-and-processed-model-types)
 * [Multi-processing steps](#multi-processing-steps)
+* [Conditional post-processing](#conditional-post-processing)
 * [Generic post-processors](#generic-post-processors)
   * [Identity](#identity)
+  * [Discard](#discard)
   * [Metadata copy](#metadata-copy)
   * [Metadata default](#metadata-default)
   * [Metadata parse](#metadata-parse)
@@ -42,6 +44,35 @@ In this situation, the accepted model type of the chain is the one of the first 
 
 Note: An empty chain (`postProcessing: []`) is equivalent to the [identity](#identity) post-processor, and a chain of only one post-processor is equivalent to that single post-processor.
 
+## Conditional post-processing
+
+Sometimes, only a subset of models need specific post-processing. This can be handled using a conditional post-processor, with a [model filter](GenerationParameters.md#model-selections) as condition, and post-processing to apply to matching models.
+
+**Type**: conditional
+
+**Extra parameters**:
+- `if` (required): [Models filter](GenerationParameters.md#model-selections) to decide which models should be post-processed.
+- `then` (required): Post-processing to apply to matching models.
+- `else` (optional, default [identity](#identity)): Post-processing to apply to other models.
+
+For example, to apply a buffer around the geometry of models with a given metadata value, and discard others:
+```yaml
+postProcessing:
+  type: conditional
+  if:
+    metadata: classification
+    equals: forest
+  then:
+    type: geometryBuffer
+    buffer: 3
+  else:
+    type: discard
+```
+
+Of course, `then` can contain multiple post-processing steps, as explained in [the previous section](#multi-processing-steps).
+
+Warning: Models that do not match the condition will be left untouched. Thus, the processed model type of this post-processor is defined as "Same as input", and the accepted model type is the one of the underlying post-processing operation. This means that operation must comply with the "Same as input" processed model type requirement.
+
 ## Generic post-processors
 
 These post-processors can be applied to any model, and they only modifies the model, without changing its type.
@@ -55,6 +86,12 @@ These post-processors can be applied to any model, and they only modifies the mo
 A post-processor doing nothing, returning the input model untouched. It can be convenient if one is required, but you don't need one.
 
 **Type**: identity
+
+### Discard
+
+A post-processor discarding everything. It can be paired with [conditional post-processing](#conditional-post-processing) to drop models based on a condition.
+
+**Type**: discard
 
 ### Metadata copy
 

--- a/docs/usage/PostProcessing.md
+++ b/docs/usage/PostProcessing.md
@@ -1,0 +1,97 @@
+# Post-processing
+
+Post-processing can be applied to models to alter them so they can comply with renderers requirements. This can be particularly useful to mix two heterogeneous data sources to later use them indifferently.
+Each post-processor has a field `type` which is used to identify it.
+
+## Table of contents
+* [Accepted and processed model types](#accepted-and-processed-model-types)
+* [Multi-processing steps](#multi-processing-steps)
+* [Generic post-processors](#generic-post-processors)
+  * [Identity](#identity)
+  * [Metadata copy](#metadata-copy)
+  * [Metadata default](#metadata-default)
+  * [Metadata parse](#metadata-parse)
+
+## Accepted and processed model types
+
+Post-processors take a model as input, and return a processed version of that model as output. Because of this, not all post-processors can be applied to all types of model. Furthermore, a post-processor can return either the (modified) input model, or a complete new one. It can even not return anything, discarding the model.
+
+Most of them are generic, meaning they can work with any type of model, and return the input model. However, some are more specific and only accept a specific model type. In the following sections, these capabilities are expressed as "accepted model type" and "processed model type".
+
+## Multi-processing steps
+
+Post-processors can be chained together sequentially. This is done by giving a list of post-processors instead of a single post-processor. They will be applied in the same order they are defined, and their accepted and processed model type must match with their previous and following one.
+
+For example, to parse a metadata value, removing it on failure, then apply a default one:
+```yaml
+postProcessing:
+  - type: parse
+    metadata: height
+    as: decimal
+    ifMissing: ignore
+    ifNotParsable: removeMetadata
+  - type: default
+    metadata: height
+    value: 5
+    as: integer
+```
+
+In this situation, the accepted model type of the chain is the one of the first post-processor of the chain, and the processed model type is the one from the last post-processor of the chain.
+
+Note: An empty chain (`postProcessing: []`) is equivalent to the [identity](#identity) post-processor, and a chain of only one post-processor is equivalent to that single post-processor.
+
+## Generic post-processors
+
+These post-processors can be applied to any model, and they only modifies the model, without changing its type.
+
+**Accepted model type**: All
+
+**Processed model type**: Same as input
+
+### Identity
+
+A post-processor doing nothing, returning the input model untouched. It can be convenient if one is required, but you don't need one.
+
+**Type**: identity
+
+### Metadata copy
+
+A post-processor copying a metadata into another.
+
+**Type**: copy
+
+**Extra parameters**:
+- `metadata` (required, `text`): Name of the metadata to copy.
+- `to` (required, `text`): Name of destination metadata.
+- `abortIfMetadataIsAbsent` (optional, default `no`): `yes` to stop the copy if the metadata is missing, `no` to allow the copy to proceed even if the metadata is missing (in this case, the metadata value will be empty).
+- `keepExisting` (optional, default `no`): `no` to overwrite existing data, `yes` to keep existing metadata.
+
+### Metadata default
+
+Post-processor that applies a default value for a specified metadata.
+
+**Type**: `default`
+
+**Extra parameters**:
+- `metadata` (required): the name of the metadata.
+- `value` (required): the default value to use if the metadata is not present.
+- `as` (required): the type to which the value should be converted:  `integer`, `decimal`, `boolean`, `text`
+
+### Metadata parse
+
+Post-processor parsing a metadata value in-place.
+
+**Type**: `parse`
+
+**Extra parameters**:
+- `metadata` (required): the name of the metadata to parse.
+- `as` (required): the type of parsed value: `integer`, `decimal`, `boolean`, `text`.
+- `ifMissing` (optional, default `error`): What to do when metadata is absent. See failure policies below.
+- `ifNotParsable` (optional, default `error`): What to do if data parsing fails. See failure policies below.
+
+| Failure policy   | Explanation                                |
+|:-----------------|:-------------------------------------------|
+| `discardModel`   | The model is discarded.                    |
+| `removeMetadata` | The metadata is removed.                   |
+| `ignore`         | Failure is ignored, nothing is done.       |
+| `error`          | An error occurs, and the generation stops. |

--- a/examples/processes/full.yaml
+++ b/examples/processes/full.yaml
@@ -21,7 +21,7 @@ sources:
       maxFeaturesPerQuery: 500
     processor:
       type: geoToolsVector
-    postProcessors:
+    postProcessing:
       - type: copy
         metadata: hauteur
         to: height

--- a/src/main/java/com/ignfab/minalac/generator/MinalacGenerator.java
+++ b/src/main/java/com/ignfab/minalac/generator/MinalacGenerator.java
@@ -19,6 +19,8 @@ import com.ignfab.minalac.generator.parameters.placeables.voxels.MCVoxelTypePara
 import com.ignfab.minalac.generator.parameters.placeables.voxels.MTVoxelTypeParams;
 import com.ignfab.minalac.generator.parameters.processors.FloatMatrixProcessorParams;
 import com.ignfab.minalac.generator.parameters.processors.GeoToolsVectorProcessorParams;
+import com.ignfab.minalac.generator.parameters.processors.post.ConditionalPostProcessorParams;
+import com.ignfab.minalac.generator.parameters.processors.post.DiscardPostProcessorParams;
 import com.ignfab.minalac.generator.parameters.processors.post.IdentityPostProcessorParams;
 import com.ignfab.minalac.generator.parameters.processors.post.JTSGeometryBufferPostProcessorParams;
 import com.ignfab.minalac.generator.parameters.processors.post.MetadataCopyPostProcessorParams;
@@ -92,6 +94,8 @@ public final class MinalacGenerator {
         parser.registerParams("geoToolsVector", GeoToolsVectorProcessorParams.class);
 
         parser.registerParams("identity", IdentityPostProcessorParams.class);
+        parser.registerParams("discard", DiscardPostProcessorParams.class);
+        parser.registerParams("conditional", ConditionalPostProcessorParams.class);
         parser.registerParams("copy", MetadataCopyPostProcessorParams.class);
         parser.registerParams("default", MetadataDefaultPostProcessorParams.class);
         parser.registerParams("parse", MetadataParsePostProcessorParams.class);

--- a/src/main/java/com/ignfab/minalac/generator/MinalacGenerator.java
+++ b/src/main/java/com/ignfab/minalac/generator/MinalacGenerator.java
@@ -19,6 +19,7 @@ import com.ignfab.minalac.generator.parameters.placeables.voxels.MCVoxelTypePara
 import com.ignfab.minalac.generator.parameters.placeables.voxels.MTVoxelTypeParams;
 import com.ignfab.minalac.generator.parameters.processors.FloatMatrixProcessorParams;
 import com.ignfab.minalac.generator.parameters.processors.GeoToolsVectorProcessorParams;
+import com.ignfab.minalac.generator.parameters.processors.post.IdentityPostProcessorParams;
 import com.ignfab.minalac.generator.parameters.processors.post.MetadataCopyPostProcessorParams;
 import com.ignfab.minalac.generator.parameters.processors.post.MetadataDefaultPostProcessorParams;
 import com.ignfab.minalac.generator.parameters.processors.post.MetadataParsePostProcessorParams;
@@ -89,9 +90,10 @@ public final class MinalacGenerator {
         parser.registerParams("floatMatrix", FloatMatrixProcessorParams.class);
         parser.registerParams("geoToolsVector", GeoToolsVectorProcessorParams.class);
 
+        parser.registerParams("identity", IdentityPostProcessorParams.class);
         parser.registerParams("copy", MetadataCopyPostProcessorParams.class);
-        parser.registerParams("parse", MetadataParsePostProcessorParams.class);
         parser.registerParams("default", MetadataDefaultPostProcessorParams.class);
+        parser.registerParams("parse", MetadataParsePostProcessorParams.class);
 
         Generation generation = parser.parse(cli.readParameters()).create();
 

--- a/src/main/java/com/ignfab/minalac/generator/MinalacGenerator.java
+++ b/src/main/java/com/ignfab/minalac/generator/MinalacGenerator.java
@@ -20,6 +20,7 @@ import com.ignfab.minalac.generator.parameters.placeables.voxels.MTVoxelTypePara
 import com.ignfab.minalac.generator.parameters.processors.FloatMatrixProcessorParams;
 import com.ignfab.minalac.generator.parameters.processors.GeoToolsVectorProcessorParams;
 import com.ignfab.minalac.generator.parameters.processors.post.IdentityPostProcessorParams;
+import com.ignfab.minalac.generator.parameters.processors.post.JTSGeometryBufferPostProcessorParams;
 import com.ignfab.minalac.generator.parameters.processors.post.MetadataCopyPostProcessorParams;
 import com.ignfab.minalac.generator.parameters.processors.post.MetadataDefaultPostProcessorParams;
 import com.ignfab.minalac.generator.parameters.processors.post.MetadataParsePostProcessorParams;
@@ -94,6 +95,7 @@ public final class MinalacGenerator {
         parser.registerParams("copy", MetadataCopyPostProcessorParams.class);
         parser.registerParams("default", MetadataDefaultPostProcessorParams.class);
         parser.registerParams("parse", MetadataParsePostProcessorParams.class);
+        parser.registerParams("geometryBuffer", JTSGeometryBufferPostProcessorParams.class);
 
         Generation generation = parser.parse(cli.readParameters()).create();
 

--- a/src/main/java/com/ignfab/minalac/generator/generation/DataSource.java
+++ b/src/main/java/com/ignfab/minalac/generator/generation/DataSource.java
@@ -1,8 +1,6 @@
 package com.ignfab.minalac.generator.generation;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
 import com.ignfab.minalac.generator.exceptions.IgnorableException;
@@ -22,7 +20,7 @@ public class DataSource {
     private final String modelType;
     private final Provider<?> provider;
     private final Processor<Object, ?> processor;
-    private final List<PostProcessor<Model, ?>> postProcessors;
+    private final PostProcessor<Model, ?> postProcessor;
 
     /**
      * Creates a new data source.
@@ -31,37 +29,33 @@ public class DataSource {
      * @param modelType name of type to be associated with them
      * @param provider data provider
      * @param processor processor converting provided data to models
-     * @param postProcessors eventual post-processor to run on created models
+     * @param postProcessor post-processor to run on created models
      */
     public DataSource(
         ModelStore modelStore,
         String modelType,
         Provider<?> provider,
         Processor<?, ? extends Model> processor,
-        List<PostProcessor<?, ?>> postProcessors
+        PostProcessor<?, ?> postProcessor
     ) {
-        Class<? extends Model> modelClass = processor.modelType();
-
         if (!processor.acceptedType().isAssignableFrom(provider.providedType()))
-            throw new IllegalArgumentException("Processor cannot treat provided type. Provided = %s, Accepted = %s".formatted(provider.providedType(), processor.acceptedType()));
+            throw new IllegalArgumentException("%s cannot treat provided type. Provided = %s, Accepted = %s".formatted(
+                processor.getClass().getSimpleName(),
+                provider.providedType(),
+                processor.acceptedType()
+            ));
+        postProcessor.checkProcessingType(processor.modelType());
 
-        this.postProcessors = new ArrayList<>();
-        for (PostProcessor<?, ?> postProcessor : postProcessors) {
-            if (!postProcessor.acceptedModelType().isAssignableFrom(modelClass))
-                throw new IllegalArgumentException("PostProcessor cannot treat model type. Current model type = %s, Accepted model type = %s".formatted(modelType, postProcessor.acceptedModelType()));
-            @SuppressWarnings("unchecked") // The model type has been validated above
-            PostProcessor<Model, ?> uncheckedPostProcessor = (PostProcessor<Model, ?>) postProcessor;
-            this.postProcessors.add(uncheckedPostProcessor);
-            modelClass = uncheckedPostProcessor.processedModelType(modelClass);
-        }
-
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings("unchecked") // The provided type has been validated above
         Processor<Object, ?> uncheckedProcessor = (Processor<Object, ?>) processor;
+        @SuppressWarnings("unchecked") // The model type has been validated above
+        PostProcessor<Model, ?> uncheckedPostProcessor = (PostProcessor<Model, ?>) postProcessor;
 
         this.modelStore = modelStore;
         this.modelType = modelType;
         this.provider = provider;
         this.processor = uncheckedProcessor;
+        this.postProcessor = uncheckedPostProcessor;
     }
 
     /**
@@ -76,13 +70,11 @@ public class DataSource {
                 Object data = result.next();
                 try {
                     Model model = processor.process(data);
-                    for (PostProcessor<Model, ?> postProcessor : postProcessors) {
-                        if (model == null)
-                            break;
+                    if (model != null) {
                         model = postProcessor.process(model);
+                        if (model != null)
+                            modelStore.add(modelType, model);
                     }
-                    if (model != null)
-                        modelStore.add(modelType, model);
                 } catch (IgnorableException e) {
                     // TODO Add an exception handling policy
                     // To fail even on ignorable exceptions:

--- a/src/main/java/com/ignfab/minalac/generator/models/JTSGeometryModel.java
+++ b/src/main/java/com/ignfab/minalac/generator/models/JTSGeometryModel.java
@@ -31,7 +31,7 @@ import com.ignfab.minalac.generator.voxelization.shape3d.ShapesVoxelizer3d;
  * It is voxelizable both in 2d and 3d.
  */
 public class JTSGeometryModel extends ModelImpl implements ShapesVoxelizable2d, ShapesVoxelizable3d {
-    private final Geometry geom;
+    private Geometry geom;
 
     /**
      * Creates a new {@link JTSGeometryModel}.
@@ -44,6 +44,33 @@ public class JTSGeometryModel extends ModelImpl implements ShapesVoxelizable2d, 
         // Until there is no need of it we don't keep original geometry.
         // Geometry is stored transformed into world coordinates
         this.geom = converter.convert(geom);
+    }
+
+    /**
+     * Gets the model's geometry.
+     * The returned object is a direct reference and any modification
+     * will be reflected in the model, until another geometry is set.
+     * <p>
+     * Note: The current geometry is different from the one used in the
+     * constructor, because it was converted using the given converter.
+     * @return The current geometry
+     * @see #setGeometry(Geometry)
+     */
+    public Geometry getGeometry() {
+        return geom;
+    }
+
+    /**
+     * Sets the model's geometry.
+     * This will overwrite the current geometry of the model, and therefore
+     * the new geometry should probably be computed from the current one.
+     * <p>
+     * Note: The new geometry won't be converted again like the one used in
+     * the constructor. It must be in the world's coordinate system.
+     * @param geom The new geometry
+     */
+    public void setGeometry(Geometry geom) {
+        this.geom = geom;
     }
 
     @Override

--- a/src/main/java/com/ignfab/minalac/generator/parameters/DataSourceParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/DataSourceParams.java
@@ -1,7 +1,6 @@
 package com.ignfab.minalac.generator.parameters;
 
 import java.beans.ConstructorProperties;
-import java.util.ArrayList;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonSetter;
@@ -9,12 +8,10 @@ import com.fasterxml.jackson.annotation.Nulls;
 
 import com.ignfab.minalac.generator.generation.DataSource;
 import com.ignfab.minalac.generator.generation.Generation;
-import com.ignfab.minalac.generator.inputs.Provider;
 import com.ignfab.minalac.generator.parameters.processors.ProcessorParams;
+import com.ignfab.minalac.generator.parameters.processors.post.IdentityPostProcessorParams;
 import com.ignfab.minalac.generator.parameters.processors.post.PostProcessorParams;
 import com.ignfab.minalac.generator.parameters.providers.ProviderParams;
-import com.ignfab.minalac.generator.processors.Processor;
-import com.ignfab.minalac.generator.processors.post.PostProcessor;
 
 /**
  * Represents the parameters used for {@link DataSource} creation.
@@ -40,7 +37,7 @@ public class DataSourceParams {
      * Additional data-processing steps (optional).
      */
     @JsonSetter(nulls = Nulls.SKIP)
-    public List<PostProcessorParams> postProcessors = new ArrayList<>();
+    public PostProcessorParams postProcessing = new IdentityPostProcessorParams();
 
     /**
      * Dependencies (optional).
@@ -72,8 +69,7 @@ public class DataSourceParams {
 
         provider.validate();
         processor.validate();
-        for (PostProcessorParams params : postProcessors)
-            params.validate();
+        postProcessing.validate();
     }
 
     /**
@@ -83,18 +79,12 @@ public class DataSourceParams {
      * @return the created data source
      */
     public DataSource create(Generation generation) {
-        Provider<?> provider = this.provider.create(generation);
-        Processor<?, ?> processor = this.processor.create(generation);
-        List<PostProcessor<?, ?>> postProcessors = new ArrayList<>();
-        for (PostProcessorParams params : this.postProcessors)
-            postProcessors.add(params.create());
-
         return new DataSource(
             generation.models(),
             modelType,
-            provider,
-            processor,
-            postProcessors
+            provider.create(generation),
+            processor.create(generation),
+            postProcessing.create()
         );
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/ConditionalPostProcessorParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/ConditionalPostProcessorParams.java
@@ -1,0 +1,66 @@
+package com.ignfab.minalac.generator.parameters.processors.post;
+
+import java.beans.ConstructorProperties;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+
+import com.ignfab.minalac.generator.models.Model;
+import com.ignfab.minalac.generator.parameters.models.filters.ModelFilterParams;
+import com.ignfab.minalac.generator.processors.post.ConditionalPostProcessor;
+import com.ignfab.minalac.generator.processors.post.PostProcessor;
+
+/**
+ * Parameters for {@link ConditionalPostProcessor}.
+ */
+public class ConditionalPostProcessorParams extends PostProcessorParams {
+    /**
+     * Filter to decide which models should be post-processed (required).
+     */
+    @JsonSetter(nulls = Nulls.FAIL)
+    @JsonProperty("if")
+    public ModelFilterParams condition;
+
+    /**
+     * Post-processor to apply to matching models (required).
+     */
+    @JsonSetter(nulls = Nulls.FAIL)
+    @JsonProperty("then")
+    public PostProcessorParams postProcessorIfTrue;
+
+    /**
+     * Post-processor to apply to other models (optional, defaults to identity).
+     */
+    @JsonSetter(nulls = Nulls.SKIP)
+    @JsonProperty("else")
+    public PostProcessorParams postProcessorIfFalse = new IdentityPostProcessorParams();
+
+    /**
+     * Constructor used to ensure that the required fields are present during deserialization.
+     * @param condition the filter to match models
+     * @param postProcessorIfTrue the post-processor to apply
+     */
+    @ConstructorProperties({ "condition", "postProcessorIfTrue" })
+    public ConditionalPostProcessorParams(ModelFilterParams condition, PostProcessorParams postProcessorIfTrue) {
+        this.condition = condition;
+        this.postProcessorIfTrue = postProcessorIfTrue;
+    }
+
+    @Override
+    public void validate() throws IllegalArgumentException {
+        condition.validate();
+        postProcessorIfTrue.validate();
+        postProcessorIfFalse.validate();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked") // Types will be validated later
+    public PostProcessor<?, ?> create() {
+        return new ConditionalPostProcessor<>(
+            condition.create(),
+            (PostProcessor<Model, ?>) postProcessorIfTrue.create(),
+            (PostProcessor<Model, ?>) postProcessorIfFalse.create()
+        );
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/DiscardPostProcessorParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/DiscardPostProcessorParams.java
@@ -1,0 +1,14 @@
+package com.ignfab.minalac.generator.parameters.processors.post;
+
+import com.ignfab.minalac.generator.processors.post.DiscardPostProcessor;
+import com.ignfab.minalac.generator.processors.post.PostProcessor;
+
+/**
+ * Parameters for {@link DiscardPostProcessor}.
+ */
+public class DiscardPostProcessorParams extends PostProcessorParams {
+    @Override
+    public PostProcessor<?, ?> create() {
+        return DiscardPostProcessor.INSTANCE;
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/IdentityPostProcessorParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/IdentityPostProcessorParams.java
@@ -1,0 +1,14 @@
+package com.ignfab.minalac.generator.parameters.processors.post;
+
+import com.ignfab.minalac.generator.processors.post.IdentityPostProcessor;
+import com.ignfab.minalac.generator.processors.post.PostProcessor;
+
+/**
+ * Parameters for {@link IdentityPostProcessor}.
+ */
+public class IdentityPostProcessorParams extends PostProcessorParams {
+    @Override
+    public PostProcessor<?, ?> create() {
+        return IdentityPostProcessor.INSTANCE;
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/JTSGeometryBufferPostProcessorParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/JTSGeometryBufferPostProcessorParams.java
@@ -1,0 +1,47 @@
+package com.ignfab.minalac.generator.parameters.processors.post;
+
+import java.beans.ConstructorProperties;
+
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+
+import com.ignfab.minalac.generator.models.JTSGeometryModel;
+import com.ignfab.minalac.generator.processors.post.JTSGeometryBufferPostProcessor;
+import com.ignfab.minalac.generator.processors.post.PostProcessor;
+
+/**
+ * Parameters for {@link JTSGeometryBufferPostProcessor}.
+ */
+public class JTSGeometryBufferPostProcessorParams extends PostProcessorParams {
+    /**
+     * Buffer distance value to apply (required).
+     */
+    @JsonSetter(nulls = Nulls.FAIL)
+    public double buffer;
+
+    /**
+     * Whether to discard models resulting in empty geometry (optional, default false).
+     */
+    @JsonSetter(nulls = Nulls.SKIP)
+    public boolean discardEmptyResults = false;
+
+    /**
+     * Constructor used to ensure that the required fields are present during deserialization.
+     * @param buffer The buffer value
+     */
+    @ConstructorProperties({ "buffer" })
+    public JTSGeometryBufferPostProcessorParams(double buffer) {
+        this.buffer = buffer;
+    }
+
+    @Override
+    public void validate() throws IllegalArgumentException {
+        if (!Double.isFinite(buffer))
+            throw new IllegalArgumentException("The 'buffer' field must be a finite decimal number");
+    }
+
+    @Override
+    public PostProcessor<JTSGeometryModel, ?> create() {
+        return new JTSGeometryBufferPostProcessor(buffer, discardEmptyResults);
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/PostProcessorParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/PostProcessorParams.java
@@ -1,11 +1,24 @@
 package com.ignfab.minalac.generator.parameters.processors.post;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.deser.std.DelegatingDeserializer;
+import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
+
+import com.ignfab.minalac.generator.parameters.JsonDelegateDeserialize;
 import com.ignfab.minalac.generator.parameters.PolymorphicParams;
 import com.ignfab.minalac.generator.processors.post.PostProcessor;
 
 /**
  * Parameters for {@link PostProcessor}.
  */
+@JsonDelegateDeserialize(using = PostProcessorParams.Deserializer.class)
 public abstract class PostProcessorParams extends PolymorphicParams {
     /**
      * Creates the corresponding {@link PostProcessor}.
@@ -13,4 +26,33 @@ public abstract class PostProcessorParams extends PolymorphicParams {
      * @return the created {@link PostProcessor}
      */
     public abstract PostProcessor<?, ?> create();
+
+    /**
+     * Custom deserializer to handle list of post processors seamlessly.
+     */
+    public static class Deserializer extends DelegatingDeserializer {
+        /**
+         * Creates a new instance.
+         * @param delegate The default deserializer.
+         */
+        public Deserializer(JsonDeserializer<?> delegate) {
+            super(delegate);
+        }
+
+        @Override
+        protected JsonDeserializer<?> newDelegatingInstance(JsonDeserializer<?> delegate) {
+            return new Deserializer(delegate);
+        }
+
+        @Override
+        public Object deserializeWithType(JsonParser jsonParser, DeserializationContext deserializationContext, TypeDeserializer typeDeserializer) throws IOException {
+            if (jsonParser.isExpectedStartArrayToken()) {
+                List<PostProcessorParams> sequence = new ArrayList<>();
+                while (jsonParser.nextToken() != JsonToken.END_ARRAY)
+                    sequence.add(jsonParser.readValueAs(PostProcessorParams.class));
+                return new SequentialPostProcessorParams(sequence);
+            }
+            return super.deserializeWithType(jsonParser, deserializationContext, typeDeserializer);
+        }
+    }
 }

--- a/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/SequentialPostProcessorParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/SequentialPostProcessorParams.java
@@ -1,0 +1,37 @@
+package com.ignfab.minalac.generator.parameters.processors.post;
+
+import java.util.List;
+
+import com.ignfab.minalac.generator.processors.post.IdentityPostProcessor;
+import com.ignfab.minalac.generator.processors.post.PostProcessor;
+import com.ignfab.minalac.generator.processors.post.SequentialPostProcessor;
+
+/**
+ * Parameters for {@link SequentialPostProcessor}.
+ */
+public class SequentialPostProcessorParams extends PostProcessorParams {
+    private final List<PostProcessorParams> sequence;
+
+    /**
+     * Creates a new instance.
+     * @param sequence The post-processing sequence params
+     */
+    public SequentialPostProcessorParams(List<PostProcessorParams> sequence) {
+        this.sequence = sequence;
+    }
+
+    @Override
+    public void validate() throws IllegalArgumentException {
+        for (PostProcessorParams params : sequence)
+            params.validate();
+    }
+
+    @Override
+    public PostProcessor<?, ?> create() {
+        if (sequence.isEmpty())
+            return IdentityPostProcessor.INSTANCE;
+        if (sequence.size() == 1)
+            return sequence.get(0).create();
+        return new SequentialPostProcessor<>(sequence.stream().map(PostProcessorParams::create).toList());
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/processors/post/ConditionalPostProcessor.java
+++ b/src/main/java/com/ignfab/minalac/generator/processors/post/ConditionalPostProcessor.java
@@ -1,0 +1,75 @@
+package com.ignfab.minalac.generator.processors.post;
+
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.function.Predicate;
+
+import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
+import com.ignfab.minalac.generator.exceptions.IgnorableException;
+import com.ignfab.minalac.generator.models.Model;
+
+/**
+ * Post-processor applying another post-processor based on a condition.
+ * @param <M1> The accepted model type. Must be accepted by both of its underlying post-processors.
+ * @param <M2> The processed model type. Must be common to both of its underlying post-processors.
+ */
+public class ConditionalPostProcessor<M1 extends Model, M2 extends Model> implements PostProcessor<M1, M2> {
+    private final Predicate<? super M1> condition;
+    private final PostProcessor<? super M1, ? extends M2> postProcessorIfTrue;
+    private final PostProcessor<? super M1, ? extends M2> postProcessorIfFalse;
+
+    /**
+     * Creates a new {@code ConditionalPostProcessor}.
+     * @param condition The predicate to decide if a model should be processed
+     * @param postProcessorIfTrue The post-processor to apply on matching models
+     * @param postProcessorIfFalse The post-processor to apply on other models
+     */
+    public ConditionalPostProcessor(
+        Predicate<? super M1> condition,
+        PostProcessor<? super M1, ? extends M2> postProcessorIfTrue,
+        PostProcessor<? super M1, ? extends M2> postProcessorIfFalse
+    ) {
+        this.condition = condition;
+        this.postProcessorIfTrue = postProcessorIfTrue;
+        this.postProcessorIfFalse = postProcessorIfFalse;
+    }
+
+    @Override
+    public Class<? extends M2> checkProcessingType(Class<? extends Model> inputModelType) throws IllegalArgumentException {
+        Class<? extends M2> typeIfTrue = postProcessorIfTrue.checkProcessingType(inputModelType);
+        Class<? extends M2> typeIfFalse = postProcessorIfFalse.checkProcessingType(inputModelType);
+        return findCommonAncestor(typeIfTrue, typeIfFalse);
+    }
+
+    @Override
+    public M2 process(M1 model) throws IgnorableException, GenerationFailedException {
+        return condition.test(model) ? postProcessorIfTrue.process(model) : postProcessorIfFalse.process(model);
+    }
+
+    private static <T extends Model> Class<? extends T> findCommonAncestor(Class<? extends T> a, Class<? extends T> b) {
+        // Common case
+        if (a.isAssignableFrom(b))
+            return a;
+        if (b.isAssignableFrom(a))
+            return b;
+        // Traverse hierarchy using BFS to find common ancestor
+        Queue<Class<?>> ancestors = new LinkedList<>();
+        ancestors.offer(a);
+        while (!ancestors.isEmpty()) {
+            Class<?> cls = ancestors.poll();
+            if (cls.isAssignableFrom(b)) {
+                @SuppressWarnings("unchecked")
+                Class<? extends T> ancestor = (Class<? extends T>) cls;
+                return ancestor;
+            }
+            Class<?> superclass = cls.getSuperclass();
+            if (superclass != null)
+                ancestors.offer(superclass);
+            for (Class<?> superinterface : cls.getInterfaces())
+                if (Model.class.isAssignableFrom(superinterface))
+                   ancestors.offer(superinterface);
+        }
+        // Should never get there: Model is the least common ancestor
+        throw new RuntimeException();
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/processors/post/DiscardPostProcessor.java
+++ b/src/main/java/com/ignfab/minalac/generator/processors/post/DiscardPostProcessor.java
@@ -1,0 +1,24 @@
+package com.ignfab.minalac.generator.processors.post;
+
+import com.ignfab.minalac.generator.models.Model;
+
+/**
+ * Post-processor discarding everything.
+ * Can be used for example inside a {@link ConditionalPostProcessor} to discard matching models.
+ */
+public final class DiscardPostProcessor extends PostProcessor.Generic {
+    /**
+     * Singleton instance.
+     */
+    public static final DiscardPostProcessor INSTANCE = new DiscardPostProcessor();
+
+    /**
+     * @see #INSTANCE
+     */
+    private DiscardPostProcessor() {}
+
+    @Override
+    public Model process(Model model) {
+        return null;
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/processors/post/IdentityPostProcessor.java
+++ b/src/main/java/com/ignfab/minalac/generator/processors/post/IdentityPostProcessor.java
@@ -1,0 +1,23 @@
+package com.ignfab.minalac.generator.processors.post;
+
+import com.ignfab.minalac.generator.models.Model;
+
+/**
+ * Post-processor doing nothing. Can be convenient as a default value when not needed.
+ */
+public final class IdentityPostProcessor extends PostProcessor.Generic {
+    /**
+     * Singleton instance.
+     */
+    public static final IdentityPostProcessor INSTANCE = new IdentityPostProcessor();
+
+    /**
+     * @see #INSTANCE
+     */
+    private IdentityPostProcessor() {}
+
+    @Override
+    public Model process(Model model) {
+        return model;
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/processors/post/JTSGeometryBufferPostProcessor.java
+++ b/src/main/java/com/ignfab/minalac/generator/processors/post/JTSGeometryBufferPostProcessor.java
@@ -1,0 +1,41 @@
+package com.ignfab.minalac.generator.processors.post;
+
+import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
+import com.ignfab.minalac.generator.exceptions.IgnorableException;
+import com.ignfab.minalac.generator.models.JTSGeometryModel;
+
+/**
+ * Post-processor working on {@link JTSGeometryModel}s
+ * applying a buffer around a model's geometry.
+ * The model's geometry is modified using the
+ * {@link org.locationtech.jts.geom.Geometry#buffer(double) .buffer(d)}
+ * JTS method on the geometry with a buffer value {@code d}.
+ * <p>
+ * Models resulting in empty geometries can be discarded.
+ * <p>
+ * The same model object is returned after post-processing.
+ */
+public class JTSGeometryBufferPostProcessor extends PostProcessor.Simple<JTSGeometryModel> {
+    private final double buffer;
+    private final boolean discardEmptyResults;
+
+    /**
+     * Creates a new {@code JTSGeometryBufferPostProcessor}.
+     * @param buffer The buffer distance value to apply
+     * @param discardEmptyResults Whether to discard models resulting in empty geometry
+     */
+    public JTSGeometryBufferPostProcessor(double buffer, boolean discardEmptyResults) {
+        super(JTSGeometryModel.class);
+        this.buffer = buffer;
+        this.discardEmptyResults = discardEmptyResults;
+    }
+
+    @Override
+    public JTSGeometryModel process(JTSGeometryModel model) throws GenerationFailedException, IgnorableException {
+        if (buffer != 0)
+            model.setGeometry(model.getGeometry().buffer(buffer));
+        if (discardEmptyResults && model.getGeometry().isEmpty())
+            return null;
+        return model;
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/processors/post/MetadataCopyPostProcessor.java
+++ b/src/main/java/com/ignfab/minalac/generator/processors/post/MetadataCopyPostProcessor.java
@@ -8,7 +8,7 @@ import com.ignfab.minalac.generator.models.Model;
  * This operation can be seen as renaming a metadata, with
  * the side effect of leaving the original one in place.
  * <p>
- * The model same model object is returned after post-processing.
+ * The same model object is returned after post-processing.
  */
 public class MetadataCopyPostProcessor extends PostProcessor.Generic {
     private final String from;

--- a/src/main/java/com/ignfab/minalac/generator/processors/post/MetadataCopyPostProcessor.java
+++ b/src/main/java/com/ignfab/minalac/generator/processors/post/MetadataCopyPostProcessor.java
@@ -10,7 +10,7 @@ import com.ignfab.minalac.generator.models.Model;
  * <p>
  * The model same model object is returned after post-processing.
  */
-public class MetadataCopyPostProcessor implements PostProcessor<Model, Model> {
+public class MetadataCopyPostProcessor extends PostProcessor.Generic {
     private final String from;
     private final String to;
     private final boolean abortIfFromIsAbsent;
@@ -28,16 +28,6 @@ public class MetadataCopyPostProcessor implements PostProcessor<Model, Model> {
         this.to = to;
         this.abortIfFromIsAbsent = abortIfFromIsAbsent;
         this.doNotOverwriteExistingTo = doNotOverwriteExistingTo;
-    }
-
-    @Override
-    public Class<? super Model> acceptedModelType() {
-        return Model.class;
-    }
-
-    @Override
-    public Class<? extends Model> processedModelType(Class<? extends Model> inputModelType) {
-        return inputModelType;
     }
 
     @Override

--- a/src/main/java/com/ignfab/minalac/generator/processors/post/MetadataDefaultPostProcessor.java
+++ b/src/main/java/com/ignfab/minalac/generator/processors/post/MetadataDefaultPostProcessor.java
@@ -5,7 +5,7 @@ import com.ignfab.minalac.generator.models.Model;
 /**
  * Post-processor that applies a default value for a specified metadata.
  */
-public class MetadataDefaultPostProcessor implements PostProcessor<Model, Model> {
+public class MetadataDefaultPostProcessor extends PostProcessor.Generic {
     private final String name;
     private final Object defaultValue;
 
@@ -18,16 +18,6 @@ public class MetadataDefaultPostProcessor implements PostProcessor<Model, Model>
     public MetadataDefaultPostProcessor(String name, Object defaultValue) {
         this.name = name;
         this.defaultValue = defaultValue;
-    }
-
-    @Override
-    public Class<? super Model> acceptedModelType() {
-        return Model.class;
-    }
-
-    @Override
-    public Class<? extends Model> processedModelType(Class<? extends Model> inputModelType) {
-       return inputModelType;
     }
 
     @Override

--- a/src/main/java/com/ignfab/minalac/generator/processors/post/MetadataParsePostProcessor.java
+++ b/src/main/java/com/ignfab/minalac/generator/processors/post/MetadataParsePostProcessor.java
@@ -11,7 +11,7 @@ import com.ignfab.minalac.generator.models.Model;
  *
  * @param <T> type of parsed value
  */
-public class MetadataParsePostProcessor<T> implements PostProcessor<Model, Model> {
+public class MetadataParsePostProcessor<T> extends PostProcessor.Generic {
     private final String name;
     private final Class<T> type;
     private final Function<Object, ? extends T> parser;
@@ -39,16 +39,6 @@ public class MetadataParsePostProcessor<T> implements PostProcessor<Model, Model
         this.parser = parser;
         this.ifMissingMetadata = ifMissingMetadata;
         this.ifParserFails = ifParserFails;
-    }
-
-    @Override
-    public Class<? super Model> acceptedModelType() {
-        return Model.class;
-    }
-
-    @Override
-    public Class<? extends Model> processedModelType(Class<? extends Model> inputModelType) {
-        return inputModelType;
     }
 
     @Override

--- a/src/main/java/com/ignfab/minalac/generator/processors/post/PostProcessor.java
+++ b/src/main/java/com/ignfab/minalac/generator/processors/post/PostProcessor.java
@@ -11,30 +11,25 @@ import com.ignfab.minalac.generator.models.Model;
  * Its main method is {@link #process(Model)}, which take a
  * model and return the altered model.
  * <p>
- * The type of processable models and models returned are defined
- * by the generic types {@code M1} and {@code M2} (compile-time check)
- * and must also be returned by the {@link #acceptedModelType()} and
- * {@link #processedModelType(Class)} methods to allow runtime check.
+ * The type of processable models and models returned are
+ * defined by the generic types {@code M1} and {@code M2}
+ * (compile-time check) and must also be checked at runtime
+ * be the {@link #checkProcessingType(Class)} method.
  *
  * @param <M1> The type of processable models
  * @param <M2> The type of altered models
  */
 public interface PostProcessor<M1 extends Model, M2 extends Model> {
     /**
-     * Returns the type of processable models.
-     *
-     * @return the type of processable models
-     */
-    Class<? super M1> acceptedModelType();
-
-    /**
-     * Returns the type of altered models.
+     * Checks that the given type can be processed by this post-processor,
+     * then returns the type of altered models.
      * It may vary depending on the model type received as an input.
      *
      * @param inputModelType the input model type
      * @return the type of altered models
+     * @throws IllegalArgumentException if this post-processor cannot handle the input model type
      */
-    Class<? extends M2> processedModelType(Class<? extends M1> inputModelType);
+    Class<? extends M2> checkProcessingType(Class<? extends Model> inputModelType) throws IllegalArgumentException;
 
     /**
      * Post-processes a model and returns an altered model.
@@ -45,4 +40,47 @@ public interface PostProcessor<M1 extends Model, M2 extends Model> {
      * @throws IgnorableException If an error occurs but the model may be ignored
      */
     M2 process(M1 model) throws GenerationFailedException, IgnorableException;
+
+    /**
+     * Basic post-processor implementation working on a model type.
+     * The accepted model type is defined in the constructor, and the
+     * post-processor is intended to return the same model type given as input.
+     * @param <M> The type of models handled by this simple post-processor
+     */
+    abstract class Simple<M extends Model> implements PostProcessor<M, M> {
+        private final Class<M> acceptedModelType;
+
+        /**
+         * Creates a new simple post-processor handling the given model type.
+         * @param acceptedModelType The model type handled
+         */
+        public Simple(Class<M> acceptedModelType) {
+            this.acceptedModelType = acceptedModelType;
+        }
+
+        @Override
+        public Class<? extends M> checkProcessingType(Class<? extends Model> inputModelType) throws IllegalArgumentException {
+            try {
+                return inputModelType.asSubclass(acceptedModelType);
+            } catch (ClassCastException e) {
+                throw new IllegalArgumentException("%s cannot treat model type. Current model type = %s, Accepted model type = %s".formatted(
+                    getClass().getSimpleName(),
+                    inputModelType.getName(),
+                    acceptedModelType.getName()
+                ));
+            }
+        }
+    }
+
+    /**
+     * Generic post-processor base, i.e. simple post-processor handling {@link Model}s.
+     */
+    abstract class Generic extends Simple<Model> {
+        /**
+         * Creates a new generic post-processor.
+         */
+        public Generic() {
+            super(Model.class);
+        }
+    }
 }

--- a/src/main/java/com/ignfab/minalac/generator/processors/post/SequentialPostProcessor.java
+++ b/src/main/java/com/ignfab/minalac/generator/processors/post/SequentialPostProcessor.java
@@ -1,0 +1,53 @@
+package com.ignfab.minalac.generator.processors.post;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
+import com.ignfab.minalac.generator.exceptions.IgnorableException;
+import com.ignfab.minalac.generator.models.Model;
+
+/**
+ * Post-processor applying other post-processors in sequence.
+ * @param <M1> The accepted model type. Must match the one of the first most-restricting underlying post-processor.
+ * @param <M2> The processed model type. Must match the one of the last underlying post-processor after going through all of them.
+ */
+public class SequentialPostProcessor<M1 extends Model, M2 extends Model> implements PostProcessor<M1, M2> {
+    private final List<PostProcessor<Model, ?>> postProcessors;
+
+    /**
+     * Creates a new {@code SequentialPostProcessor}.
+     * @param postProcessors The underlying processors to apply
+     */
+    public SequentialPostProcessor(List<? extends PostProcessor<?, ?>> postProcessors) {
+        this.postProcessors = new ArrayList<>(postProcessors.size());
+        for (PostProcessor<?, ?> postProcessor : postProcessors) {
+            @SuppressWarnings("unchecked") // The model types will be validated later
+            PostProcessor<Model, ?> uncheckedPostProcessor = (PostProcessor<Model, ?>) postProcessor;
+            this.postProcessors.add(uncheckedPostProcessor);
+        }
+    }
+
+    @Override
+    public Class<? extends M2> checkProcessingType(Class<? extends Model> inputModelType) throws IllegalArgumentException {
+        Class<? extends Model> modelType = inputModelType;
+        for (PostProcessor<Model, ?> postProcessor : postProcessors)
+            modelType = postProcessor.checkProcessingType(modelType);
+        @SuppressWarnings("unchecked") // The processed model type should match the generic M2
+        Class<? extends M2> processedModelType = (Class<? extends M2>) modelType;
+        return processedModelType;
+    }
+
+    @Override
+    public M2 process(M1 inputModel) throws IgnorableException, GenerationFailedException {
+        Model model = inputModel;
+        for (PostProcessor<Model, ?> postProcessor : postProcessors) {
+            if (model == null)
+                break;
+            model = postProcessor.process(model);
+        }
+        @SuppressWarnings("unchecked") // The processed model type should match the generic M2
+        M2 processedModel = (M2) model;
+        return processedModel;
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/models/ModelSelectionTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/models/ModelSelectionTest.java
@@ -15,9 +15,9 @@ public class ModelSelectionTest {
     public void testIterator() {
         ModelStore store = new ModelStore();
 
-        Model modelA = new TestingModel(Map.of("a", 1));
-        Model modelB = new TestingModel(Map.of("b", 2));
-        Model modelC = new TestingModel();
+        Model modelA = new TestingModel("A", Map.of("a", 1));
+        Model modelB = new TestingModel("B", Map.of("b", 2));
+        Model modelC = new TestingModel("C");
 
         store.add("X", modelA);
         store.add("Y", modelA);

--- a/src/test/java/com/ignfab/minalac/generator/models/TestingModel.java
+++ b/src/test/java/com/ignfab/minalac/generator/models/TestingModel.java
@@ -8,22 +8,43 @@ import static org.junit.jupiter.api.Assertions.*;
  * A testing model with only metadata and assertions.
  */
 public class TestingModel extends ModelImpl {
-    public TestingModel() {}
+    private final String name;
 
-    public TestingModel(Map<String, Object> metadata) {
+    public TestingModel(String name, Map<String, Object> metadata) {
+        this.name = name;
         metadata.forEach(this::setMetadata);
     }
 
+    public TestingModel(Map<String, Object> metadata) {
+        this(null, metadata);
+    }
+
+    public TestingModel(String name) {
+        this(name, Map.of());
+    }
+
+    public TestingModel() {
+        this(null, Map.of());
+    }
+
     private static String prefix(String message) {
-        return message == null ? "" : message + " ===> ";
+        return message == null ? "" : message + " ==> ";
     }
 
-    public void assertMetadata(String name, Object value) {
-        assertMetadata(name, value, null);
+    public void assertMetadata(String name, Object expectedValue) {
+        assertMetadata(name, expectedValue, null);
     }
 
-    public void assertMetadata(String name, Object value, String message) {
-        assertEquals(getMetadata(name), value, prefix(message) + "Metadata mismatch with name: " + name);
+    public void assertMetadata(String name, Object expectedValue, String message) {
+        assertEquals(expectedValue, getMetadata(name), prefix(message) + "model <%s> has wrong metadata with name <%s>".formatted(this, name));
+    }
+
+    public void assertMetadataPresent(String name) {
+        assertMetadataPresent(name, null);
+    }
+
+    public void assertMetadataPresent(String name, String message) {
+        assertTrue(hasMetadata(name), prefix(message) + "model <%s> is missing metadata with name <%s>".formatted(this, name));
     }
 
     public void assertMetadataAbsent(String name) {
@@ -31,11 +52,18 @@ public class TestingModel extends ModelImpl {
     }
 
     public void assertMetadataAbsent(String name, String message) {
-        assertFalse(hasMetadata(name), prefix(message) + "Unexpected metadata with name: " + name);
+        assertFalse(hasMetadata(name), prefix(message) + "model <%s> has metadata with name <%s>".formatted(this, name));
     }
 
     @Override
     public String salt() {
         throw new UnsupportedOperationException("Unimplemented method 'salt'");
     }
+
+    @Override
+    public String toString() {
+        return name == null ? super.toString() : "%s(name=%s)".formatted(getClass().getSimpleName(), name);
+    }
+
+    public static final class Subclass extends TestingModel {}
 }

--- a/src/test/java/com/ignfab/minalac/generator/parameters/models/ModelSelectionParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/models/ModelSelectionParamsTest.java
@@ -24,10 +24,10 @@ public class ModelSelectionParamsTest {
 
         // Testing validation of filter is done and exception transmitted to caller
 
-        params.filter = new TestingModelFilterParams(false);
+        params.filter = TestingModelFilterParams.INVALID;
         assertThrows(IllegalArgumentException.class, params::validate);
 
-        params.filter = new TestingModelFilterParams(true);
+        params.filter = TestingModelFilterParams.VALID;
         assertDoesNotThrow(params::validate);
     }
 
@@ -39,7 +39,7 @@ public class ModelSelectionParamsTest {
         params = new ModelSelectionParams("aa");
         assertInstanceOf(ModelSelection.class, assertDoesNotThrow(() -> params.create(store)));
 
-        params.filter = new TestingModelFilterParams();
+        params.filter = TestingModelFilterParams.VALID;
         assertInstanceOf(ModelSelection.class, assertDoesNotThrow(() -> params.create(store)));
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/parameters/models/filters/ModelFilterAndParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/models/filters/ModelFilterAndParamsTest.java
@@ -16,8 +16,8 @@ public class ModelFilterAndParamsTest {
     public void testConstructor() {
         assertDoesNotThrow(() -> new ModelFilterAndParams(List.of()));
         assertDoesNotThrow(() -> new ModelFilterAndParams(List.of(
-            new TestingModelFilterParams(),
-            new TestingModelFilterParams()
+            TestingModelFilterParams.VALID,
+            TestingModelFilterParams.VALID
         )));
     }
 
@@ -26,14 +26,14 @@ public class ModelFilterAndParamsTest {
         ModelFilterParams params;
 
         params = new ModelFilterAndParams(List.of(
-            new TestingModelFilterParams(true)
+            TestingModelFilterParams.VALID
         ));
         assertDoesNotThrow(params::validate);
 
         params = new ModelFilterAndParams(List.of(
-            new TestingModelFilterParams(true),
-            new TestingModelFilterParams(false),
-            new TestingModelFilterParams(false)
+            TestingModelFilterParams.VALID,
+            TestingModelFilterParams.INVALID,
+            TestingModelFilterParams.INVALID
         ));
         assertThrows(IllegalArgumentException.class, params::validate);
 
@@ -44,13 +44,13 @@ public class ModelFilterAndParamsTest {
 
     @Test
     public void testCreate() {
-        Model model1 = new TestingModel();
-        Model model2 = new TestingModel();
+        Model model1 = new TestingModel("1");
+        Model model2 = new TestingModel("2");
 
         ModelFilterParams params;
         Predicate<Model> filter;
 
-        // Check we realy have a "AND" at the end
+        // Check we really have an "AND" at the end
 
         params = new ModelFilterAndParams(List.of(
             new TestingModelFilterParams(model1),
@@ -76,7 +76,7 @@ public class ModelFilterAndParamsTest {
         // Check we have same predicate if it is the only element in list
 
         params = new ModelFilterAndParams(List.of(
-            new TestingModelFilterParams(true, model1)
+            new TestingModelFilterParams(model1)
         ));
         filter = assertDoesNotThrow(params::create);
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/models/filters/ModelFilterNotParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/models/filters/ModelFilterNotParamsTest.java
@@ -13,13 +13,13 @@ public class ModelFilterNotParamsTest {
 
     @Test
     public void testConstructor() {
-        assertDoesNotThrow(() -> new ModelFilterNotParams(new TestingModelFilterParams(true, null)));
+        assertDoesNotThrow(() -> new ModelFilterNotParams(TestingModelFilterParams.VALID));
     }
 
     @Test
     public void testValidate() {
-        ModelFilterParams valid = new ModelFilterNotParams(new TestingModelFilterParams(true, null));
-        ModelFilterParams invalid = new ModelFilterNotParams(new TestingModelFilterParams(false, null));
+        ModelFilterParams valid = new ModelFilterNotParams(TestingModelFilterParams.VALID);
+        ModelFilterParams invalid = new ModelFilterNotParams(TestingModelFilterParams.INVALID);
 
         assertThrows(IllegalArgumentException.class, invalid::validate);
         assertDoesNotThrow(valid::validate);
@@ -27,10 +27,10 @@ public class ModelFilterNotParamsTest {
 
     @Test
     public void testCreate() {
-        Model model1 = new TestingModel();
-        Model model2 = new TestingModel();
+        Model model1 = new TestingModel("1");
+        Model model2 = new TestingModel("2");
 
-        ModelFilterParams params = new ModelFilterNotParams(new TestingModelFilterParams(true, model1));
+        ModelFilterParams params = new ModelFilterNotParams(new TestingModelFilterParams(model1));
 
         Predicate<Model> filter = assertDoesNotThrow(params::create);
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/models/filters/ModelFilterOrParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/models/filters/ModelFilterOrParamsTest.java
@@ -16,8 +16,8 @@ public class ModelFilterOrParamsTest {
     public void testConstructor() {
         assertDoesNotThrow(() -> new ModelFilterOrParams(List.of()));
         assertDoesNotThrow(() -> new ModelFilterOrParams(List.of(
-            new TestingModelFilterParams(true, null),
-            new TestingModelFilterParams(true, null)
+            TestingModelFilterParams.VALID,
+            TestingModelFilterParams.VALID
         )));
     }
 
@@ -26,13 +26,13 @@ public class ModelFilterOrParamsTest {
         ModelFilterParams params;
 
         params = new ModelFilterOrParams(List.of(
-            new TestingModelFilterParams(true, null)
+            TestingModelFilterParams.VALID
         ));
         assertDoesNotThrow(params::validate);
 
         params = new ModelFilterOrParams(List.of(
-            new TestingModelFilterParams(true, null),
-            new TestingModelFilterParams(false, null)
+            TestingModelFilterParams.VALID,
+            TestingModelFilterParams.INVALID
         ));
         assertThrows(IllegalArgumentException.class, params::validate);
 
@@ -42,14 +42,14 @@ public class ModelFilterOrParamsTest {
 
     @Test
     public void testCreate() {
-        Model model1 = new TestingModel();
-        Model model2 = new TestingModel();
-        Model model3 = new TestingModel();
+        Model model1 = new TestingModel("1");
+        Model model2 = new TestingModel("2");
+        Model model3 = new TestingModel("3");
 
         ModelFilterParams params;
         Predicate<Model> filter;
 
-        // Check we realy have a "OR" at the end
+        // Check we really have an "OR" at the end
 
         params = new ModelFilterOrParams(List.of(
             new TestingModelFilterParams(model2),
@@ -66,7 +66,7 @@ public class ModelFilterOrParamsTest {
         // Check we have same predicate if it is the only element in list
 
         params = new ModelFilterOrParams(List.of(
-            new TestingModelFilterParams(true, model1)
+            new TestingModelFilterParams(model1)
         ));
         filter = assertDoesNotThrow(params::create);
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/models/filters/TestingModelFilterParams.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/models/filters/TestingModelFilterParams.java
@@ -10,8 +10,17 @@ import com.ignfab.minalac.generator.models.filters.TestingModelFilter;
  * filter (it says ok to models equals to model given in constructor).
  */
 public class TestingModelFilterParams extends ModelFilterParams {
-    boolean valid;
-    Model model;
+    private final boolean valid;
+    private final Model model;
+
+    /**
+     * A valid testing model filter params.
+     */
+    public static final TestingModelFilterParams VALID = new TestingModelFilterParams();
+    /**
+     * An invalid testing model filter params.
+     */
+    public static final TestingModelFilterParams INVALID = new TestingModelFilterParams(false);
 
     public TestingModelFilterParams(boolean valid, Model model) {
         this.valid = valid;
@@ -20,20 +29,17 @@ public class TestingModelFilterParams extends ModelFilterParams {
 
     // Simplified constructor for validate() only tests
     public TestingModelFilterParams(boolean valid) {
-        this.valid = valid;
-        this.model = null;
+        this(valid, null);
     }
 
     // Simplified constructor for create() only tests
     public TestingModelFilterParams(Model model) {
-        this.valid = true;
-        this.model = model;
+        this(true, model);
     }
 
     // The yolo constructor for constructors tests
     public TestingModelFilterParams() {
-        this.valid = true;
-        this.model = null;
+        this(true, null);
     }
 
     @Override

--- a/src/test/java/com/ignfab/minalac/generator/parameters/processors/post/ConditionalPostProcessorParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/processors/post/ConditionalPostProcessorParamsTest.java
@@ -1,0 +1,76 @@
+package com.ignfab.minalac.generator.parameters.processors.post;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.ignfab.minalac.generator.models.Model;
+import com.ignfab.minalac.generator.models.TestingModel;
+import com.ignfab.minalac.generator.parameters.models.filters.TestingModelFilterParams;
+import com.ignfab.minalac.generator.processors.post.ConditionalPostProcessor;
+import com.ignfab.minalac.generator.processors.post.PostProcessor;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ConditionalPostProcessorParamsTest {
+    @Test
+    @DisplayName("Simple conditional post-processor params is valid")
+    public void testValidateValid() {
+        ConditionalPostProcessorParams valid = new ConditionalPostProcessorParams(
+            TestingModelFilterParams.VALID,
+            TestingPostProcessorParams.VALID
+        );
+        assertDoesNotThrow(valid::validate);
+    }
+
+    @Test
+    @DisplayName("Conditional post-processor params with an invalid model filter is invalid")
+    public void testValidateInvalidModelFilter() {
+        ConditionalPostProcessorParams invalid = new ConditionalPostProcessorParams(
+            TestingModelFilterParams.INVALID,
+            TestingPostProcessorParams.VALID
+        );
+        assertThrows(IllegalArgumentException.class, invalid::validate);
+    }
+
+    @Test
+    @DisplayName("Conditional post-processor params with an invalid post-processor is invalid")
+    public void testValidateInvalidPostProcessor() {
+        ConditionalPostProcessorParams invalidIfTrue = new ConditionalPostProcessorParams(
+            TestingModelFilterParams.VALID,
+            TestingPostProcessorParams.INVALID
+        );
+        assertThrows(IllegalArgumentException.class, invalidIfTrue::validate);
+
+        ConditionalPostProcessorParams invalidIfFalse = new ConditionalPostProcessorParams(
+            TestingModelFilterParams.VALID,
+            TestingPostProcessorParams.VALID
+        );
+        invalidIfFalse.postProcessorIfFalse = TestingPostProcessorParams.INVALID;
+        assertThrows(IllegalArgumentException.class, invalidIfFalse::validate);
+    }
+
+    @Test
+    @DisplayName("Conditional post-processor params creates the correct conditional post-processor")
+    public void testCreate() {
+        TestingModel matching = new TestingModel("matching");
+        TestingModel notMatching = new TestingModel("not-matching");
+
+        ConditionalPostProcessorParams params = new ConditionalPostProcessorParams(
+            new TestingModelFilterParams(matching),
+            new TestingPostProcessorParams("matched")
+        );
+        params.postProcessorIfFalse = new TestingPostProcessorParams("not-matched");
+        @SuppressWarnings("unchecked") // TestingPostProcessor is generic
+        PostProcessor<Model, ?> postProcessor = (PostProcessor<Model, ?>) assertDoesNotThrow(params::create);
+        assertInstanceOf(ConditionalPostProcessor.class, postProcessor);
+
+        assertDoesNotThrow(() -> {
+            postProcessor.process(matching);
+            postProcessor.process(notMatching);
+        });
+        matching.assertMetadataPresent("matched");
+        matching.assertMetadataAbsent("not-matched");
+        notMatching.assertMetadataPresent("not-matched");
+        notMatching.assertMetadataAbsent("matched");
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/parameters/processors/post/DiscardPostProcessorParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/processors/post/DiscardPostProcessorParamsTest.java
@@ -1,0 +1,14 @@
+package com.ignfab.minalac.generator.parameters.processors.post;
+
+import org.junit.jupiter.api.Test;
+
+import com.ignfab.minalac.generator.processors.post.DiscardPostProcessor;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class DiscardPostProcessorParamsTest {
+    @Test
+    public void testCreate() {
+        assertSame(DiscardPostProcessor.INSTANCE, new DiscardPostProcessorParams().create());
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/parameters/processors/post/IdentityPostProcessorParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/processors/post/IdentityPostProcessorParamsTest.java
@@ -1,0 +1,14 @@
+package com.ignfab.minalac.generator.parameters.processors.post;
+
+import org.junit.jupiter.api.Test;
+
+import com.ignfab.minalac.generator.processors.post.IdentityPostProcessor;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class IdentityPostProcessorParamsTest {
+    @Test
+    public void testCreate() {
+        assertSame(IdentityPostProcessor.INSTANCE, new IdentityPostProcessorParams().create());
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/parameters/processors/post/JTSGeometryBufferPostProcessorParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/processors/post/JTSGeometryBufferPostProcessorParamsTest.java
@@ -1,0 +1,34 @@
+package com.ignfab.minalac.generator.parameters.processors.post;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.ignfab.minalac.generator.processors.post.JTSGeometryBufferPostProcessor;
+import com.ignfab.minalac.generator.processors.post.PostProcessor;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class JTSGeometryBufferPostProcessorParamsTest {
+    @Test
+    @DisplayName("Simple JTS geometry buffer post-processor params is valid")
+    public void testValidateValid() {
+        JTSGeometryBufferPostProcessorParams valid = new JTSGeometryBufferPostProcessorParams(7);
+        assertDoesNotThrow(valid::validate);
+    }
+
+    @Test
+    @DisplayName("JTS geometry buffer post-processor params with an invalid buffer is invalid")
+    public void testValidateInvalid() {
+        JTSGeometryBufferPostProcessorParams invalid = new JTSGeometryBufferPostProcessorParams(Double.NaN);
+        assertThrows(IllegalArgumentException.class, invalid::validate);
+    }
+
+    @Test
+    @DisplayName("JTS geometry buffer post-processor params creates a JTS geometry post-processor")
+    public void testCreate() {
+        JTSGeometryBufferPostProcessorParams params = new JTSGeometryBufferPostProcessorParams(-2);
+        params.discardEmptyResults = true;
+        PostProcessor<?, ?> postProcessor = assertDoesNotThrow(params::create);
+        assertInstanceOf(JTSGeometryBufferPostProcessor.class, postProcessor);
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/parameters/processors/post/PostProcessorParamsDeserializerTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/processors/post/PostProcessorParamsDeserializerTest.java
@@ -1,0 +1,26 @@
+package com.ignfab.minalac.generator.parameters.processors.post;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.ignfab.minalac.generator.parameters.ParamsTester;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class PostProcessorParamsDeserializerTest {
+    @Test
+    @DisplayName("Test multiple post-processing steps deserialization using list")
+    public void testList() {
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        mapper.registerSubtypes(new NamedType(IdentityPostProcessorParams.class, "identity"));
+
+        PostProcessorParams params = assertDoesNotThrow(() -> ParamsTester.deserialize(PostProcessorParams.class, """
+            - type: identity
+            - type: identity
+            """, mapper));
+        assertInstanceOf(SequentialPostProcessorParams.class, params);
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/parameters/processors/post/SequentialPostProcessorParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/processors/post/SequentialPostProcessorParamsTest.java
@@ -1,0 +1,80 @@
+package com.ignfab.minalac.generator.parameters.processors.post;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.ignfab.minalac.generator.processors.post.IdentityPostProcessor;
+import com.ignfab.minalac.generator.processors.post.PostProcessor;
+import com.ignfab.minalac.generator.processors.post.SequentialPostProcessor;
+import com.ignfab.minalac.generator.processors.post.TestingPostProcessor;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SequentialPostProcessorParamsTest {
+    @Test
+    @DisplayName("Empty sequential post-processor params is valid")
+    public void testValidateEmpty() {
+        SequentialPostProcessorParams empty = new SequentialPostProcessorParams(List.of());
+        assertDoesNotThrow(empty::validate);
+    }
+
+    @Test
+    @DisplayName("Sequential post-processor params with a single post-processor is valid")
+    public void testValidateSingle() {
+        SequentialPostProcessorParams single = new SequentialPostProcessorParams(List.of(
+            TestingPostProcessorParams.VALID
+        ));
+        assertDoesNotThrow(single::validate);
+    }
+
+    @Test
+    @DisplayName("Sequential post-processor params with multiple post-processors is valid")
+    public void testValidateMultiple() {
+        SequentialPostProcessorParams multiple = new SequentialPostProcessorParams(List.of(
+            TestingPostProcessorParams.VALID,
+            TestingPostProcessorParams.VALID
+        ));
+        assertDoesNotThrow(multiple::validate);
+    }
+
+    @Test
+    @DisplayName("Sequential post-processor params with an invalid post-processor is invalid")
+    public void testValidateInvalid() {
+        SequentialPostProcessorParams invalid = new SequentialPostProcessorParams(List.of(
+            TestingPostProcessorParams.VALID,
+            TestingPostProcessorParams.INVALID
+        ));
+        assertThrows(IllegalArgumentException.class, invalid::validate);
+    }
+
+    @Test
+    @DisplayName("Empty sequential post-processor params creates an identity post-processor")
+    public void testCreateEmpty() {
+        SequentialPostProcessorParams emptyParams = new SequentialPostProcessorParams(List.of());
+        PostProcessor<?, ?> emptyPostProcessor = assertDoesNotThrow(emptyParams::create);
+        assertSame(IdentityPostProcessor.INSTANCE, emptyPostProcessor);
+    }
+
+    @Test
+    @DisplayName("Sequential post-processor params with a single post-processor creates that post-processor")
+    public void testCreateSingle() {
+        SequentialPostProcessorParams singleParams = new SequentialPostProcessorParams(List.of(
+            TestingPostProcessorParams.VALID
+        ));
+        PostProcessor<?, ?> singlePostProcessor = assertDoesNotThrow(singleParams::create);
+        assertInstanceOf(TestingPostProcessor.class, singlePostProcessor);
+    }
+
+    @Test
+    @DisplayName("Sequential post-processor params with multiple post-processors creates a sequential post-processor")
+    public void testCreateMultiple() {
+        SequentialPostProcessorParams multipleParams = new SequentialPostProcessorParams(List.of(
+            TestingPostProcessorParams.VALID,
+            TestingPostProcessorParams.VALID
+        ));
+        PostProcessor<?, ?> multiplePostProcessor = assertDoesNotThrow(multipleParams::create);
+        assertInstanceOf(SequentialPostProcessor.class, multiplePostProcessor);
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/parameters/processors/post/TestingPostProcessorParams.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/processors/post/TestingPostProcessorParams.java
@@ -1,0 +1,49 @@
+package com.ignfab.minalac.generator.parameters.processors.post;
+
+import com.ignfab.minalac.generator.processors.post.PostProcessor;
+import com.ignfab.minalac.generator.processors.post.TestingPostProcessor;
+
+/**
+ * A {@code PostProcessorParams} for testing purposes.
+ */
+public class TestingPostProcessorParams extends PostProcessorParams {
+    private final String mark;
+    private final boolean valid;
+
+    /**
+     * A valid testing post-processor params.
+     */
+    public static final TestingPostProcessorParams VALID = new TestingPostProcessorParams();
+    /**
+     * An invalid testing post-processor params.
+     */
+    public static final TestingPostProcessorParams INVALID = new TestingPostProcessorParams(false);
+
+    public TestingPostProcessorParams(String mark, boolean valid) {
+        this.mark = mark;
+        this.valid = valid;
+    }
+
+    public TestingPostProcessorParams(String mark) {
+        this(mark, true);
+    }
+
+    public TestingPostProcessorParams(boolean valid) {
+        this(null, valid);
+    }
+
+    public TestingPostProcessorParams() {
+        this(null, true);
+    }
+
+    @Override
+    public void validate() {
+        if (!valid)
+            throw new IllegalArgumentException();
+    }
+
+    @Override
+    public PostProcessor<?, ?> create() {
+        return new TestingPostProcessor(mark);
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/processors/post/ConditionalPostProcessorTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/processors/post/ConditionalPostProcessorTest.java
@@ -1,0 +1,75 @@
+package com.ignfab.minalac.generator.processors.post;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.ignfab.minalac.generator.models.Model;
+import com.ignfab.minalac.generator.models.TestingModel;
+import com.ignfab.minalac.generator.models.filters.TestingModelFilter;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ConditionalPostProcessorTest {
+    private TestingModel modelA;
+    private TestingModel modelB;
+    private TestingModel modelC;
+
+    @BeforeEach
+    public void setUp() {
+        modelA = new TestingModel("A", Map.of("value", 7));
+        modelB = new TestingModel("B", Map.of("value", "test"));
+        modelC = new TestingModel("C");
+    }
+
+    private void processAll(ConditionalPostProcessor<? super TestingModel, ?> postProcessor) {
+        Model processedModelA = assertDoesNotThrow(() -> postProcessor.process(modelA));
+        Model processedModelB = assertDoesNotThrow(() -> postProcessor.process(modelB));
+        Model processedModelC = assertDoesNotThrow(() -> postProcessor.process(modelC));
+        modelA = processedModelA == null ? null : assertInstanceOf(TestingModel.class, processedModelA);
+        modelB = processedModelB == null ? null : assertInstanceOf(TestingModel.class, processedModelB);
+        modelC = processedModelC == null ? null : assertInstanceOf(TestingModel.class, processedModelC);
+    }
+
+    @Test
+    @DisplayName("Conditional post-processor processes models using the correct underlying post-processor")
+    public void testProcess() {
+        TestingPostProcessor testingPostProcessor1 = new TestingPostProcessor();
+        TestingPostProcessor testingPostProcessor2 = new TestingPostProcessor();
+        processAll(new ConditionalPostProcessor<>(new TestingModelFilter(modelB), testingPostProcessor1, testingPostProcessor2));
+
+        testingPostProcessor1.assertNotPostProcessed(modelA);
+        testingPostProcessor1.assertPostProcessed(modelB);
+        testingPostProcessor1.assertNotPostProcessed(modelC);
+
+        testingPostProcessor2.assertPostProcessed(modelA);
+        testingPostProcessor2.assertNotPostProcessed(modelB);
+        testingPostProcessor2.assertPostProcessed(modelC);
+    }
+
+    @Test
+    @DisplayName("Conditional post-processor returns the model processed by its underlying post-processors")
+    public void testReturnValue() {
+        TestingModel a = modelA;
+        TestingModel b = modelB;
+        processAll(new ConditionalPostProcessor<>(new TestingModelFilter(modelC), DiscardPostProcessor.INSTANCE, IdentityPostProcessor.INSTANCE));
+        assertSame(a, modelA);
+        assertSame(b, modelB);
+        assertNull(modelC);
+    }
+
+    @Test
+    @DisplayName("Conditional post-processor respects the processing type of its underlying post-processors")
+    public void testCheckProcessingType() {
+        ConditionalPostProcessor<?, ?> postProcessor = new ConditionalPostProcessor<>(
+            new TestingModelFilter(modelA),
+            new PostProcessorTest.ComplexPostProcessor(),
+            IdentityPostProcessor.INSTANCE
+        );
+        assertThrows(IllegalArgumentException.class, () -> postProcessor.checkProcessingType(Model.class));
+        Class<?> processedModelType = assertDoesNotThrow(() -> postProcessor.checkProcessingType(TestingModel.class));
+        assertEquals(TestingModel.class, processedModelType);
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/processors/post/DiscardPostProcessorTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/processors/post/DiscardPostProcessorTest.java
@@ -1,0 +1,16 @@
+package com.ignfab.minalac.generator.processors.post;
+
+import org.junit.jupiter.api.Test;
+
+import com.ignfab.minalac.generator.models.Model;
+import com.ignfab.minalac.generator.models.TestingModel;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class DiscardPostProcessorTest {
+    @Test
+    public void testProcess() {
+        Model model = new TestingModel();
+        assertNull(DiscardPostProcessor.INSTANCE.process(model));
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/processors/post/IdentityPostProcessorTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/processors/post/IdentityPostProcessorTest.java
@@ -1,0 +1,16 @@
+package com.ignfab.minalac.generator.processors.post;
+
+import org.junit.jupiter.api.Test;
+
+import com.ignfab.minalac.generator.models.Model;
+import com.ignfab.minalac.generator.models.TestingModel;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class IdentityPostProcessorTest {
+    @Test
+    public void testProcess() {
+        Model model = new TestingModel();
+        assertSame(model, IdentityPostProcessor.INSTANCE.process(model));
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/processors/post/JTSGeometryBufferPostProcessorTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/processors/post/JTSGeometryBufferPostProcessorTest.java
@@ -1,0 +1,64 @@
+package com.ignfab.minalac.generator.processors.post;
+
+import org.geotools.referencing.operation.transform.IdentityTransform;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.geom.util.AffineTransformation;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
+
+import com.ignfab.minalac.generator.exceptions.TransformException;
+import com.ignfab.minalac.generator.models.JTSGeometryModel;
+import com.ignfab.minalac.generator.utils.coordinates.MapToWorldConverter;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class JTSGeometryBufferPostProcessorTest {
+    private JTSGeometryModel model;
+
+    private static final MapToWorldConverter IDENTITY_CONVERTER = new MapToWorldConverter(IdentityTransform.create(2), new AffineTransformation());
+    private static final WKTReader WKT_READER = new WKTReader();
+
+    @BeforeEach
+    public void setUp() throws ParseException, TransformException {
+        model = new JTSGeometryModel(WKT_READER.read("POLYGON ((0 0, 5 0, 5 5, 0 5, 0 0))"), IDENTITY_CONVERTER);
+    }
+
+    private JTSGeometryModel process(JTSGeometryBufferPostProcessor postProcessor) {
+        JTSGeometryModel processed = assertDoesNotThrow(() -> postProcessor.process(model));
+        if (processed != null)
+            assertSame(model, processed);
+        return processed;
+    }
+
+    @Test
+    @DisplayName("JTS geometry buffer post-processor with positive buffer distance")
+    public void testPositive() {
+        JTSGeometryModel processed = process(new JTSGeometryBufferPostProcessor(2, true));
+        assertEquals(new Envelope(-2, 7, -2, 7), processed.getGeometry().getEnvelopeInternal());
+    }
+
+    @Test
+    @DisplayName("JTS geometry buffer post-processor with negative buffer distance")
+    public void testNegative() {
+        JTSGeometryModel processed = process(new JTSGeometryBufferPostProcessor(-1, true));
+        assertEquals(new Envelope(1, 4, 1, 4), processed.getGeometry().getEnvelopeInternal());
+    }
+
+    @Test
+    @DisplayName("JTS geometry buffer post-processor discarding model")
+    public void testDiscard() {
+        JTSGeometryModel processed = process(new JTSGeometryBufferPostProcessor(-3, true));
+        assertNull(processed);
+    }
+
+    @Test
+    @DisplayName("JTS geometry buffer post-processor keeping model")
+    public void testKeep() {
+        JTSGeometryModel processed = process(new JTSGeometryBufferPostProcessor(-3, false));
+        assertNotNull(processed);
+        assertTrue(processed.getGeometry().isEmpty());
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/processors/post/MetadataCopyPostProcessorTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/processors/post/MetadataCopyPostProcessorTest.java
@@ -22,13 +22,6 @@ public class MetadataCopyPostProcessorTest {
         ));
     }
 
-    @Test
-    public void testCapabilities() {
-        MetadataCopyPostProcessor postProcessor = new MetadataCopyPostProcessor("a", "d", false, false);
-        assertTrue(postProcessor.acceptedModelType().isAssignableFrom(TestingModel.class), "post-processor accepts any model type");
-        assertTrue(TestingModel.class.isAssignableFrom(postProcessor.processedModelType(TestingModel.class)), "post-processor produces same model type");
-    }
-
     private TestingModel getProcessed(MetadataCopyPostProcessor postProcessor) {
         Model processedModel = assertDoesNotThrow(() -> postProcessor.process(model));
         return assertInstanceOf(TestingModel.class, processedModel);

--- a/src/test/java/com/ignfab/minalac/generator/processors/post/MetadataDefaultPostProcessorTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/processors/post/MetadataDefaultPostProcessorTest.java
@@ -1,27 +1,37 @@
 package com.ignfab.minalac.generator.processors.post;
 
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.ignfab.minalac.generator.models.Model;
 import com.ignfab.minalac.generator.models.TestingModel;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 public class MetadataDefaultPostProcessorTest {
-    @Test
-    public static void testConstructor() {
-        assertDoesNotThrow(() -> new MetadataDefaultPostProcessor("toto", 1));
+    private Model model;
+
+    @BeforeEach
+    public void setUp() {
+        model = new TestingModel(Map.of("value", 7));
+    }
+
+    private TestingModel getProcessed(MetadataDefaultPostProcessor postProcessor) {
+        Model processedModel = assertDoesNotThrow(() -> postProcessor.process(model));
+        return assertInstanceOf(TestingModel.class, processedModel);
     }
 
     @Test
-    public void testProcess() {
-        MetadataDefaultPostProcessor processor = new MetadataDefaultPostProcessor("toto", 1);
-        TestingModel model = new TestingModel();
+    public void testMetadataAbsent() {
+        TestingModel processed = getProcessed(new MetadataDefaultPostProcessor("extra", 42));
+        processed.assertMetadata("extra", 42);
+    }
 
-        assertDoesNotThrow(() -> processor.process(model));
-        model.assertMetadata("toto", 1);
-
-        model.setMetadata("toto", 10);
-        assertDoesNotThrow(() -> processor.process(model));
-        model.assertMetadata("toto", 10);
+    @Test
+    public void testMetadataPresent() {
+        TestingModel processed = getProcessed(new MetadataDefaultPostProcessor("value", 42));
+        processed.assertMetadata("value", 7);
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/processors/post/MetadataParsePostProcessorTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/processors/post/MetadataParsePostProcessorTest.java
@@ -2,7 +2,6 @@ package com.ignfab.minalac.generator.processors.post;
 
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Function;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,19 +22,6 @@ public class MetadataParsePostProcessorTest {
             "string", "value",
             "int", 7
         ));
-    }
-
-    @Test
-    public void testCapabilities() {
-        MetadataParsePostProcessor<?> postProcessor = new MetadataParsePostProcessor<>(
-            "name",
-            Object.class,
-            Function.identity(),
-            MetadataParsePostProcessor.ParsingFailurePolicy.IGNORE,
-            MetadataParsePostProcessor.ParsingFailurePolicy.IGNORE
-        );
-        assertTrue(postProcessor.acceptedModelType().isAssignableFrom(TestingModel.class), "post-processor accepts any model type");
-        assertTrue(TestingModel.class.isAssignableFrom(postProcessor.processedModelType(TestingModel.class)), "post-processor produces same model type");
     }
 
     private TestingModel getProcessed(MetadataParsePostProcessor<?> postProcessor) {

--- a/src/test/java/com/ignfab/minalac/generator/processors/post/PostProcessorTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/processors/post/PostProcessorTest.java
@@ -1,0 +1,51 @@
+package com.ignfab.minalac.generator.processors.post;
+
+import org.junit.jupiter.api.Test;
+
+import com.ignfab.minalac.generator.models.Model;
+import com.ignfab.minalac.generator.models.TestingModel;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class PostProcessorTest {
+    @Test
+    public void testGenericCapabilities() {
+        TestingPostProcessor postProcessor = new TestingPostProcessor();
+        Class<? extends Model> processedModelType = assertDoesNotThrow(() -> postProcessor.checkProcessingType(TestingModel.class), "post-processor accepts any model type");
+        assertTrue(TestingModel.class.isAssignableFrom(processedModelType), "post-processor produces same model type");
+    }
+
+    @Test
+    public void testSimpleCapabilities() {
+        SimplePostProcessor postProcessor = new SimplePostProcessor();
+        Class<? extends TestingModel> processedModelType = assertDoesNotThrow(() -> postProcessor.checkProcessingType(TestingModel.Subclass.class), "post-processor accepts given model type");
+        assertTrue(TestingModel.Subclass.class.isAssignableFrom(processedModelType), "post-processor produces same model type");
+
+        assertThrows(IllegalArgumentException.class, () -> postProcessor.checkProcessingType(Model.class), "post-processor rejects other model types");
+    }
+
+    public static final class SimplePostProcessor extends PostProcessor.Simple<TestingModel> {
+        SimplePostProcessor() {
+            super(TestingModel.class);
+        }
+
+        @Override
+        public TestingModel process(TestingModel model) {
+            return null;
+        }
+    }
+
+    public static final class ComplexPostProcessor implements PostProcessor<TestingModel, TestingModel.Subclass> {
+        @Override
+        public Class<? extends TestingModel.Subclass> checkProcessingType(Class<? extends Model> inputModelType) throws IllegalArgumentException {
+            if (!TestingModel.class.isAssignableFrom(inputModelType))
+                throw new IllegalArgumentException();
+            return TestingModel.Subclass.class;
+        }
+
+        @Override
+        public TestingModel.Subclass process(TestingModel model) {
+            return null;
+        }
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/processors/post/SequentialPostProcessorTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/processors/post/SequentialPostProcessorTest.java
@@ -1,0 +1,56 @@
+package com.ignfab.minalac.generator.processors.post;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.ignfab.minalac.generator.models.Model;
+import com.ignfab.minalac.generator.models.TestingModel;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SequentialPostProcessorTest {
+    private TestingModel model;
+    private TestingPostProcessor ppA;
+    private TestingPostProcessor ppB;
+    private TestingPostProcessor ppC;
+
+    @BeforeEach
+    public void setUp() {
+        model = new TestingModel();
+        ppA = new TestingPostProcessor("A");
+        ppB = new TestingPostProcessor("B");
+        ppC = new TestingPostProcessor("C");
+    }
+
+    private TestingModel getProcessed(SequentialPostProcessor<? super TestingModel, ?> postProcessor) {
+        Model processedModel = assertDoesNotThrow(() -> postProcessor.process(model));
+        return processedModel == null ? null : assertInstanceOf(TestingModel.class, processedModel);
+    }
+
+    @Test
+    @DisplayName("Sequential post-processor applies its underlying post-processors")
+    public void testSimple() {
+        TestingModel processed = getProcessed(new SequentialPostProcessor<>(List.of(ppA, ppB, ppC)));
+        assertSame(model, processed);
+        ppA.assertPostProcessed(model);
+        ppB.assertPostProcessed(model);
+        ppC.assertPostProcessed(model);
+    }
+
+    @Test
+    @DisplayName("Sequential post-processor checks the processing types of its underlying post-processors")
+    public void testCheckProcessingType() {
+        SequentialPostProcessor<?, ?> postProcessor = new SequentialPostProcessor<>(List.of(
+            new TestingPostProcessor(),
+            new PostProcessorTest.ComplexPostProcessor(),
+            new PostProcessorTest.SimplePostProcessor(),
+            new TestingPostProcessor()
+        ));
+        assertThrows(IllegalArgumentException.class, () -> postProcessor.checkProcessingType(Model.class));
+        Class<?> processedModelType = assertDoesNotThrow(() -> postProcessor.checkProcessingType(TestingModel.class));
+        assertEquals(TestingModel.Subclass.class, processedModelType);
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/processors/post/SequentialPostProcessorTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/processors/post/SequentialPostProcessorTest.java
@@ -41,6 +41,16 @@ public class SequentialPostProcessorTest {
     }
 
     @Test
+    @DisplayName("Sequential post-processor stops when model is discarded by one of its underlying post-processors")
+    public void testDiscarded() {
+        TestingModel discarded = getProcessed(new SequentialPostProcessor<>(List.of(ppA, ppB, DiscardPostProcessor.INSTANCE, ppC)));
+        assertNull(discarded);
+        ppA.assertPostProcessed(model);
+        ppB.assertPostProcessed(model);
+        ppC.assertNotPostProcessed(model);
+    }
+
+    @Test
     @DisplayName("Sequential post-processor checks the processing types of its underlying post-processors")
     public void testCheckProcessingType() {
         SequentialPostProcessor<?, ?> postProcessor = new SequentialPostProcessor<>(List.of(

--- a/src/test/java/com/ignfab/minalac/generator/processors/post/TestingPostProcessor.java
+++ b/src/test/java/com/ignfab/minalac/generator/processors/post/TestingPostProcessor.java
@@ -1,0 +1,52 @@
+package com.ignfab.minalac.generator.processors.post;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.ignfab.minalac.generator.models.Model;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestingPostProcessor extends PostProcessor.Generic {
+    private final String mark;
+
+    private static final AtomicInteger COUNTER = new AtomicInteger();
+
+    public TestingPostProcessor(String mark) {
+        this.mark = mark == null ? "testing-" + COUNTER.incrementAndGet() : mark;
+    }
+
+    public TestingPostProcessor() {
+        this(null);
+    }
+
+    @Override
+    public Model process(Model model) {
+        model.setMetadata(mark, true);
+        return model;
+    }
+
+    @Override
+    public String toString() {
+        return "%s(mark=%s)".formatted(getClass().getSimpleName(), mark);
+    }
+
+    public void assertPostProcessed(Model model, String message) {
+        assertTrue(model.hasMetadata(mark), prefix(message) + "model <%s> was not post-processed by <%s>".formatted(model, this));
+    }
+
+    public void assertPostProcessed(Model model) {
+        assertPostProcessed(model, null);
+    }
+
+    public void assertNotPostProcessed(Model model, String message) {
+        assertFalse(model.hasMetadata(mark), prefix(message) + "model <%s> was post-processed by <%s>".formatted(model, this));
+    }
+
+    public void assertNotPostProcessed(Model model) {
+        assertNotPostProcessed(model, null);
+    }
+
+    private static String prefix(String message) {
+        return message == null ? "" : message + " ==> ";
+    }
+}


### PR DESCRIPTION
### Type of modification

- Code
  - Inputs
- Documentation
  - Markdown Files
- Tests

### Changes

This PR improves post-processing with better control over the post-processing steps and new post-processors.

#### Feature description

A data source was composed of a provider, a processor, and a list of post-processors. The "list of post-processors" part has been extracted to its own post-processor: `SequentialPostProcessor`. A custom deserializer has been added to seamlessly handle a list of post-processing steps from the config as a single post-processor params. The old behavior of having an empty post-processors list can know be achieved by the `identity` post-processor, which is the default value in the data source params, so that post-processing is still optional. The field `postProcessors` has been renamed to `postProcessing`, to better match the fact it can be either a single post-processor or a list of post-processing steps.

Three new post-processors have also been added:
- `geometryBuffer`: to apply a buffer around the geometry of a model. Only supports JTS models.
- `discard`: to completely discard the model (it won't be added to the model store).
- `conditional`: to apply different post-processing based on a model filter.

On the other hand, the way post-processors describe their capabilities (the type of models they can handle) has been merged into a single method `checkProcessingType`, simplifying in the same time the creation of post-processors, with default implementations like `PostProcessor.Simple` (accepting a fixed model type and returning the same type as output) or `PostProcessor.Generic` (simple post-processor with `Model`).

Parameters documentation has been extracted from `docs/usage/GenerationParameters.md` to its own file `docs/usage/PostProcessing.md`.

#### Showcase

Post-processing steps for buildings could be (just an example):
```yml
postProcessing:
  - type: parse
    metadata: height
    as: decimal
    ifMissing: ignore
    ifNotParsable: removeMetadata
  - type: default
    metadata: height
    value: 5
    as: integer
  - type: conditional
    if:
      metadata: height
      lowerThan: 3
    then:
      type: discard
```

### Reason

The data source was responsible of the handling of that sequence of post-processors, but all it needed to know was it was running some post-processing. Furthermore, it wasn't possible to make something else accept a list of post-processors as well without having to rewrite that logic.

The new post-processors will be used to improve the current rendering, as well as offer new possibilities for the future. Especially the conditional post-processor will be absolutely necessary to fine-tune the post-processing treatments applied to some models, in order to greatly improve the result.

### Self-checks

- [x] The code has unit tests associated
- [x] The code has Javadoc Comments associated
- [x] Complex / Unexpected code is explained / justified with a small comment
- [x] Relevant documentation inside the `/docs` folder has been updated
- [x] All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [x] The texts have been proofread (documentation, error messages, logs, comments...)
