### PR TITLE
build(windows): Port generate.sh script to Windows

### DIFF
--- a/docs/usage/Generator.md
+++ b/docs/usage/Generator.md
@@ -11,7 +11,7 @@ Generation involves too many parameters to be passed on command line. They are p
 
 Refer to [generation parameters documentation](parameters/Parameters.md) for further information.
 
-To avoid useless efforts building a parameter file, you can use provided `generate.sh` script (see [Run.md](Run.md#generatesh)).
+To avoid useless efforts building a parameter file, you can use provided `generate.sh` script (see [Run.md](Run.md#generatesh-unix)).
 
 ## Command line arguments
 Usage:

--- a/docs/usage/Run.md
+++ b/docs/usage/Run.md
@@ -17,7 +17,7 @@ Run only (from repository root):
 ./generate.sh minetest full ign $HOME/.minetest/worlds/minalac
 ```
 
-## generate.sh
+## generate.sh (Unix)
 
 `generate.sh` scripts creates yaml configuration from configuration fragments and passes it to `Generator.jar`.
 
@@ -30,12 +30,23 @@ generate.sh [options] <format> <process> <place> [<outputPath>]
 
 Where:
 - `options` may be:
-   - `-y` do nothing but displaying resulting parameters (in Yaml format).
+   - `-h` do nothing but displaying the help message.
    - `-g` do not perform generation.
    - `-s` do not save generated map to disk.
-- `<format>` is the wanted generation format, refering to yaml file (without extension) in `examples/formats`.
-- `<process>` is the wanted generation process, refering to yaml file (without extension) in `examples/processes`.
-- `<places>` is the wanted generation area, refering to yaml file (without extension) in `examples/places`.
+  - `-y` do nothing but displaying resulting parameters (in Yaml format).
+  - `-l (formats|processes|places)` do nothing but listing available formats/processes/places.
+- `<format>` is the wanted generation format, referring to yaml file (without extension) in `examples/formats`.
+- `<process>` is the wanted generation process, referring to yaml file (without extension) in `examples/processes`.
+- `<places>` is the wanted generation area, referring to yaml file (without extension) in `examples/places`.
 - `<outputPath>` is where world files will be generated, only required if no option set (if directory exists, it will be emptied).
 
 While many places are available, there are only two formats (`minecraft`, `minetest`) and one process (`full`) for now.
+
+## Windows
+
+On Windows, the same script is available as `generate.bat` and `generate.ps1`, respectively as batch and powershell scripts.
+
+For the `generate.bat` version, options are prefixed by `/` instead of `-`. For help, use `generate.bat /h`.
+Note : Due to technical limitation, this script relies on a temporary file to combine Yaml parameters. By default, that file will be in the `examples` directory and named `temp.yaml`. If, for some reason, a file named like that already exists, the script will abort to prevent any undesired overwriting. You can change that name at the beginning of the script, in the variables' setup.
+
+For the `generate.ps1` version, options have both long and short names. For help, use `.\generate.ps1 -help`.

--- a/generate.bat
+++ b/generate.bat
@@ -1,0 +1,165 @@
+@echo off
+
+:: Place ourselves in script directory
+cd "%~dp0"
+
+:: We use batch-style option prefix '/' instead of unix-style '-'
+set OPT_PREFIX=/
+set GENERATE_BAT=%~0
+:: Check if JAVA_CMD is set, if not, set it to java.exe
+if not defined JAVA_CMD set JAVA_CMD=java.exe
+set JAR_PATH=.\target\Generator.jar
+set PARAMS_DIR=.\examples
+:: Must use a temp file to hold the params as variables can't contain newlines
+set TEMP_PARAMETERS_YAML_FILE=%PARAMS_DIR%\temp.yaml
+set FORMATS_DIR=%PARAMS_DIR%\formats
+set PROCESSES_DIR=%PARAMS_DIR%\processes
+set PLACES_DIR=%PARAMS_DIR%\places
+
+set output_dir_needed=1
+set generator_opt=
+set display_only=
+
+:: Count args shifted while processing options
+set /a nargs=0
+:process_cli_options
+    set opt=%~1
+    :: If no arg is present or arg does not start with OPT_PREFIX, stop processing
+    if "%opt%"=="" goto cli_options_processed
+    if not "%opt:~0,1%"=="%OPT_PREFIX%" goto cli_options_processed
+    shift
+    set /a nargs+=1
+    :: Remove OPT_PREFIX from opt
+    set opt=%opt:~1%
+    if /i "%opt%"=="h" (
+        call :usage
+        exit /b 0
+    ) else if /i "%opt%"=="g" (
+        set generator_opt=%generator_opt% --generation-disabled
+        set output_dir_needed=
+    ) else if /i "%opt%"=="s" (
+        set generator_opt=%generator_opt% --save-disabled
+        set output_dir_needed=
+    ) else if /i "%opt%"=="y" (
+        set display_only=1
+        set output_dir_needed=
+    ) else if /i "%opt%"=="l" (
+        if /i "%~1"=="formats" (
+            call :list_yaml_files %FORMATS_DIR%
+        ) else if /i "%~1"=="processes" (
+            call :list_yaml_files %PROCESSES_DIR%
+        ) else if /i "%~1"=="places" (
+            call :list_yaml_files %PLACES_DIR%
+        ) else (
+            echo Unknown %OPT_PREFIX%l option '%~1'
+            exit /b 1
+        )
+        exit /b 0
+    ) else (
+        echo Unknown option '%OPT_PREFIX%%opt%'
+        call :usage
+        exit /b 1
+    )
+:: Loop
+goto process_cli_options
+:: End of loop
+:cli_options_processed
+
+if defined output_dir_needed (set /a nargs+=4) else (set /a nargs+=3)
+call :argc %*
+if not %argc%==%nargs% (
+    echo Wrong number of arguments, expected %nargs% given %argc%
+    call :usage
+    exit /b 1
+)
+
+set format=%FORMATS_DIR%\%~1.yaml
+if not exist "%format%" (
+    echo Format '%~1' is incorrect!
+    call :usage
+    exit /b 1
+)
+
+set process=%PROCESSES_DIR%\%~2.yaml
+if not exist "%process%" (
+    echo Process '%~2' is incorrect!
+    call :usage
+    exit /b 1
+)
+
+set place=%PLACES_DIR%\%~3.yaml
+if not exist "%place%" (
+    echo Place '%~3' is incorrect!
+    call :usage
+    exit /b 1
+)
+
+set output_dir=%~f4
+if defined output_dir_needed (
+    :: Backslash at the end tests for directory
+    if exist "%output_dir%\" (
+        rmdir /s /q "%output_dir%"
+        if errorlevel 1 (
+            echo Could not delete directory '%output_dir%'
+            exit /b 1
+        )
+    )
+    mkdir "%output_dir%"
+    if errorlevel 1 (
+        echo Could not create directory '%output_dir%'
+        exit /b 1
+    )
+)
+
+if exist "%TEMP_PARAMETERS_YAML_FILE%" (
+    echo Temporary file '%TEMP_PARAMETERS_YAML_FILE%' already exist and would be overridden by the current operation. Aborting!
+    exit /b 1
+)
+
+:: UTF-8 encoding
+chcp 65001 > nul
+:: Batch variables cannot hold multiline strings, thus we must use a file
+type "%format%" > "%TEMP_PARAMETERS_YAML_FILE%"
+echo: >> "%TEMP_PARAMETERS_YAML_FILE%"
+type "%process%" >> "%TEMP_PARAMETERS_YAML_FILE%"
+echo: >> "%TEMP_PARAMETERS_YAML_FILE%"
+type "%place%" >> "%TEMP_PARAMETERS_YAML_FILE%"
+
+if defined display_only (
+    type "%TEMP_PARAMETERS_YAML_FILE%"
+) else (
+    "%JAVA_CMD%" -jar "%JAR_PATH%" %generator_opt% -p "%TEMP_PARAMETERS_YAML_FILE%" "%output_dir%"
+)
+
+del "%TEMP_PARAMETERS_YAML_FILE%"
+exit /b 0
+
+:argc
+    set /a argc=0
+    :argc_loop
+        if "%~1"=="" exit /b
+        set /a argc+=1
+        shift
+    goto argc_loop
+exit /b
+
+:list_yaml_files
+    for %%f in ( %~1\*.yaml ) do echo %~2%%~nf
+exit /b
+
+:usage
+    echo %GENERATE_BAT% [options] ^<format^> ^<process^> ^<place^> [^<outputdir^>]
+    echo available options:
+    echo %OPT_PREFIX%h Displays this help message only
+    echo %OPT_PREFIX%g Stops before generation
+    echo %OPT_PREFIX%s Stops before saving
+    echo %OPT_PREFIX%y Displays Yaml configuration only
+    echo %OPT_PREFIX%l (formats^|processes^|places) Lists available formats/processes/places only
+    echo formats:
+    call :list_yaml_files %FORMATS_DIR% "  "
+    echo processes:
+    call :list_yaml_files %PROCESSES_DIR% "  "
+    echo places:
+    call :list_yaml_files %PLACES_DIR% "  "
+    echo outputdir is required if no option given (if directory exists, it will be emptied)
+exit /b

--- a/generate.ps1
+++ b/generate.ps1
@@ -1,0 +1,173 @@
+<#
+.SYNOPSIS
+    Helper script for Minalac Generator.
+.DESCRIPTION
+    This script can combine Yaml parameters from multiple files and
+    launch the Generator.jar program with that parameters. Multiple
+    options are available to control the process.
+#>
+
+Param (
+    # Displays this help message only.
+    [Parameter(ParameterSetName = "help", Mandatory)]
+    [Alias("h")]
+    [Switch] $Help,
+
+    # Stops before generation.
+    [Parameter(ParameterSetName = "no-output-dir")]
+    [Alias("g")]
+    [Switch] $DisableGeneration,
+
+    # Stops before saving.
+    [Parameter(ParameterSetName = "no-output-dir")]
+    [Alias("s")]
+    [Switch] $DisableSaving,
+
+    # Displays Yaml configuration only.
+    [Parameter(ParameterSetName = "no-output-dir")]
+    [Alias("y")]
+    [Switch] $YamlOnly,
+
+    # Lists available formats/processes/places only.
+    [Parameter(ParameterSetName = "list", Mandatory)]
+    [Alias("l")]
+    [ValidateSet("formats", "processes", "places")]
+    [String] $ListYaml,
+
+    # Name of the format to use.
+    # Use '-ListYaml formats' option to get the list of allowed values.
+    [Parameter(ParameterSetName = "regular", Position = 0, Mandatory)]
+    [Parameter(ParameterSetName = "no-output-dir", Position = 0, Mandatory)]
+    [String] $Format,
+
+    # Name of the process to use.
+    # Use '-ListYaml processes' option to get the list of allowed values.
+    [Parameter(ParameterSetName = "regular", Position = 1, Mandatory)]
+    [Parameter(ParameterSetName = "no-output-dir", Position = 1, Mandatory)]
+    [String] $Process,
+
+    # Name of the place to use.
+    # Use '-ListYaml places' option to get the list of allowed values.
+    [Parameter(ParameterSetName = "regular", Position = 2, Mandatory)]
+    [Parameter(ParameterSetName = "no-output-dir", Position = 2, Mandatory)]
+    [String] $Place,
+
+    # Output directory where the result will be generated.
+    [Parameter(ParameterSetName = "regular", Position = 3, Mandatory)]
+    [String] $OutputDir
+)
+
+# Place ourselves in script directory
+Set-Location $PSScriptRoot
+
+# Check if JAVA_CMD is set, if not, set it to java.exe
+If (!(Test-Path Variable:JAVA_CMD)) {
+    $JAVA_CMD = "java.exe"
+}
+$JAR_PATH = ".\target\Generator.jar"
+$PARAMS_DIR = ".\examples"
+$FORMATS_DIR = "$PARAMS_DIR\formats"
+$PROCESSES_DIR = "$PARAMS_DIR\processes"
+$PLACES_DIR = "$PARAMS_DIR\places"
+
+Function Get-YamlFiles {
+    Param (
+        [Parameter(Position = 0, Mandatory)]
+        [String] $Path,
+        [String] $Prefix = ""
+    )
+    Get-ChildItem $Path -Filter *.yaml -File | ForEach-Object {
+        Write-Output "$($Prefix)$($_.BaseName)"
+    }
+}
+
+Function Get-Usage {
+    Get-Help $MyInvocation.ScriptName -Detailed
+    $prefix = "$([Environment]::NewLine)`t"
+    Write-Host "Formats: $(Get-YamlFiles $FORMATS_DIR -Prefix $prefix)"
+    Write-Host "Processes: $(Get-YamlFiles $PROCESSES_DIR -Prefix $prefix)"
+    Write-Host "Places: $(Get-YamlFiles $PLACES_DIR -Prefix $prefix)"
+}
+
+If ($Help) {
+    Get-Usage
+    Return
+}
+
+$OutputDirNeeded = $true
+$GeneratorOpts = @()
+
+If ($DisableGeneration) {
+    $GeneratorOpts += "--generation-disabled"
+    $OutputDirNeeded = $false
+}
+
+If ($DisableSaving) {
+    $GeneratorOpts += "--save-disabled"
+    $OutputDirNeeded = $false
+}
+
+If ($YamlOnly) {
+    $OutputDirNeeded = $false
+}
+
+If ($ListYaml) {
+    Switch ($ListYaml) {
+        "formats" { Get-YamlFiles $FORMATS_DIR }
+        "processes" { Get-YamlFiles $PROCESSES_DIR }
+        "places" { Get-YamlFiles $PLACES_DIR }
+    }
+    Return
+}
+
+If ($OutputDirNeeded -And !($OutputDir)) {
+    Throw "OutputDir is missing!"
+}
+
+$FormatYaml = "$FORMATS_DIR\$Format.yaml"
+If (!(Test-Path $FormatYaml -PathType Leaf)) {
+    Throw "Format '$Format' is incorrect!"
+}
+
+$ProcessYaml = "$PROCESSES_DIR\$Process.yaml"
+If (!(Test-Path $ProcessYaml -PathType Leaf)) {
+    Throw "Process '$Process' is incorrect!"
+}
+
+$PlaceYaml = "$PLACES_DIR\$Place.yaml"
+If (!(Test-Path $PlaceYaml -PathType Leaf)) {
+    Throw "Place '$Place' is incorrect!"
+}
+
+If ($OutputDirNeeded) {
+    If (Test-Path $OutputDir -PathType Container) {
+        Remove-Item -Recurse -Force $OutputDir
+    }
+    If (Test-Path $OutputDir) {
+        Throw "'$OutputDir' is not a directory"
+    }
+    New-Item -Path $OutputDir -ItemType Directory -Force | Out-Null
+    $OutputDir = Resolve-Path $OutputDir
+} Else {
+    $OutputDir = "NUL" # Fake output that won't be used
+}
+
+$FormatParams = Get-Content $FormatYaml -Encoding UTF8
+$ProcessParams = Get-Content $ProcessYaml -Encoding UTF8
+$PlaceParams = Get-Content $PlaceYaml -Encoding UTF8
+$Params = $FormatParams + $ProcessParams + $PlaceParams -Join [Environment]::NewLine
+
+If ($YamlOnly) {
+    Write-Host $Params
+    Return
+}
+
+# Temporarily set the MINALAC_PARAMS environment variable
+$Prev = $Env:MINALAC_PARAMS
+$Env:MINALAC_PARAMS = $Params
+& $JAVA_CMD (@("-jar", $JAR_PATH) + $GeneratorOpts + @($OutputDir))
+If ($Prev) {
+    $Env:MINALAC_PARAMS = $Prev
+} Else {
+    Remove-Item Env:\MINALAC_PARAMS
+}

--- a/generate.sh
+++ b/generate.sh
@@ -19,9 +19,11 @@ list_yaml_files() {
 usage() {
     echo "$0 [options] <format> <process> <place> [<outputdir>]"
     echo "available options:"
+    echo "-h Displays this help message only"
     echo "-g Stops before generation"
     echo "-s Stops before saving"
-    echo "-y Display Yaml configuration only"
+    echo "-y Displays Yaml configuration only"
+    echo "-l (formats|processes|places) Lists available formats/processes/places only"
     echo "formats:"
     list_yaml_files $FORMATS_DIR "\t"
     echo "processes:"
@@ -38,6 +40,10 @@ while [[ "$1" == "-"* ]]; do
     opt=$1
     shift
     case $opt in
+        -h)
+            usage
+            exit 0
+            ;;
         -g)
             generator_opt="$generator_opt --generation-disabled"
             unset output_dir_needed
@@ -62,7 +68,7 @@ while [[ "$1" == "-"* ]]; do
                     list_yaml_files $PLACES_DIR
                     ;;
                 *)
-                    echo "Unknown -l option $1"
+                    echo "Unknown -l option '$1'"
                     usage
                     exit 1
                     ;;
@@ -70,7 +76,7 @@ while [[ "$1" == "-"* ]]; do
             exit 0 
             ;;
         *)
-            echo "Unknown option $opt"
+            echo "Unknown option '$opt'"
             usage
             exit 1
             ;;
@@ -84,6 +90,7 @@ else
 fi
 
 if [[ $# -ne $nargs ]]; then
+    echo "Wrong number of arguments, expected $nargs given $#"
     usage
     exit 1
 fi
@@ -113,16 +120,16 @@ if [ $output_dir_needed ]; then
     output_dir="$4"
     if [ -d "$output_dir" ]; then
         if ! rm -r "$output_dir"; then
-            echo "Could not delete directory $output_dir"
+            echo "Could not delete directory '$output_dir'"
             exit 1
         fi
     fi
     if [ -e "$output_dir" ]; then
-        echo "$output_dir is not a directory"
+        echo "'$output_dir' is not a directory"
         exit 1
     fi
     if ! mkdir -p "$output_dir"; then
-        echo "Could create directory $output_dir"
+        echo "Could not create directory '$output_dir'"
         exit 1
     fi
     output_dir=$(realpath "$output_dir")


### PR DESCRIPTION
### Type of modification

- Documentation:
  - Markdown Files
- Other: `generate` helper script

### Changes

This PR adds Windows version of the helper script.

#### Feature description

I rewrote the `generate.sh` shell script in batch (`generate.bat`) and PowerShell (`generate.ps1`) to allow Windows users to use it.

I also updated the messages of the original script because I noticed some minor issues.

Finally, I updated the docs to reflect those changes.

#### Showcase

<details>
<summary>Batch help example</summary>

```
D:\Programmation\Java\Minalac\Generator>generate.bat /h
generate.bat [options] <format> <process> <place> [<outputdir>]
available options:
/h Displays this help message only
/g Stops before generation
/s Stops before saving
/y Displays Yaml configuration only
/l (formats|processes|places) Lists available formats/processes/places only
formats:
  minecraft
  minetest
processes:
  full
places:
  bagnolet
  boulouris
  ign
  lakeSaintMande
  martrou
  millau
  serreponcon
  stlazare
  villeneuve
outputdir is required if no option given (if directory exists, it will be emptied)
```
</details>

<details>
<summary>PowerShell help example</summary>
Note: Since the help message is partially auto-generated, some parts are in my computer's language (French)

```
PS D:\Programmation\Java\Minalac\Generator> .\generate.ps1 -h

NOM
    D:\Programmation\Java\Minalac\Generator\generate.ps1

RÉSUMÉ
    Helper script for Minalac Generator.


SYNTAXE
    D:\Programmation\Java\Minalac\Generator\generate.ps1 -Help [<CommonParameters>]

    D:\Programmation\Java\Minalac\Generator\generate.ps1 [-DisableGeneration] [-DisableSaving] [-YamlOnly] [-Format] <String> [-Process] <String> [-Place] <String> [<CommonParameters>]

    D:\Programmation\Java\Minalac\Generator\generate.ps1 -ListYaml <String> [<CommonParameters>]

    D:\Programmation\Java\Minalac\Generator\generate.ps1 [-Format] <String> [-Process] <String> [-Place] <String> [-OutputDir] <String> [<CommonParameters>]


DESCRIPTION
    This script can combine Yaml parameters from multiple files and
    launch the Generator.jar program with that parameters. Multiple
    options are available to control the process.


PARAMÈTRES
    -Help [<SwitchParameter>]
        Displays this help message only.

    -DisableGeneration [<SwitchParameter>]
        Stops before generation.

    -DisableSaving [<SwitchParameter>]
        Stops before saving.

    -YamlOnly [<SwitchParameter>]
        Displays Yaml configuration only.

    -ListYaml <String>
        Lists available formats/processes/places only.

    -Format <String>
        Name of the format to use.
        Use '-ListYaml formats' option to get the list of allowed values.

    -Process <String>
        Name of the process to use.
        Use '-ListYaml processes' option to get the list of allowed values.

    -Place <String>
        Name of the place to use.
        Use '-ListYaml places' option to get the list of allowed values.

    -OutputDir <String>
        Output directory where the result will be generated.

    <CommonParameters>
        Cette applet de commande prend en charge les paramètres courants : Verbose, Debug,
     ErrorAction, ErrorVariable, WarningAction, WarningVariable,
     OutBuffer, PipelineVariable et OutVariable. Pour plus d’informations, voir
     about_CommonParameters (https://go.microsoft.com/fwlink/?LinkID=113216).

REMARQUES
    Pour consulter les exemples, tapez : "get-help D:\Programmation\Java\Minalac\Generator\generate.ps1 -examples".
    Pour plus d'informations, tapez : "get-help D:\Programmation\Java\Minalac\Generator\generate.ps1 -detailed".
    Pour obtenir des informations techniques, tapez : "get-help D:\Programmation\Java\Minalac\Generator\generate.ps1 -full".

Formats: 
        minecraft
        minetest
Processes:
        full
Places:
        bagnolet
        boulouris
        ign
        lakeSaintMande
        martrou
        millau
        serreponcon
        stlazare
        villeneuve
```
</details>

### Reason

Since commit https://github.com/ignfab/minalac-generator/commit/63e5169d7c3da23213d07e68e641eba9483025ef, Windows users cannot really use the bundled example files to start the generator anymore. The solution I came up with was just to rewrite the shell script in batch, then I realized how terrible batch was, thus I did it in PowerShell as well.

Another solution would be to rewrite that helper script in a platform-independent language, such as Java (using Maven modules could allow us to keep the main generator apart from that helper tool, for example). This would require a little bit more work initially, but maybe a bit less later.

### Self-checks

- ~~The code has unit tests associated~~
- ~~The code has Javadoc Comments associated~~
- [x] Complex / Unexpected code is explained / justified with a small comment
- [x] Relevant documentation inside the `/docs` folder has been updated
- ~~All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)~~
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [x] The texts have been proofread (documentation, error messages, logs, comments...)
