### PR TITLE
Improve `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,54 @@
+# https://gist.github.com/dedunumax/54e82214715e35439227
+
+##############################
+## Java
+##############################
+.mtj.tmp/
+*.class
+*.jar
+*.war
+*.ear
+*.nar
+hs_err_pid*
+replay_pid*
+
+##############################
+## Maven
+##############################
 target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+pom.xml.bak
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+.mvn/wrapper/maven-wrapper.jar
+
+##############################
+## IntelliJ
+##############################
+out/
 .idea/
-src/main/java/test/
+.idea_modules/
+*.iml
+*.ipr
+*.iws
+
+##############################
+## Visual Studio Code
+##############################
+.vscode/
+.code-workspace
+
+##############################
+## OS X
+##############################
+.DS_Store
+
+##############################
+## Miscellaneous
+##############################
+*.log


### PR DESCRIPTION
### Changes

`.gitignore` edited to ignore the `.vscode` folder.

### Reason

We (me instead :)) can make a mistake when we push edits quickly and push the `.vscode` folder.

### Self-checks

~~- [ ] The code has unit tests associated~~
~~- [ ] The code has Javadoc Comments associated~~
~~- [ ] Complex / Unexpected code is explained / justified with a small comment~~
~~- [ ] Relevant documentation inside the `/docs` folder has been updated~~
~~- [ ] All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)~~
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [ ] The texts have been proofread (documentation, error messages, logs, comments...)
