### PR TITLE
Add `get` and `limits` to `PlaceableStructure`

### DIFF
--- a/src/main/java/com/ignfab/minalac/generator/placeables/PlaceableStructure.java
+++ b/src/main/java/com/ignfab/minalac/generator/placeables/PlaceableStructure.java
@@ -12,6 +12,7 @@ import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
  */
 public class PlaceableStructure implements Placeable {
     private final Map<WorldCoords3d, Placeable> placeables = new HashMap<>();
+    private WorldBBox3d limits = null;
 
     /**
      * {@inheritDoc}
@@ -31,9 +32,12 @@ public class PlaceableStructure implements Placeable {
      */
     public void set(WorldCoords3d coords, Placeable placeable) {
         if (placeable == null)
-            remove(coords);
+            placeables.remove(coords);
         else
             placeables.put(coords, placeable);
+
+        // Force limits recompute
+        limits = null;
     }
 
     /**
@@ -71,7 +75,7 @@ public class PlaceableStructure implements Placeable {
      * @param coords the relative {@code WorldCoords3d}
      */
     public void remove(WorldCoords3d coords) {
-        placeables.remove(coords);
+        set(coords, null);
     }
 
     /**
@@ -93,5 +97,38 @@ public class PlaceableStructure implements Placeable {
     public void remove(WorldBBox3d bbox) {
         for (WorldCoords3d coords : bbox)
             remove(coords);
+    }
+
+    /**
+     * Returns the placable at the specified coordinates.
+     *
+     * @param x relative x-coordinate
+     * @param y relative y-coordinate
+     * @param z relative z-coordinate
+     *
+     * @return placeable at relative structure coordinates or {@code NoVoxel.INSTANCE} if none
+     */
+    public Placeable get(int x, int y, int z) {
+        Placeable placeable = placeables.get(new WorldCoords3d(x, y, z));
+        return placeable == null ? NoVoxel.INSTANCE : placeable;
+    }
+
+    /**
+     * Tells the limits of this structure in relative coordinates.
+     * <p>
+     * This is not the bounding box of all that would be placed.
+     * Limits will only contain origin coordinates of contained placeables.
+     * <p>
+     * In other words, limits contains every position for which {@code get} returns something else than {@code NoVoxel.INSTANCE}.
+     * This may be used to know how to repeat this structure.
+     *
+     * @return limits of the structure in relative coordinates.
+     */
+    public WorldBBox3d limits() {
+        if (limits == null)
+            limits =  placeables.isEmpty() ? WorldBBox3d.EMPTY
+                : new WorldBBox3d(placeables.keySet().toArray(new WorldCoords3d[0]));
+
+        return limits;
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/utils/world2d/WorldBBox2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world2d/WorldBBox2d.java
@@ -55,20 +55,26 @@ public class WorldBBox2d implements Bounded2d, Iterable<WorldCoords2d> {
     /**
      * Creates a new {@link WorldBBox2d} containing all given coordinates.
      *
-     * @param first a first mandatory coordinate that should be in resulting box
-     * @param others a list of coordinate that should be in resulting box
+     * @param positions a list of position coordinates that should be in resulting box
      */
-    public WorldBBox2d(WorldCoords2d first, WorldCoords2d... others) {
-        int minX = first.x();
-        int minY = first.y();
-        int maxX = first.x();
-        int maxY = first.y();
+    public WorldBBox2d(WorldCoords2d... positions) {
+        if (positions.length == 0) {
+            size = new WorldSize2d(0, 0);
+            min = new WorldCoords2d(0, 0);
+            max = new WorldCoords2d(0, 0);
+            return;
+        }
 
-        for (WorldCoords2d coord : others) {
-            minX = Math.min(minX, coord.x());
-            minY = Math.min(minY, coord.y());
-            maxX = Math.max(maxX, coord.x());
-            maxY = Math.max(maxY, coord.y());
+        int minX = positions[0].x();
+        int minY = positions[0].y();
+        int maxX = positions[0].x();
+        int maxY = positions[0].y();
+
+        for (int index = 1; index < positions.length; index++) {
+            minX = Math.min(minX, positions[index].x());
+            minY = Math.min(minY, positions[index].y());
+            maxX = Math.max(maxX, positions[index].x());
+            maxY = Math.max(maxY, positions[index].y());
         }
 
         min = new WorldCoords2d(minX, minY);

--- a/src/main/java/com/ignfab/minalac/generator/utils/world3d/WorldBBox3d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world3d/WorldBBox3d.java
@@ -61,26 +61,32 @@ public class WorldBBox3d implements Bounded3d, Iterable<WorldCoords3d> {
     }
 
     /**
-     * Creates a new {@link WorldBBox3d} containing all given coordinates.
+     * Creates a new {@link WorldBBox3d} containing all given positions.
      *
-     * @param first a first mandatory coordinate that should be in resulting box
-     * @param others a list of coordinate that should be in resulting box
+     * @param positions a list of position coordinates that should be in resulting box
      */
-    public WorldBBox3d(WorldCoords3d first, WorldCoords3d... others) {
-        int minX = first.x();
-        int minY = first.y();
-        int minZ = first.z();
-        int maxX = first.x();
-        int maxY = first.y();
-        int maxZ = first.z();
+    public WorldBBox3d(WorldCoords3d... positions) {
+        if (positions.length == 0) {
+            size = new WorldSize3d(0, 0, 0);
+            min = new WorldCoords3d(0, 0, 0);
+            max = new WorldCoords3d(0, 0, 0);
+            return;
+        }
 
-        for (WorldCoords3d coord : others) {
-            minX = Math.min(minX, coord.x());
-            minY = Math.min(minY, coord.y());
-            minZ = Math.min(minZ, coord.z());
-            maxX = Math.max(maxX, coord.x());
-            maxY = Math.max(maxY, coord.y());
-            maxZ = Math.max(maxZ, coord.z());
+        int minX = positions[0].x();
+        int minY = positions[0].y();
+        int minZ = positions[0].z();
+        int maxX = positions[0].x();
+        int maxY = positions[0].y();
+        int maxZ = positions[0].z();
+
+        for (int index = 1; index < positions.length; index++) {
+            minX = Math.min(minX, positions[index].x());
+            minY = Math.min(minY, positions[index].y());
+            minZ = Math.min(minZ, positions[index].z());
+            maxX = Math.max(maxX, positions[index].x());
+            maxY = Math.max(maxY, positions[index].y());
+            maxZ = Math.max(maxZ, positions[index].z());
         }
 
         min = new WorldCoords3d(minX, minY, minZ);

--- a/src/test/java/com/ignfab/minalac/generator/placeables/PlaceableStructureTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/placeables/PlaceableStructureTest.java
@@ -6,6 +6,8 @@ import com.ignfab.minalac.generator.outputs.testing.TestingVoxelType;
 import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 public class PlaceableStructureTest {
 
     @Test
@@ -133,5 +135,49 @@ public class PlaceableStructureTest {
 
         world.assertVoxelNull(3, 4, 5);
         world.assertVoxel("*", 4, 4, 5);
+    }
+
+    @Test
+    public void testGet() {
+        TestingVoxelWorld world = new TestingVoxelWorld(WorldBBox3d.ORIGIN);
+
+        Placeable vtA = new TestingVoxelType(world, "A");
+        Placeable vtB = new TestingVoxelType(world, "B");
+
+        PlaceableStructure structure = new PlaceableStructure();
+        structure.set(1, 2, 3, vtA);
+        structure.set(3, 2, 1, vtB);
+
+        assertEquals(vtA, structure.get(1, 2, 3));
+        assertEquals(vtB, structure.get(3, 2, 1));
+        assertEquals(NoVoxel.INSTANCE, structure.get(10, 20, 30));
+    }
+
+    @Test
+    public void testLimits() {
+        TestingVoxelWorld world = new TestingVoxelWorld(WorldBBox3d.ORIGIN);
+
+        Placeable vt = new TestingVoxelType(world, "X");
+        PlaceableStructure structure = new PlaceableStructure();
+
+        // Basic checks
+        structure.set(1, 2, 3, vt);
+        assertEquals(new WorldBBox3d(1, 2, 3, 1, 1, 1), structure.limits());
+
+        structure.set(0, 0, 0, vt);
+        assertEquals(new WorldBBox3d(0, 0, 0, 2, 3, 4), structure.limits());
+
+        // Check adding novoxel extends limits
+        structure.set(6, 7, 8, NoVoxel.INSTANCE);
+        assertEquals(new WorldBBox3d(0, 0, 0, 7, 8, 9), structure.limits());
+
+        // Check remove shrinks limits
+        structure.remove(0, 0, 0);
+        assertEquals(new WorldBBox3d(1, 2, 3, 6, 6, 6), structure.limits());
+
+        // Check underlying placeable does not extend limits
+        PlaceableStructure superStructure = new PlaceableStructure();
+        superStructure.set(3, 2, 1, structure);
+        assertEquals(new WorldBBox3d(3, 2, 1, 1, 1, 1), superStructure.limits());
     }
 }


### PR DESCRIPTION
### Changes
Add `get` and `limits` methods to `PlaceableStructure`

#### Feature description
Additions in `PlaceableStructure`:
- `get` method returns `Placeable` contained in a `PlaceableStructure` at a given coordinates;
- `limits` method returns a bounding box containing all coordinates where there are `Placeable` in a `PlaceableStructure`;

This allows new use of structures:
- Structure oriented along roads or building facades.
- Repetition/tiling of structures (using `limits()`).

Both methods are required by future `LinearRenderer` and by improvements on `BuildingRenderer`.

### Self-checks

- [x] The code has unit tests associated
- [x] The code has Javadoc Comments associated
- ~~Complex / Unexpected code is explained / justified with a small comment~~
- ~~Relevant documentation inside the `/docs` folder has been updated~~
- [x] All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- ~~The texts have been proofread (documentation, error messages, logs, comments...)~~
