### PR TITLE
feat(scheduler): Make scheduler re-runnable

### DIFF
--- a/src/main/java/com/ignfab/minalac/generator/MinalacGenerator.java
+++ b/src/main/java/com/ignfab/minalac/generator/MinalacGenerator.java
@@ -4,10 +4,12 @@ import java.io.File;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.geotools.api.referencing.FactoryException;
 
+import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
 import com.ignfab.minalac.generator.exceptions.TransformException;
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.outputs.minecraft.MCVoxelWorld;
@@ -57,7 +59,7 @@ public final class MinalacGenerator {
      * @param args command line arguments
      * @throws JsonProcessingException
      */
-    public static void main(String[] args) throws FactoryException, InterruptedException, MapWriteException, ParseException, TaskFailedException, TransformException, JsonProcessingException {
+    public static void main(String[] args) throws FactoryException, InterruptedException, MapWriteException, ParseException, TaskFailedException, TransformException, JsonProcessingException, TimeoutException, GenerationFailedException {
         // Execution duration start
         Instant start = Instant.now();
         HttpTrustAllSSL.applyGlobally();
@@ -113,9 +115,8 @@ public final class MinalacGenerator {
         System.out.println("Creation of the map.");
         // Start generation duration
         Instant generationStart = Instant.now();
-        generation.scheduler().start();
         try {
-            generation.scheduler().waitUntilAllTasksFinished(5, TimeUnit.MINUTES);
+            generation.scheduler().run(5, TimeUnit.MINUTES);
         } finally {
             generation.scheduler().shutdown();
         }

--- a/src/main/java/com/ignfab/minalac/generator/parameters/DataSourceParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/DataSourceParams.java
@@ -1,6 +1,7 @@
 package com.ignfab.minalac.generator.parameters;
 
 import java.beans.ConstructorProperties;
+import java.util.ArrayList;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonSetter;
@@ -42,7 +43,8 @@ public class DataSourceParams {
     /**
      * Dependencies (optional).
      */
-    public List<String> after;
+    @JsonSetter(nulls = Nulls.SKIP)
+    public List<String> after = new ArrayList<>();
 
    /**
      * Constructor used to ensure that the required fields are present during deserialization.

--- a/src/main/java/com/ignfab/minalac/generator/parameters/GenerationCreator.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/GenerationCreator.java
@@ -69,9 +69,13 @@ public final class GenerationCreator {
             DataSource dataSource = dataSourceParams.create(generation);
             generation.scheduler().schedule(
                 "source:" + name,
-                () -> dataSource.fetch(generation.world().limits()),
-                dataSourceParams.after
+                () -> dataSource.fetch(generation.world().limits())
             );
+        });
+
+        params.sources.forEach((name, dataSourceParams) -> {
+            for (String depName : dataSourceParams.after)
+                generation.scheduler().addDependency("source:" + name, depName);
         });
 
         // Renderers scheduling
@@ -79,9 +83,13 @@ public final class GenerationCreator {
             Renderer renderer = rendererParams.create(generation);
             generation.scheduler().schedule(
                 "renderer:" + name,
-                () -> renderer.render(generation.world().limits()),
-                rendererParams.after
+                () -> renderer.render(generation.world().limits())
             );
+        });
+
+        params.renderers.forEach((name, rendererParams) -> {
+            for (String depName : rendererParams.after)
+                generation.scheduler().addDependency("renderer:" + name, depName);
         });
 
         return generation;

--- a/src/main/java/com/ignfab/minalac/generator/parameters/renderers/RendererParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/renderers/RendererParams.java
@@ -1,6 +1,10 @@
 package com.ignfab.minalac.generator.parameters.renderers;
 
+import java.util.ArrayList;
 import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.parameters.PolymorphicParams;
@@ -13,7 +17,8 @@ public abstract class RendererParams extends PolymorphicParams {
     /**
      * Dependencies (optional).
      */
-    public List<String> after;
+    @JsonSetter(nulls = Nulls.SKIP)
+    public List<String> after = new ArrayList<>();
 
     /**
      * Creates the corresponding {@code Renderer}.

--- a/src/main/java/com/ignfab/minalac/generator/utils/execution/ScheduledTask.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/execution/ScheduledTask.java
@@ -1,10 +1,9 @@
 package com.ignfab.minalac.generator.utils.execution;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 
 /**
  * A task registered in the {@link Scheduler}.
@@ -12,36 +11,90 @@ import java.util.Set;
 public class ScheduledTask {
     private final String id;
     private final Runnable task;
-    private final Set<String> conditions;
-    private ScheduledTaskState state = ScheduledTaskState.WAITING;
+    private final Set<ScheduledTask> dependencies;
+    private ScheduledTaskState state;
+    private TaskFailedException error;
+    private Future<?> future;
 
     /**
      * Creates a new task with the given characteristics.
      *
      * @param id the ID of the task
      * @param task the runnable to execute
-     * @param conditions the IDs of the tasks that need to complete before this one can run
      */
-    public ScheduledTask(String id, Runnable task, String... conditions) {
-        this(id, task, Arrays.asList(conditions));
+    public ScheduledTask(String id, Runnable task) {
+        this.id = id;
+        this.task = task;
+        this.dependencies = new HashSet<>();
+        reset();
     }
 
     /**
-     * Creates a new task with the given characteristics.
-     *
-     * @param id the ID of the task
-     * @param task the runnable to execute
-     * @param conditions the IDs of the tasks that need to complete before this one can run
+     * Resets this task so it can be re-executed.
      */
-    public ScheduledTask(String id, Runnable task, Collection<String> conditions) {
-        this.id = id;
-        this.task = task;
-        if (conditions == null)
-            conditions = Collections.emptyList();
+    public void reset() {
+        state = ScheduledTaskState.WAITING;
+        error = null;
+        future = null;
+    }
 
-        // Synchronized collections are thread-safe equivalent of regular collections
-        // This is important to ensure no problem occurs if two required tasks finishes at the same time
-        this.conditions = Collections.synchronizedSet(new HashSet<>(conditions));
+    /**
+     * Tries to submit this task for execution.
+     * The lock is used as a way to communicate to a potential main thread the end or failure of this task.
+     *
+     * @param executor the service where tasks are submitted for execution
+     * @param lock the lock used for communication
+     * @return true if the task was submitted for execution.
+     */
+    public boolean tryExecute(ExecutorService executor, Object lock) {
+        // Check if task can run
+        if (state != ScheduledTaskState.WAITING)
+            return false;
+        for (ScheduledTask task : dependencies)
+            if (task.state() != ScheduledTaskState.FINISHED)
+                return false;
+
+        // It can, let's go!
+        state = ScheduledTaskState.LAUNCHING;
+        future = executor.submit(() -> {
+            try {
+                Thread.currentThread().setName(id);
+                System.out.printf("Starting task %s%n", id);
+                state = ScheduledTaskState.RUNNING;
+                task.run();
+                state = ScheduledTaskState.FINISHED;
+                System.out.printf("Task %s finished%n", id);
+            } catch (RuntimeException e) {
+                // If an error occurs, we take note of the task failure
+                System.out.printf("Error in task %s%n", id);
+                error = new TaskFailedException(this, e);
+                state = ScheduledTaskState.FAILED;
+            } finally {
+                // On both cases, we wake up the main thread
+                // The synchronized block is mandatory to take ownership of the lock
+                synchronized (lock) {
+                    lock.notifyAll();
+                }
+            }
+        });
+        return true;
+    }
+
+    /**
+     * Interrupts this task if it is running.
+     */
+    public void cancel() {
+        if (future != null)
+            future.cancel(true);
+    }
+
+    /**
+     * Adds a task that needs to be completed before this task can be run.
+     *
+     * @param dependency the dependency task
+     */
+    protected void addDependency(ScheduledTask dependency) {
+        this.dependencies.add(dependency);
     }
 
     /**
@@ -49,27 +102,8 @@ public class ScheduledTask {
      *
      * @return the ID of the task
      */
-    public String getId() {
+    public String id() {
         return id;
-    }
-
-    /**
-     * Runs this task's runnable.
-     * This method will return when the runnable returns.
-     */
-    public void run() {
-        System.out.printf("[%s] %s%n", Thread.currentThread().getName(), "Starting " + id);
-        task.run();
-        System.out.printf("[%s] %s%n", Thread.currentThread().getName(), id + " finished");
-    }
-
-    /**
-     * Returns the IDs of the tasks that need to complete before this one can run.
-     *
-     * @return the conditions of this task
-     */
-    public Set<String> getConditions() {
-        return conditions;
     }
 
     /**
@@ -77,16 +111,17 @@ public class ScheduledTask {
      *
      * @return the state of this task
      */
-    public ScheduledTaskState getState() {
+    public ScheduledTaskState state() {
         return state;
     }
 
     /**
-     * Sets the state of this task.
+     * If an error occurred during execution of this task, returns the associated {@code TaskFailedException}.
      *
-     * @param state the new state of the task
+     * @return the associated {@code TaskFailedException}, {@code null} otherwise
      */
-    public void setState(ScheduledTaskState state) {
-        this.state = state;
+    public TaskFailedException error() {
+        return error;
     }
+
 }

--- a/src/main/java/com/ignfab/minalac/generator/utils/execution/ScheduledTaskState.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/execution/ScheduledTaskState.java
@@ -6,23 +6,27 @@ package com.ignfab.minalac.generator.utils.execution;
 public enum ScheduledTaskState {
     /**
      * The task is waiting for other tasks to complete.
-     * It will be launched once all conditions are fulfilled.
+     * It will be launched once all of its dependencies are finished.
      */
     WAITING,
     /**
-     * All conditions have been fulfilled, the task is being launched.
+     * All dependencies have been finished, the task is being launched.
      * It will be running once the execution service has a thread ready.
      */
     LAUNCHING,
     /**
      * The task is running.
      * It will be finished once the task's runnable returns.
-     * If an error occurs, it will stop everything and the state won't be updated.
+     * If this task is interrupted following {@link ScheduledTask#cancel()} the state won't be updated.
      */
     RUNNING,
     /**
      * The task has finished.
-     * It ran without error, and will be removed from the scheduler.
      */
-    FINISHED
+    FINISHED,
+
+    /**
+     * The task execution failed.
+     */
+    FAILED
 }

--- a/src/main/java/com/ignfab/minalac/generator/utils/execution/Scheduler.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/execution/Scheduler.java
@@ -1,13 +1,15 @@
 package com.ignfab.minalac.generator.utils.execution;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
 
 /**
  * A scheduler is a service managing execution of tasks.
@@ -16,120 +18,113 @@ import java.util.concurrent.TimeUnit;
 public class Scheduler {
     // An executor using a thread pool to run tasks
     private final ExecutorService executor = Executors.newCachedThreadPool();
-    // Synchronized collections are thread-safe equivalent of regular collections
-    // This is important to ensure no problem occurs if two required tasks finishes at the same time
-    private final List<ScheduledTask> tasks = Collections.synchronizedList(new ArrayList<>());
-
-    // Stores the exception that occurred, if any.
-    // Needed to pass the exception between threads
-    private TaskFailedException error = null;
-    // Object used for synchronized blocks, like a mutex.
+    private final Map<String, ScheduledTask> tasks = new HashMap<>();
+    // Object used for communication between the main thread and task threads.
     // .wait() / .notify() operations are performed on this object
     private final Object lock = new Object();
 
     /**
-     * Schedules the task to be executed when all conditions are fulfilled.
-     * If the task has no condition, it will be executed at {@link #start()}.
+     * Schedules the task to be executed when all dependencies are finished.
+     * If the task has no dependency, it will be executed at {@link #run(long, TimeUnit)}.
      *
      * @param id the ID of the task
      * @param task the task to be scheduled
-     * @param conditions the conditions before the task may run
      */
-    public void schedule(String id, Runnable task, Collection<String> conditions) {
-        schedule(new ScheduledTask(id, task, conditions));
+    public void schedule(String id, Runnable task) {
+        schedule(new ScheduledTask(id, task));
     }
 
     /**
-     * Schedules the task to be executed when all conditions are fulfilled.
-     * If the task has no condition, it will be executed at {@link #start()}.
-     *
-     * @param id the ID of the task
-     * @param task the task to be scheduled
-     * @param conditions the conditions before the task may run
-     */
-    public void schedule(String id, Runnable task, String... conditions) {
-        schedule(new ScheduledTask(id, task, conditions));
-    }
-
-    /**
-     * Schedules the task to be executed when all conditions are fulfilled.
-     * If the task has no condition, it will be executed at {@link #start()}.
+     * Schedules the task to be executed when all dependencies are finished.
+     * If the task has no condition, it will be executed at {@link #run(long, TimeUnit)}.
      *
      * @param task the task to be scheduled
      */
     public void schedule(ScheduledTask task) {
-        tasks.add(task);
-    }
-
-    // This method is synchronized to prevent multiple concurrent trigger of the same task
-    private synchronized void execute(ScheduledTask task) {
-        // Only a waiting task can be executed
-        if (task.getState() != ScheduledTaskState.WAITING)
-            return;
-        task.setState(ScheduledTaskState.LAUNCHING);
-        // The .execute() method asks for execution but real execution can be delayed if no thread is currently available
-        executor.execute(() -> {
-            try {
-                // Name current thread according to task id
-                Thread.currentThread().setName(task.getId());
-                task.setState(ScheduledTaskState.RUNNING);
-                task.run();
-                task.setState(ScheduledTaskState.FINISHED);
-                // The synchronized block prevents ConcurrentModificationException
-                synchronized (tasks) {
-                    // Once the task has been run, we remove it from our list
-                    // This is not strictly necessary, but avoid the need to loop on every
-                    // task and check their state to find out whether some task remains or not
-                    tasks.remove(task);
-                }
-                // Signals that the task finished to trigger any dependent task
-                conditionFulfilled(task.getId());
-                // If this was the last task, we wake up the main thread
-                // The synchronized block is mandatory to take ownership of the lock
-                synchronized (lock) {
-                    // The synchronized block prevents ConcurrentModificationException
-                    synchronized (tasks) {
-                        if (tasks.isEmpty())
-                            lock.notifyAll();
-                    }
-                }
-            } catch (RuntimeException e) {
-                // If an error occurs, we take note of the task failure and wake up the main thread
-                // The synchronized block is mandatory to take ownership of the lock
-                synchronized (lock) {
-                    error = new TaskFailedException(task, e);
-                    lock.notifyAll();
-                }
-            }
-        });
+        if (tasks.containsKey(task.id()))
+            throw new IllegalArgumentException("Task %s already scheduled".formatted(task.id()));
+        tasks.put(task.id(), task);
     }
 
     /**
-     * Signals the fulfillment of a condition.
-     * If this condition was the last one of the task, it will be executed.
+     * Makes {@code idTask} dependent on the completion of the specified {@code idDependency} task.
      *
-     * @param condition the fulfilled condition
+     * @param idTask the id of the task
+     * @param idDependency the id the dependency
      */
-    public void conditionFulfilled(String condition) {
-        // The synchronized block prevents ConcurrentModificationException
-        synchronized (tasks) {
-            for (ScheduledTask task : tasks) {
-                Set<String> conditions = task.getConditions();
-                conditions.remove(condition);
-                // If this was the last condition, the task may now run
-                if (conditions.isEmpty())
-                    execute(task);
-            }
+    public void addDependency(String idTask, String idDependency) {
+        getTask(idTask).addDependency(getTask(idDependency));
+    }
+
+    /**
+     * Starts this scheduler and waits for the completion of all tasks.
+     * This method can be used multiple times meaning the same set of tasks can be re-executed.
+     * When waiting for task completion, this thread is paused until all tasks are over, a single task fails, or the wait timed out.
+     * Following an exception there is an attempt to interrupt underlying tasks.
+     *
+     * @param timeout the maximum amount of time before timing out
+     * @param unit the unit of time for the timeout
+     * @throws TaskFailedException if a task fails
+     * @throws InterruptedException if the current thread was interrupted while waiting
+     * @throws TimeoutException if the wait timed out
+     * @throws GenerationFailedException for any other unexpected exceptions during execution
+     */
+    public void run(long timeout, TimeUnit unit) throws TaskFailedException, InterruptedException, TimeoutException, GenerationFailedException {
+        tasks.values().forEach(ScheduledTask::reset);
+        Future<Void> future = executor.submit(this::launchTasks);
+        try {
+            future.get(timeout, unit);
+        } catch (ExecutionException e) {
+            if (e.getCause() instanceof RuntimeException re)
+                throw re;
+            if (e.getCause() instanceof TaskFailedException tfe)
+                throw tfe;
+            throw new GenerationFailedException(e.getCause());
+        } finally {
+            // Attempt to interrupt any ongoing task in case of an error
+            tasks.values().forEach(ScheduledTask::cancel);
         }
     }
 
-    /**
-     * Starts this scheduler.
-     * Any task scheduled without condition will be executed right now.
-     */
-    public void start() {
-        // Simulates a condition fulfill to trigger tasks without any condition
-        this.conditionFulfilled(null);
+    // The method submit() of ExecutorService can take either a Runnable or Callable as parameter.
+    // Unlike Runnable, Callable can throw a checked exception, which is useful to easily propagate exceptions.
+    // This method signature return type is a Void solely to conform with the Callable interface.
+    private Void launchTasks() throws InterruptedException, TaskFailedException {
+        while (true) {
+            boolean hasRunningTasks = false;
+            boolean hasWaitingTasks = false;
+            boolean hasRemainingTasks = false;
+
+            // There is a possibility that a task finishes before this thread has a chance to wait for notify()
+            // The whole block is synchronized to prevent that
+            synchronized (lock) {
+                for (ScheduledTask task : tasks.values()) {
+                    switch (task.state()) {
+                        case FINISHED -> {}
+                        case FAILED -> throw task.error();
+                        case WAITING -> {
+                            hasRemainingTasks = true;
+                            if (task.tryExecute(executor, lock))
+                                hasRunningTasks = true;
+                            else
+                                hasWaitingTasks = true;
+                        }
+                        case LAUNCHING, RUNNING -> {
+                            hasRunningTasks = true;
+                            hasRemainingTasks = true;
+                        }
+                    }
+                }
+
+                if (hasWaitingTasks && !hasRunningTasks)
+                    throw new IllegalStateException("Deadlock detected: some tasks are waiting and can not be started");
+
+                if (!hasRemainingTasks)
+                    break;
+                lock.wait();
+            }
+        }
+        return null;
     }
 
     /**
@@ -141,23 +136,9 @@ public class Scheduler {
         executor.shutdown();
     }
 
-    /**
-     * Pauses this thread until all tasks are over, or a single task fails.
-     *
-     * @param timeout the maximum amount of time before timing out
-     * @param unit the unit of time for the timeout
-     * @throws InterruptedException if the thread is interrupted
-     * @throws TaskFailedException if a task fails
-     */
-    public void waitUntilAllTasksFinished(long timeout, TimeUnit unit) throws InterruptedException, TaskFailedException {
-        // Pause this thread by sleeping until being waked up by the end / failure of tasks
-        // The synchronized block is mandatory to take ownership of the lock
-        synchronized (lock) {
-            // TODO Spurious wakeup guard
-            lock.wait(unit.toMillis(timeout));
-        }
-        // Propagates the task failure, if any
-        if (error != null)
-            throw error;
+    private ScheduledTask getTask(String id) {
+        if (!tasks.containsKey(id))
+            throw new IllegalArgumentException("Task %s doesn't exist".formatted(id));
+        return tasks.get(id);
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/utils/execution/TaskFailedException.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/execution/TaskFailedException.java
@@ -13,7 +13,7 @@ public class TaskFailedException extends Exception {
      * @param cause the exception causing the failure
      */
     public TaskFailedException(ScheduledTask task, Throwable cause) {
-        super("Task failed: " + task.getId(), cause);
+        super("Task failed: " + task.id(), cause);
         this.task = task;
     }
 

--- a/src/test/java/com/ignfab/minalac/generator/utils/execution/SchedulerTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/execution/SchedulerTest.java
@@ -5,8 +5,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -20,57 +22,78 @@ public class SchedulerTest {
         scheduler = new Scheduler();
     }
 
+    @AfterEach
+    public void tearDown() {
+        scheduler.shutdown();
+    }
+
     @Test
-    public void testTasksWithoutCondition() {
+    public void testTasksWithoutDependency() {
         List<String> actual = Collections.synchronizedList(new ArrayList<>());
 
-        scheduler.schedule("a", () -> actual.add("a"));
-        scheduler.schedule("b", () -> actual.add("b"));
-        scheduler.schedule("c", () -> actual.add("c"));
+        scheduler.schedule("testWithoutDependency:a", () -> actual.add("a"));
+        scheduler.schedule("testWithoutDependency:b", () -> actual.add("b"));
+        scheduler.schedule("testWithoutDependency:c", () -> actual.add("c"));
 
-        scheduler.start();
-        assertDoesNotThrow(() -> scheduler.waitUntilAllTasksFinished(50, TimeUnit.MILLISECONDS));
-        scheduler.shutdown();
+        assertDoesNotThrow(() -> scheduler.run(1, TimeUnit.MINUTES));
 
         List<String> expected = Arrays.asList("a", "b", "c");
         assertTrue(expected.size() == actual.size() && expected.containsAll(actual) && actual.containsAll(expected),
             () -> "List elements expected to be the same (ignoring order). Expected: " + expected + ", actual: " + actual);
     }
 
+
     @Test
-    public void testTasksWithCondition() {
+    public void testTasksWithDependency() {
         List<String> actual = Collections.synchronizedList(new ArrayList<>());
 
-        scheduler.schedule("1", () -> actual.add("1"));
-        scheduler.schedule("2", () -> actual.add("2"), "1");
-        scheduler.schedule("3", () -> actual.add("3"), "1", "2");
+        scheduler.schedule("testWithDependency:1", () -> actual.add("1"));
+        scheduler.schedule("testWithDependency:2", () -> actual.add("2"));
+        scheduler.schedule("testWithDependency:3", () -> actual.add("3"));
+        scheduler.addDependency("testWithDependency:2", "testWithDependency:1");
+        scheduler.addDependency("testWithDependency:3", "testWithDependency:1");
+        scheduler.addDependency("testWithDependency:3", "testWithDependency:2");
 
-        scheduler.start();
-        assertDoesNotThrow(() -> scheduler.waitUntilAllTasksFinished(50, TimeUnit.MILLISECONDS));
-        scheduler.shutdown();
+        assertDoesNotThrow(() -> scheduler.run(1, TimeUnit.MINUTES));
 
         List<String> expected = Arrays.asList("1", "2", "3");
         assertEquals(expected, actual);
     }
 
     @Test
+    public void testResetTasks() {
+        List<String> actual = Collections.synchronizedList(new ArrayList<>());
+
+        scheduler.schedule("testReset:x", () -> actual.add("x"));
+        scheduler.schedule("testReset:y", () -> actual.add("y"));
+        scheduler.schedule("testReset:z", () -> actual.add("z"));
+        scheduler.addDependency("testReset:y", "testReset:x");
+        scheduler.addDependency("testReset:z", "testReset:y");
+
+        List<String> expected = Arrays.asList("x", "y", "z");
+
+        for (int i = 1; i <= 3; i++) {
+            assertDoesNotThrow(() -> scheduler.run(1, TimeUnit.MINUTES));
+            assertEquals(expected, actual, "Iteration " + i);
+            actual.clear();
+        }
+    }
+
+    @Test
     public void testFailingTask() {
-        ScheduledTask task = new ScheduledTask("id", () -> {
+        ScheduledTask task = new ScheduledTask("testFailingTask:id", () -> {
             throw new RuntimeException("Boom!");
         });
         scheduler.schedule(task);
 
-        scheduler.start();
-        TaskFailedException e = assertThrows(TaskFailedException.class, () -> scheduler.waitUntilAllTasksFinished(50, TimeUnit.MILLISECONDS));
-        scheduler.shutdown();
-
-        assertEquals(task, e.getTask());
+        TaskFailedException t = assertThrows(TaskFailedException.class, () -> scheduler.run(1, TimeUnit.MINUTES));
+        assertEquals(task, t.getTask());
     }
 
     @Test
     public void testLongTaskTimedOut() {
         AtomicBoolean executed = new AtomicBoolean(false);
-        scheduler.schedule("id", () -> {
+        scheduler.schedule("testLongTaskTimeout:id", () -> {
             try {
                 Thread.sleep(10_000); // Completes after 10s
             } catch (InterruptedException e) {
@@ -79,10 +102,49 @@ public class SchedulerTest {
             executed.set(true); // Should never happen because timeout is 50ms
         });
 
-        scheduler.start();
-        assertDoesNotThrow(() -> scheduler.waitUntilAllTasksFinished(50, TimeUnit.MILLISECONDS));
-        scheduler.shutdown();
-
+        assertThrows(TimeoutException.class, () -> scheduler.run(50, TimeUnit.MILLISECONDS));
         assertFalse(executed.get());
     }
+
+    @Test
+    public void testDeadLock() {
+        scheduler.schedule("testDeadLock:A", () -> {});
+        scheduler.schedule("testDeadLock:B", () -> {});
+        scheduler.addDependency("testDeadLock:A", "testDeadLock:B");
+        scheduler.addDependency("testDeadLock:B", "testDeadLock:A");
+
+        assertThrows(IllegalStateException.class, () -> scheduler.run(1, TimeUnit.MINUTES));
+    }
+
+    @Test
+    public void testCancel() {
+        ScheduledTask cancelled = new ScheduledTask("testCancel:cancelled", () -> {
+            try {
+                Thread.sleep(3_000); // Completes after 3s
+            } catch (InterruptedException e) {
+                fail("Thread interrupted");
+            }
+        });
+
+        ScheduledTask failed = new ScheduledTask("testCancel:fail", () -> {
+            try {
+                Thread.sleep(500); // Completes after 0.5s
+            } catch (InterruptedException e) {
+                fail("Thread interrupted");
+            }
+            throw new RuntimeException("Boom!");
+        });
+
+        ScheduledTask success = new ScheduledTask("testCancel:success", () -> {});
+
+        scheduler.schedule(cancelled);
+        scheduler.schedule(failed);
+        scheduler.schedule(success);
+
+        assertThrows(TaskFailedException.class, () -> scheduler.run(1, TimeUnit.MINUTES));
+        assertEquals(ScheduledTaskState.RUNNING, cancelled.state());
+        assertEquals(ScheduledTaskState.FAILED, failed.state());
+        assertEquals(ScheduledTaskState.FINISHED, success.state());
+    }
+
 }


### PR DESCRIPTION
### Issue

[MINALAC-125](https://ignfab.atlassian.net/browse/MINALAC-125)

### Changes

Modify `Scheduler` to make it resetable so tasks can be relaunched after completion. 

#### Feature description

`ScheduledTask` contains now its dependencies (the others that need to be completed) and its dependants (the others tasks that depend on it).

The `Scheduler` now relies on the state of the tasks to manage task execution. `runThenReset()` replaces `start()` and `waitUntilAllTasksFinished()`: it starts the scheduler, waits for tasks completion and then reset it, so the scheduler can be re-run.

### Reason

This will be needed for tiling generation.

### Self-checks

- [x] The code has unit tests associated
- [x] The code has Javadoc Comments associated
- [x] Complex / Unexpected code is explained / justified with a small comment
- ~~Relevant documentation inside the `/docs` folder has been updated~~
- ~~All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)~~
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [x] The texts have been proofread (documentation, error messages, logs, comments...)

### Questions/Others

- [x] ~~Properly terminated `ExecutorService` ?~~ (Same `ExecutorService`)
- [ ] Change/Remove some `ScheduledTaskState` ?

[MINALAC-125]: https://ignfab.atlassian.net/browse/MINALAC-125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ