### PR TITLE
feat(world): Add descending column voxel iterator

### DIFF
--- a/src/main/java/com/ignfab/minalac/generator/generation/heightmaps/Heightmap.java
+++ b/src/main/java/com/ignfab/minalac/generator/generation/heightmaps/Heightmap.java
@@ -12,6 +12,10 @@ import com.ignfab.minalac.generator.utils.world2d.WorldSize2d;
 public class Heightmap implements ReadableHeightmap {
     private final WorldBBox2d bbox;
     private int[] values;
+    /**
+     * A reusable instance of an empty {@link Heightmap}.
+     */
+    public static final Heightmap EMPTY = new Heightmap(WorldBBox2d.EMPTY, 0);
 
     /**
      * Creates a new {@link Heightmap}.

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelType.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelType.java
@@ -1,8 +1,11 @@
 package com.ignfab.minalac.generator.outputs.minecraft;
 
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import net.querz.nbt.tag.CompoundTag;
+import net.querz.nbt.tag.StringTag;
 
 import com.ignfab.minalac.generator.placeables.VoxelType;
 
@@ -49,6 +52,29 @@ public class MCVoxelType implements VoxelType {
     }
 
     /**
+     * Creates a new instance of {@link MCVoxelType} from a {@link CompoundTag} and a {@link MCVoxelWorld}.
+     *
+     * @param block the {@code CompoundTag} representing a block.
+     * @param world the world in which the voxel can be placed
+     * @return a new {@code MCVoxelType}
+     */
+    public static MCVoxelType fromBlockState(CompoundTag block, MCVoxelWorld world) {
+        String type = block.getStringTag("Name").getValue();
+
+        CompoundTag propertiesTag = block.getCompoundTag("Properties");
+        if (propertiesTag != null) {
+            Map<String, String> properties = new HashMap<>();
+            propertiesTag.forEach(entry -> properties.put(
+                entry.getKey(),
+                ((StringTag) entry.getValue()).getValue()
+            ));
+            return new MCVoxelType(world, type, properties);
+        }
+
+        return new MCVoxelType(world, type);
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override
@@ -61,5 +87,18 @@ public class MCVoxelType implements VoxelType {
             block.put("Properties", state);
         }
         world.setBlockState(x, z, -y - 1, block); // X/Y/Z => X/Z/-Y
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MCVoxelType that = (MCVoxelType) o;
+        return world == that.world && type.equals(that.type) && Objects.equals(properties, that.properties);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(world, type, properties);
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelWorld.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelWorld.java
@@ -17,6 +17,7 @@ import net.querz.nbt.tag.IntTag;
 import net.querz.nbt.tag.ListTag;
 import net.querz.nbt.tag.StringTag;
 
+import com.ignfab.minalac.generator.placeables.VoxelType;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldSize3d;
@@ -471,6 +472,8 @@ public class MCVoxelWorld extends VoxelWorld {
 
         if (isOutOfLimits(blockX, blockY, blockZ)) return;
         getOrCreateRegion(blockX, blockZ).file().setBlockStateAt(blockX, blockY, blockZ, block, false);
+        // (In-Game coords to world coords) X/Z/-Y => X/Y/Z
+        updateHeightmaps(blockX, -(blockZ + 1), blockY);
     }
 
     // In-Game coords
@@ -496,6 +499,21 @@ public class MCVoxelWorld extends VoxelWorld {
             regions.put(key, region);
         }
         return region;
+    }
+
+    /**
+     * {@inheritDoc}
+     * The returned voxel is not necessarily one placed using {@link VoxelType#place}.
+     * It may be an air block created when a {@link Region} is initialized.
+     */
+    @Override
+    public VoxelType getVoxel(int x, int y, int z) {
+        Region region = regions.get(computeRegionKey(MCAUtil.blockToRegion(x), MCAUtil.blockToRegion(-y - 1)));
+
+        if (region == null) return null;
+
+        // (World coords to In-Game coords) X/Y/Z => X/Z/-Y-1
+        return region.getBlock(x, z, -y - 1, this);
     }
 
     // In-Game coords

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/Region.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/Region.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import net.querz.mca.Chunk;
 import net.querz.mca.MCAFile;
 import net.querz.mca.MCAUtil;
+import net.querz.nbt.tag.CompoundTag;
 
 /**
  * Represents a Minecraft region.
@@ -80,5 +81,19 @@ public record Region(int regionX, int regionZ, MCAFile file) {
      */
     public static Region load(String regionsDirectory, int regionX, int regionZ) throws IOException {
         return new Region(regionX, regionZ, MCAUtil.read(new File(regionsDirectory, MCAUtil.createNameFromRegionLocation(regionX, regionZ))));
+    }
+
+    /**
+     * Returns a block as a new {@link MCVoxelType}.
+     *
+     * @param blockX the in-game x-coordinate
+     * @param blockY the in-game y-coordinate
+     * @param blockZ the in-game z-coordinate
+     * @param world the {@code MCVoxelWorld} in which the voxel can be placed
+     * @return the corresponding voxel, or {@code null} if it doesn't exist
+     */
+    public MCVoxelType getBlock(int blockX, int blockY, int blockZ, MCVoxelWorld world) {
+        CompoundTag block = file().getBlockStateAt(blockX, blockY, blockZ);
+        return (block == null) ? null : MCVoxelType.fromBlockState(block, world);
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/Block.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/Block.java
@@ -33,15 +33,13 @@ public class Block {
      * Places the specified voxel on the block by updating the block's three array parameters.
      * The coordinate system is the one used in Minetest.
      *
-     * @param x the x-coordinate value relatively to the block
-     * @param y the y-coordinate value relatively to the block
-     * @param z the z-coordinate value relatively to the block
+     * @param nodeX the x-coordinate value relatively to the block
+     * @param nodeY the y-coordinate value relatively to the block
+     * @param nodeZ the z-coordinate value relatively to the block
      * @param voxel the {@link MTVoxelType} to place within the block
      */
-    public void set(int x, int y, int z, MTVoxelType voxel) {
-        // Node location on arrays
-        // https://github.com/minetest/minetest/blob/master/doc/world_format.md#node-data
-        int i = z << 8 | y << 4 | x;
+    public void set(int nodeX, int nodeY, int nodeZ, MTVoxelType voxel) {
+        int i = nodeCoordsToIndex(nodeX, nodeY, nodeZ);
         param0[i] = getOrCreateIdForType(voxel.getType());
         param1[i] = voxel.getParam1();
         param2[i] = voxel.getParam2();
@@ -106,5 +104,16 @@ public class Block {
      */
     public byte[] getParam2() {
         return param2;
+    }
+
+    private int nodeCoordsToIndex(int nodeX, int nodeY, int nodeZ) {
+        // Node location on arrays
+        // https://github.com/minetest/minetest/blob/master/doc/world_format.md#node-data
+        return nodeZ << 8 | nodeY << 4 | nodeX;
+    }
+
+    protected MTVoxelType get(int nodeX, int nodeY, int nodeZ, MTVoxelWorld world) {
+        int i = nodeCoordsToIndex(nodeX, nodeY, nodeZ);
+        return new MTVoxelType(world, nameIdMapping.get((int) param0[i]), param1[i], param2[i]);
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelType.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelType.java
@@ -1,5 +1,7 @@
 package com.ignfab.minalac.generator.outputs.minetest;
 
+import java.util.Objects;
+
 import com.ignfab.minalac.generator.placeables.VoxelType;
 
 /**
@@ -74,5 +76,18 @@ public class MTVoxelType implements VoxelType {
      */
     public byte getParam2() {
         return param2;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MTVoxelType that = (MTVoxelType) o;
+        return param1 == that.param1 && param2 == that.param2 && world == that.world && type.equals(that.type);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(world, type, param1, param2);
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelWorld.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelWorld.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.ignfab.minalac.generator.outputs.minetest.utils.SQLiteMapWriter;
+import com.ignfab.minalac.generator.placeables.VoxelType;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
 import com.ignfab.minalac.generator.world.MapWriteException;
@@ -45,10 +46,8 @@ public class MTVoxelWorld extends VoxelWorld {
     }
 
     // Retrieves or creates the mapblock corresponding to given voxel position.
-    private Block getOrCreateBlock(int x, int y, int z) {
-        // See position hashing algorithm on world format documentation
-        // https://github.com/minetest/minetest/blob/master/doc/world_format.md#position-hashing
-        Integer pos = z * 16777216 + y * 4096 + x;
+    private Block getOrCreateBlock(int blockX, int blockY, int blockZ) {
+        Integer pos = coordsToPos(blockX, blockY, blockZ);
 
         Block block = blocks.get(pos);
         if (block == null)
@@ -60,6 +59,16 @@ public class MTVoxelWorld extends VoxelWorld {
                 }
             }
         return block;
+    }
+
+    private Block getBlock(int blockX, int blockY, int blockZ) {
+        return blocks.get(coordsToPos(blockX, blockY, blockZ));
+    }
+
+    private Integer coordsToPos(int blockX, int blockY, int blockZ) {
+        // See position hashing algorithm on world format documentation
+        // https://github.com/minetest/minetest/blob/master/doc/world_format.md#position-hashing
+        return blockZ * 16777216 + blockY * 4096 + blockX;
     }
 
     /**
@@ -76,6 +85,9 @@ public class MTVoxelWorld extends VoxelWorld {
         if (!limits().contains(x, z, y)) return;
 
         getOrCreateBlock(x >> 4, y >> 4, z >> 4).set(x & 0x0f, y & 0x0f, z & 0x0f, voxel);
+
+        // (In-Game coords to world coords) XZY => XYZ
+        updateHeightmaps(x, z, y);
     }
 
     /**
@@ -119,5 +131,21 @@ public class MTVoxelWorld extends VoxelWorld {
         } catch (IOException e) {
             throw new MapWriteException(e);
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     * The returned voxel is not necessarily one placed using {@link VoxelType#place}.
+     * It may be an air node created when a {@link Block} is initialized.
+     */
+    @Override
+    public VoxelType getVoxel(int x, int y, int z) {
+        // X/Y/Z => X/Z/Y
+        Block block = getBlock(x >> 4, z >> 4, y >> 4);
+
+        if (block == null) return null;
+
+        // X/Y/Z => X/Z/Y
+        return block.get(x & 0x0f, z & 0x0f, y & 0x0f, this);
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/world/PlacedVoxel.java
+++ b/src/main/java/com/ignfab/minalac/generator/world/PlacedVoxel.java
@@ -1,0 +1,12 @@
+package com.ignfab.minalac.generator.world;
+
+import com.ignfab.minalac.generator.placeables.VoxelType;
+import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
+
+/**
+ * Represents a voxel placed in the world along its coordinates.
+ *
+ * @param voxel a new instance of the {@link VoxelType} placed.
+ * @param coords the {@link WorldCoords3d} where the voxel is placed.
+ */
+public record PlacedVoxel(VoxelType voxel, WorldCoords3d coords) {}

--- a/src/main/java/com/ignfab/minalac/generator/world/VoxelColumnIterator.java
+++ b/src/main/java/com/ignfab/minalac/generator/world/VoxelColumnIterator.java
@@ -1,0 +1,57 @@
+package com.ignfab.minalac.generator.world;
+
+import java.util.Iterator;
+
+import com.ignfab.minalac.generator.placeables.VoxelType;
+import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
+
+/**
+ * A descending iterator over the voxels and associated coordinates of a world's column.
+ * It is the default iterator of {@link VoxelWorld} and, as such, it is not optimized for its implementations.
+ */
+public class VoxelColumnIterator implements Iterator<PlacedVoxel> {
+    private final VoxelWorld world;
+    private final int x;
+    private final int y;
+    private final int zMin;
+    private int currentZ;
+    private VoxelType currentVoxel;
+
+    /**
+     * Constructs a new {@code VoxelColumnIterator}.
+     *
+     * @param world the world
+     * @param x x-coordinate of the column to iterate over
+     * @param y y-coordinate of the column to iterate over
+     * @param zMin z-coordinate of the lowest column voxel
+     * @param zMax z-coordinate of the highest column voxel
+     */
+    public VoxelColumnIterator(VoxelWorld world, int x, int y, int zMin, int zMax) {
+        this.world = world;
+        this.x = x;
+        this.y = y;
+        this.zMin = zMin;
+        currentZ = zMax + 1;
+        moveOn();
+    }
+
+    private void moveOn() {
+        currentVoxel = null;
+        while (currentZ > zMin && currentVoxel == null) {
+            currentZ--;
+            currentVoxel = world.getVoxel(x, y, currentZ);
+        }
+    }
+
+    @Override
+    public boolean hasNext() {
+        return currentVoxel != null;
+    }
+
+    @Override
+    public PlacedVoxel next() {
+        PlacedVoxel next = new PlacedVoxel(currentVoxel, new WorldCoords3d(x, y, currentZ));
+        moveOn();
+        return next;
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/world/VoxelWorld.java
+++ b/src/main/java/com/ignfab/minalac/generator/world/VoxelWorld.java
@@ -1,7 +1,11 @@
 package com.ignfab.minalac.generator.world;
 
 import java.io.File;
+import java.util.Collections;
+import java.util.Iterator;
 
+import com.ignfab.minalac.generator.generation.heightmaps.Heightmap;
+import com.ignfab.minalac.generator.placeables.VoxelType;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 
 /**
@@ -19,10 +23,20 @@ public abstract class VoxelWorld {
      * The metadata of the world.
      */
     protected final VoxelWorldMetadata metadata;
+    /**
+     * Heightmap representing the altitude of the highest voxels.
+     */
+    protected Heightmap minimum;
+    /**
+     * Heightmap representing the altitude of the lowest voxels.
+     */
+    protected Heightmap maximum;
 
     protected VoxelWorld(VoxelWorldMetadata metadata) {
-        limits = new WorldBBox3d(0, 0, 0, 0, 0, 0);
+        limits = WorldBBox3d.EMPTY;
         this.metadata = metadata;
+        minimum = Heightmap.EMPTY;
+        maximum = Heightmap.EMPTY;
     }
 
     /**
@@ -39,6 +53,8 @@ public abstract class VoxelWorld {
         if (!this.limits.isEmpty())
             throw new IllegalStateException("The limits have already been set");
         this.limits = limits;
+        minimum = new Heightmap(limits().to2d(), limits().maxZ());
+        maximum = new Heightmap(limits().to2d(), limits().minZ());
     }
 
     /**
@@ -74,4 +90,55 @@ public abstract class VoxelWorld {
      * @throws MapWriteException if an error occurs while writing to the specified destination.
      */
     public abstract void save(File destination) throws MapWriteException;
+
+    /**
+     * Updates the internal minimum or maximum heightmap at the coordinate (x, y) based on the provided z-coordinate value.
+     *
+     * @param x x-coordinate
+     * @param y y-coordinate
+     * @param z z-coordinate
+     */
+    protected void updateHeightmaps(int x, int y, int z) {
+        if (z > maximum.get(x, y))
+            maximum.set(x, y, z);
+        if (z < minimum.get(x, y))
+            minimum.set(x, y, z);
+    }
+
+    /**
+     * Returns the voxel located at the given coordinates as a new {@code VoxelType}.
+     *
+     * @param x x-coordinate
+     * @param y y-coordinate
+     * @param z z-coordinate
+     * @return the corresponding voxel and {@code null} if the voxel doesn't exist.
+     */
+    public abstract VoxelType getVoxel(int x, int y, int z);
+
+    /**
+     * Returns a descending iterator over the voxels and associated coordinates of a column of this world.
+     *
+     * @param x x-coordinate of the column to iterate over
+     * @param y y-coordinate of the column to iterate over
+     * @return an iterator for the pair of voxels and coordinates
+     */
+    public Iterator<PlacedVoxel> voxelIterator(int x, int y) {
+        int minZ = minimum.get(x, y);
+        int maxZ = maximum.get(x, y);
+        if (maxZ < minZ)
+            return Collections.emptyIterator();
+
+        return new VoxelColumnIterator(this, x, y, minZ, maxZ);
+    }
+
+    /**
+     * Returns an iterable over the voxels and associated coordinates of a column of this world.
+     *
+     * @param x x-coordinate of the column to iterate over
+     * @param y y-coordinate of the column to iterate over
+     * @return an iterable for the pair of voxels and coordinates
+     */
+    public Iterable<PlacedVoxel> voxels(int x, int y) {
+        return () -> this.voxelIterator(x, y);
+    }
 }

--- a/src/test/java/com/ignfab/minalac/generator/generation/TestGeneration.java
+++ b/src/test/java/com/ignfab/minalac/generator/generation/TestGeneration.java
@@ -13,6 +13,7 @@ import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
 
 import com.ignfab.minalac.generator.exceptions.TransformException;
+import com.ignfab.minalac.generator.placeables.VoxelType;
 import com.ignfab.minalac.generator.utils.coordinates.MapToWorldConverter;
 import com.ignfab.minalac.generator.utils.random.Seed;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
@@ -101,6 +102,11 @@ public class TestGeneration {
 
         @Override
         public void save(File destination) throws MapWriteException {
+        }
+
+        @Override
+        public VoxelType getVoxel(int x, int y, int z) {
+            return null;
         }
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelWorldTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelWorldTest.java
@@ -3,11 +3,13 @@ package com.ignfab.minalac.generator.outputs.minecraft;
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import net.querz.nbt.tag.CompoundTag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import com.ignfab.minalac.generator.placeables.VoxelType;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
 
@@ -70,5 +72,31 @@ public class MCVoxelWorldTest {
         assertTrue(world.isOutOfLimits(-11, 0, 19));
         assertTrue(world.isOutOfLimits(-10, -1, 19));
         assertTrue(world.isOutOfLimits(-10, 0, 20));
+    }
+
+    @Test
+    public void testGetVoxel() {
+        MCVoxelWorld world = new MCVoxelWorld();
+        world.setLimits(new WorldBBox3d(new WorldCoords3d(-20, -20, 0), new WorldCoords3d(50, 50, 255)));
+        VoxelType stone = new MCVoxelType(world, "minecraft:stone");
+        VoxelType barrel = new MCVoxelType(world, "minecraft:barrel", Map.of(
+            "facing", "south",
+            "open", "true"
+        ));
+        VoxelType dirt = new MCVoxelType(world, "minecraft:dirt");
+        barrel.place(-9, -8, 1);
+        stone.place(4, -3, 78);
+        dirt.place(-7, 5, 55);
+
+        assertEquals(barrel, world.getVoxel(-9, -8, 1));
+        assertEquals(stone, world.getVoxel(4, -3, 78));
+        assertEquals(dirt, world.getVoxel(-7, 5, 55));
+
+        // Minecraft zMax
+        dirt.place(3, 4, 255);
+        assertEquals(dirt, world.getVoxel(3, 4, 255));
+        // Minecraft zMin
+        barrel.place(-9, -8, 0);
+        assertEquals(barrel, world.getVoxel(-9, -8, 0));
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelWorldTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelWorldTest.java
@@ -1,0 +1,52 @@
+package com.ignfab.minalac.generator.outputs.minetest;
+
+import org.junit.jupiter.api.Test;
+
+import com.ignfab.minalac.generator.placeables.VoxelType;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class MTVoxelWorldTest {
+    private static MTVoxelWorld world;
+    private static VoxelType grass;
+    private static VoxelType dirt;
+    private static VoxelType stone;
+
+    private void initWorld(WorldBBox3d limits) {
+        world = new MTVoxelWorld();
+        world.setLimits(limits);
+        grass = new MTVoxelType(world, "default:dirt_with_grass", (byte) 0, (byte) 0);
+        dirt = new MTVoxelType(world, "default:dirt", (byte) 0, (byte) 0);
+        stone = new MTVoxelType(world, "default:stone", (byte) 0, (byte) 0);
+    }
+
+
+    @Test
+    public void testGetVoxel() {
+        initWorld(new WorldBBox3d(new WorldCoords3d(-1, -2, -5), new WorldCoords3d(2, 3, 6)));
+        grass.place(-1, -2, -3);
+        stone.place(0, -1, 1);
+        dirt.place(-1, 0, 0);
+
+        assertEquals(grass, world.getVoxel(-1, -2, -3));
+        assertEquals(stone, world.getVoxel(0, -1, 1));
+        assertEquals(dirt, world.getVoxel(-1, 0, 0));
+
+        initWorld(new WorldBBox3d(new WorldCoords3d(-5, -5, -20), new WorldCoords3d(50, 50, 500)));
+
+        // Extremum of a map block [-16, -1]
+        stone.place(-2, -3, -1);
+        grass.place(-2, -3, -16);
+        // Extremum of another map block [16, 31]
+        dirt.place(37, 16, 387);
+        stone.place(37, 31, 387);
+
+        // Testing on MT max limits
+        assertEquals(stone, world.getVoxel(-2, -3, -1));
+        assertEquals(grass, world.getVoxel(-2, -3, -16));
+        assertEquals(dirt, world.getVoxel(37, 16, 387));
+        assertEquals(stone, world.getVoxel(37, 31, 387));
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/outputs/testing/TestingVoxelType.java
+++ b/src/test/java/com/ignfab/minalac/generator/outputs/testing/TestingVoxelType.java
@@ -1,5 +1,7 @@
 package com.ignfab.minalac.generator.outputs.testing;
 
+import java.util.Objects;
+
 import com.ignfab.minalac.generator.placeables.VoxelType;
 
 /**
@@ -47,5 +49,18 @@ public class TestingVoxelType implements VoxelType {
      */
     protected String getType() {
         return type;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TestingVoxelType that = (TestingVoxelType) o;
+        return world == that.world && Objects.equals(type, that.type);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(world, type);
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/outputs/testing/TestingVoxelWorld.java
+++ b/src/test/java/com/ignfab/minalac/generator/outputs/testing/TestingVoxelWorld.java
@@ -2,6 +2,7 @@ package com.ignfab.minalac.generator.outputs.testing;
 
 import java.io.File;
 
+import com.ignfab.minalac.generator.placeables.VoxelType;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
 import com.ignfab.minalac.generator.world.MapWriteException;
@@ -48,6 +49,13 @@ public class TestingVoxelWorld extends VoxelWorld {
     @Override
     public void save(File destination) throws MapWriteException {}
 
+    @Override
+    public VoxelType getVoxel(int x, int y, int z) {
+        if (!limits().contains(x, y, z)) return null;
+        String type = voxels[index(x, y, z)];
+        return type == null ? null : new TestingVoxelType(this, type);
+    }
+
     // This method should not be called with out of bounds coordinate
     private int index(int x, int y, int z) {
         return x - limits().minX() + limits().sizeX()
@@ -68,8 +76,10 @@ public class TestingVoxelWorld extends VoxelWorld {
      * @param value Voxel value to set at this position
      */
     public void set(int x, int y, int z, String value) {
-        if (limits().contains(x, y, z))
+        if (limits().contains(x, y, z)) {
             voxels[index(x, y, z)] = value;
+            updateHeightmaps(x, y, z);
+        }
     }
 
     /**

--- a/src/test/java/com/ignfab/minalac/generator/outputs/testing/TestingVoxelWorldTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/outputs/testing/TestingVoxelWorldTest.java
@@ -38,6 +38,11 @@ public class TestingVoxelWorldTest {
         vt2.place(3, 4, 5);
         world.assertVoxel("AA", 1, 2, 3);
         world.assertVoxel("BB", 3, 4, 5);
+
+        assertEquals(vt1, world.getVoxel(1, 2, 3));
+        assertEquals(vt2, world.getVoxel(3, 4, 5));
+        assertNull(world.getVoxel(0, 0, 0));
+        assertNull(world.getVoxel(3, 2, 5));
     }
 
     @Test

--- a/src/test/java/com/ignfab/minalac/generator/world/VoxelWorldTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/world/VoxelWorldTest.java
@@ -1,9 +1,14 @@
 package com.ignfab.minalac.generator.world;
 
 import java.io.File;
+import java.util.Collections;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import com.ignfab.minalac.generator.outputs.testing.TestingVoxelType;
+import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
+import com.ignfab.minalac.generator.placeables.VoxelType;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
 
@@ -35,8 +40,55 @@ public class VoxelWorldTest {
                 new WorldCoords3d(7, 8, 9))
             );
         });
-
     }
+
+    @Test
+    public void testVoxelIterator() {
+        TestingVoxelWorld world = new TestingVoxelWorld(new WorldBBox3d(new WorldCoords3d(-1, -2, -5), new WorldCoords3d(2, 3, 6)));
+        VoxelType a = new TestingVoxelType(world, "aa");
+        VoxelType b = new TestingVoxelType(world, "b");
+        VoxelType c = new TestingVoxelType(world, "c");
+
+        a.place(-1, 2, 6);
+        a.place(-1, 2, -4);
+        c.place(-1, 2, -5);
+        b.place(-1, 2, 2);
+        c.place(-1, 2, 0);
+
+        b.place(1, -2, 1);
+        c.place(1, -2, -2);
+
+        assertDoesNotThrow(() -> {
+            assertIterableEquals(
+                List.of(
+                    new PlacedVoxel(a, new WorldCoords3d(-1, 2, 6)),
+                    new PlacedVoxel(b, new WorldCoords3d(-1, 2, 2)),
+                    new PlacedVoxel(c, new WorldCoords3d(-1, 2, 0)),
+                    new PlacedVoxel(a, new WorldCoords3d(-1, 2, -4)),
+                    new PlacedVoxel(c, new WorldCoords3d(-1, 2, -5))
+                ),
+                world.voxels(-1, 2)
+            );
+        });
+
+        assertDoesNotThrow(() -> {
+            assertIterableEquals(
+                List.of(
+                    new PlacedVoxel(b, new WorldCoords3d(1, -2, 1)),
+                    new PlacedVoxel(c, new WorldCoords3d(1, -2, -2))
+                ),
+                world.voxels(1, -2)
+            );
+        });
+
+        assertDoesNotThrow(() -> {
+            assertIterableEquals(
+                Collections.emptyList(),
+                world.voxels(0, -2)
+            );
+        });
+    }
+
     private static class VoxelWorldMock extends VoxelWorld {
 
         protected VoxelWorldMock() {
@@ -53,5 +105,10 @@ public class VoxelWorldTest {
 
         @Override
         public void save(File destination) throws MapWriteException {}
+
+        @Override
+        public VoxelType getVoxel(int x, int y, int z) {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
### Issue

[MINALAC-107](https://ignfab.atlassian.net/browse/MINALAC-107)

### Changes

Adds a descending voxel iterator over columns of the world.
#### Feature description

`VoxelWorld` provides an iterator overs pairs of placed `VoxelType` and `WorldCoords3d` at a specified position in the surface, starting from the highest placed voxel. It ignores placeholder voxels such as `air` or `minecraft:air`. 

`VoxelColumnIterator` is not optimized for `VoxelWorld` implementations as it checks the presence of voxels at each coordinates. (An optimized iterator for `MTVoxelWorld` could skip unexisting map blocks for example)

### Reason

This will be needed when creating the mini-map.

### Self-checks

- [x] The code has unit tests associated
- [x] The code has Javadoc Comments associated
- [x] Complex / Unexpected code is explained / justified with a small comment
- ~~Relevant documentation inside the `/docs` folder has been updated~~
-  ~~All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)~~
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [x] The texts have been proofread (documentation, error messages, logs, comments...)


[MINALAC-107]: https://ignfab.atlassian.net/browse/MINALAC-107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ