### PR TITLE
fix(provider): Prevent `NullPointerException` on empty features

### DIFF
--- a/src/main/java/com/ignfab/minalac/generator/inputs/WFS1_1_GML3_1_DataProvider.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/WFS1_1_GML3_1_DataProvider.java
@@ -198,7 +198,8 @@ public class WFS1_1_GML3_1_DataProvider implements Provider<SimpleFeature> {
 
         @Override
         public void close() throws IOException {
-            iterator.close();
+            if (iterator != null)
+                iterator.close();
         }
 
         // Checks we are in a valid position, eventually move.


### PR DESCRIPTION
<!--
Thank you for contributing to this project!
You must fill out the information below before we can review this pull request.
Be sure to update the relevant sections of this template and to complete the list of self-checks at the end.

If you need more time to check everything, consider opening a draft pull request instead.
Don't forget to update this comment to track your progress.
-->

### Type of modification

<!--
Indicate here the kind of stuff you've touched.
If your modification fits into multiple types, select all that apply and try to sort them from the most to the least important.

Types:
- Code
  - General
  - Inputs
  - Outputs
  - Tools
  - Other: (specify)
- Documentation
  - Javadoc Comments
  - Markdown Files
  - Code Comments
- Tests
- Resources
- CI/CD
- Other: (specify)
-->

### Issue

<!--
If an issue or a JIRA ticket about the changes in this PR exists, link it here.
Otherwise, remove this section.

> Format GitHub issue:
Closes #<issue-number>

> Format JIRA ticket:
MINALAC-<ticket-number>
-->

[MINALAC-131](https://ignfab.atlassian.net/browse/MINALAC-131)

When fetching WFS data, if there is a no feature, the generation fails.

This is because of a `null` iterator on `close()` of `WFS1_1_GML3_1_DataProvider.Result` class


[MINALAC-131]: https://ignfab.atlassian.net/browse/MINALAC-131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ