### PR TITLE
Small adjustments on the Docker build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,9 +8,6 @@ on:
     - Dockerfile
     - .m2-settings.xml
     - .github/workflows/docker.yml
-  pull_request:
-    branches:
-    - "*"
 
 env:
   REGISTRY: ghcr.io

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN <<EOF
 EOF
 
 # Build
-RUN mvn clean package
+RUN mvn -Dmaven.test.skip=true clean package
 
 #
 # Package stage

--- a/docs/usage/Docker.md
+++ b/docs/usage/Docker.md
@@ -23,22 +23,22 @@ docker build --no-cache \
 
 ## Run image locally
 
-Here, the generation parameters are passed from an example file to the container using the `MINALAC_PARAMS` environment variable. A local `output/` directory must have been created beforehand.
+Here, the generation parameters are computed using the utility script `generate.sh` (with the `-y` option) and passed to the container using the `MINALAC_PARAMS` environment variable. A local `output/` directory must have been created beforehand.
 
 ```shell
 mkdir output
-MINALAC_PARAMS=$(cat examples/minecraft.yaml) docker run \
+MINALAC_PARAMS=$(./generate.sh -y minetest full ign) docker run \
     -u $(id -u ${USER}):$(id -g ${USER}) \
     -v ./output:/output \
     -e MINALAC_PARAMS \
     minalac-generator
 ```
 
-If corporate proxy is needed use the `JAVA_TOOL_OPTIONS` environment variable to declare it:
+If corporate proxy is needed, use the `JAVA_TOOL_OPTIONS` environment variable to declare it:
 
 ```shell
 mkdir output
-MINALAC_PARAMS=$(cat examples/minecraft.yaml) docker run \
+MINALAC_PARAMS=$(./generate.sh -y minetest full ign) docker run \
     -u $(id -u ${USER}):$(id -g ${USER}) \
     -v ./output:/output \
     -e MINALAC_PARAMS \


### PR DESCRIPTION
### Type of modification

- Documentation
  - Markdown Files
- CI/CD
- Other: Dockerfile

### Changes

This PR fixes the docker build GitHub workflow triggering twice (sometimes), made the Dockerfile build ignores unit tests and updated some outdated docs.

#### Feature description

In some cases, especially when opening a PR with existing commits, the docker build GitHub workflow is trigger both by the `push` event, and the `pull_request` event. In fact, in our case, it's absolutely fine to limit it to the `push` event, because every interaction that could lead to a different docker image result would require a push to be made, somehow.

On the other hand, the Dockerfile used `RUN mvn clean package`, which works but also runs the unit tests, which are irrelevant here because it would result in failing the build, in a situation where it was avoidable. In fact, we have a GitHub workflow dedicated to unit testing, so that situation is covered, so it's better to try to provide a docker image on a best effort basis, that could maybe lead to some more tests in the future (we could imagine having a test environment to run integration tests based on that image).

Finally, the documentation about the docker usage was outdated since the parameters files are no longer static but now computed from the `generate.sh` script. The text and examples are now up-to-date.

#### Showcase

You can see the double trigger for example in this PR: https://github.com/ignfab/minalac-generator/pull/98/checks

Also, you can see in that PR that the unit tests fails (see the "Unit-Tests" workflow failing), and the docker build workflow fails as well, despite the build succeeds (see the "Build JAR" workflow passing).

### Reason

Duplicate workflow runs are pointless and wastes resources.

Failing to build the docker image because of unit tests seemed a bit rude. However, I can see the point of this being verified in some situations, so maybe adding a switch to tell in the docker build (as a build arg?) whether to run unit tests or not might comes in handy in the future.

Outdated docs is bad. How surprising?

### Self-checks

- ~~The code has unit tests associated~~
- ~~The code has Javadoc Comments associated~~
- ~~Complex / Unexpected code is explained / justified with a small comment~~
- [x] Relevant documentation inside the `/docs` folder has been updated
- ~~All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)~~
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [x] The texts have been proofread (documentation, error messages, logs, comments...)
