### PR TITLE
Truncate metadata values post-processor

### DIFF
--- a/docs/usage/parameters/PostProcessing.md
+++ b/docs/usage/parameters/PostProcessing.md
@@ -14,6 +14,7 @@ Each post-processor has a field `type` which is used to identify it.
   * [Metadata default](#metadata-default)
   * [Metadata parse](#metadata-parse)
   * [Metadata remap](#metadata-remap)
+  * [Metadata truncate](#metadata-truncate)
 * [Geometry post-processors](#geometry-post-processors)
   * [Geometry buffer](#geometry-buffer)
 
@@ -195,6 +196,33 @@ toFrom:
   vine: Vigne
 default: grass
 ```
+
+### Metadata truncate
+
+Post-processor that truncates metadata values to integers.
+
+**Type**: `truncate`
+
+**Extra parameters**
+- `metadata` (required): Name of the metadata whose value will be truncated.
+- `method` (required): How value is truncated.
+
+| Method           | Explanation                                                      |
+|:-----------------|:-----------------------------------------------------------------|
+| `round`          | Round to nearest integer.                                        |
+| `ceil`           | Round up to the smallest integer greater than or equal to value. |
+| `floor`          | Round down to the largest integer less than or equal to value.   |
+
+- `ifMissing` (optional, default `error`): Policy to apply if metadata is missing (see below).
+- `ifTruncationFail` (optional, default `error`): Policy to apply if truncation fails (see below).
+Avaliable policies:
+
+| Policy           | Explanation                                          |
+|:-----------------|:-----------------------------------------------------|
+| `discardModel`   | The model is discarded.                              |
+| `removeMetadata` | The metadata is removed (no effect for `ifMissing`). |
+| `ignore`         | Metadata is not modified.                            |
+| `error`          | An error occurs, and the generation stops.           |
 
 ## Geometry post-processors
 

--- a/docs/usage/parameters/TileTasks.md
+++ b/docs/usage/parameters/TileTasks.md
@@ -121,7 +121,7 @@ filling: default:cobble
 
 Renders buildings using selected models as buildings footprint.
 
-Building height is given by `height` metadata (the behavior of this task is undefined if value is missing, negative or zero).
+Building height is given by `height` metadata (This task does nothing if the value is not an integer, missing, negative, or zero).
 
 #### Extra parameters
 

--- a/examples/processes/full.yaml
+++ b/examples/processes/full.yaml
@@ -35,6 +35,9 @@ forEachTile:
         as: decimal
         ifMissing: ignore
         ifNotParsable: removeMetadata
+      - type: truncate
+        metadata: height
+        method: round
       - type: default
         metadata: height
         value: 5

--- a/src/main/java/com/ignfab/minalac/generator/MinalacGenerator.java
+++ b/src/main/java/com/ignfab/minalac/generator/MinalacGenerator.java
@@ -29,6 +29,7 @@ import com.ignfab.minalac.generator.parameters.processors.post.JTSGeometryBuffer
 import com.ignfab.minalac.generator.parameters.processors.post.MetadataCopyPostProcessorParams;
 import com.ignfab.minalac.generator.parameters.processors.post.MetadataDefaultPostProcessorParams;
 import com.ignfab.minalac.generator.parameters.processors.post.MetadataParsePostProcessorParams;
+import com.ignfab.minalac.generator.parameters.processors.post.MetadataTruncatePostProcessorParams;
 import com.ignfab.minalac.generator.parameters.processors.post.MetadataValueMappingPostProcessorParams;
 import com.ignfab.minalac.generator.parameters.providers.GeoPackageProviderParams;
 import com.ignfab.minalac.generator.parameters.providers.GeoTiffProviderParams;
@@ -115,6 +116,7 @@ public final class MinalacGenerator {
         parser.registerParams("copy", MetadataCopyPostProcessorParams.class);
         parser.registerParams("default", MetadataDefaultPostProcessorParams.class);
         parser.registerParams("parse", MetadataParsePostProcessorParams.class);
+        parser.registerParams("truncate", MetadataTruncatePostProcessorParams.class);
         parser.registerParams("geometryBuffer", JTSGeometryBufferPostProcessorParams.class);
         parser.registerParams("remap", MetadataValueMappingPostProcessorParams.class);
 

--- a/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataParsePostProcessorParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataParsePostProcessorParams.java
@@ -7,15 +7,15 @@ import com.fasterxml.jackson.annotation.Nulls;
 
 import com.ignfab.minalac.generator.models.Model;
 import com.ignfab.minalac.generator.parameters.ValueParser;
-import com.ignfab.minalac.generator.processors.post.MetadataParsePostProcessor;
+import com.ignfab.minalac.generator.processors.post.MetadataFunctionPostProcessor;
 import com.ignfab.minalac.generator.processors.post.PostProcessor;
 
 /**
- * Parameters for {@link MetadataParsePostProcessor}.
+ * Parameters for parsing post processor.
  */
 public class MetadataParsePostProcessorParams extends PostProcessorParams {
     /**
-     * Name of the metadata to parse (required).
+     * Name of metadata to parse (required).
      */
     @JsonSetter(nulls = Nulls.FAIL)
     public final String metadata;
@@ -27,13 +27,13 @@ public class MetadataParsePostProcessorParams extends PostProcessorParams {
     public final ValueParser<?> as;
 
     /**
-     * Parsing function to use when the metadata is absent (optional).
+     * Policy to apply when the metadata is absent (optional).
      */
     @JsonSetter(nulls = Nulls.SKIP)
     public FailurePolicyParams ifMissing = FailurePolicyParams.ERROR;
 
     /**
-     * Parsing function to use when the {@code parser} return null (optional).
+     * Policy to apply when the {@code parser} returns null (optional).
      */
     @JsonSetter(nulls = Nulls.SKIP)
     public FailurePolicyParams ifNotParsable = FailurePolicyParams.ERROR;
@@ -62,7 +62,7 @@ public class MetadataParsePostProcessorParams extends PostProcessorParams {
         @SuppressWarnings("unchecked")
         ValueParser<Object> parser = (ValueParser<Object>) as;
 
-        return new MetadataParsePostProcessor<>(
+        return new MetadataFunctionPostProcessor<>(
             parser.type(),
             metadata,
             parser.parser(),

--- a/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataTruncatePostProcessorParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataTruncatePostProcessorParams.java
@@ -1,0 +1,110 @@
+package com.ignfab.minalac.generator.parameters.processors.post;
+
+import java.beans.ConstructorProperties;
+import java.util.function.DoubleFunction;
+import java.util.function.Function;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+
+import com.ignfab.minalac.generator.models.Model;
+import com.ignfab.minalac.generator.processors.post.MetadataFunctionPostProcessor;
+import com.ignfab.minalac.generator.processors.post.PostProcessor;
+
+/**
+ * Parameters for truncating values.
+ */
+public class MetadataTruncatePostProcessorParams extends PostProcessorParams {
+    /**
+     * Name of metadata to truncate (required).
+     */
+    @JsonSetter(nulls = Nulls.FAIL)
+    public String metadata;
+
+    /**
+     * Truncation method to apply (required).
+     */
+    @JsonSetter(nulls = Nulls.FAIL)
+    public TruncationMethodParams method;
+
+    /**
+     * Policy to apply when the metadata is absent (optional).
+     */
+    @JsonSetter(nulls = Nulls.SKIP)
+    public FailurePolicyParams ifMissing = FailurePolicyParams.ERROR;
+
+    /**
+     * Policy to apply if truncation fails (optional).
+     */
+    @JsonSetter(nulls = Nulls.SKIP)
+    public FailurePolicyParams ifTruncationFail = FailurePolicyParams.ERROR;
+
+    /**
+     * Constructor used to ensure that the required fields
+     * are present during deserialization.
+     *
+     * @param metadata metadata name to truncate
+     * @param method truncation method to apply
+     */
+    @ConstructorProperties({ "metadata", "method" })
+    public MetadataTruncatePostProcessorParams(String metadata, TruncationMethodParams method) {
+        this.metadata = metadata;
+        this.method = method;
+    }
+
+    @Override
+    public void validate() throws IllegalArgumentException {
+        if (metadata.isBlank())
+            throw new IllegalArgumentException("The 'metadata' field cannot be empty or contain only whitespace.");
+    }
+
+    @Override
+    public PostProcessor<Model, Model> create() {
+        return new MetadataFunctionPostProcessor<>(
+            Integer.class,
+            metadata,
+            method.create(),
+            ifMissing.create(),
+            ifTruncationFail.create()
+        );
+    }
+
+    /**
+     * Truncation methods that can be applied to numeric values.
+     */
+    public enum TruncationMethodParams {
+        /**
+         * Round to nearest integer.
+         */
+        @JsonProperty("round")
+        ROUND(Math::round),
+        /**
+         * Round up to next integer.
+         */
+        @JsonProperty("ceil")
+        CEIL(Math::ceil),
+        /**
+         * Round down to previous integer.
+         */
+        @JsonProperty("floor")
+        FLOOR(Math::floor);
+
+        private final DoubleFunction<Number> method;
+
+        TruncationMethodParams(DoubleFunction<Number> method) {
+            this.method = method;
+        }
+
+        /**
+         * {@return the associated method}
+         */
+        public Function<Object, Integer> create() {
+            return obj -> {
+                if (obj instanceof Number number)
+                    return method.apply(number.doubleValue()).intValue();
+                throw new IllegalArgumentException("Truncation failed: metadata value is not a number.");
+            };
+        }
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/processors/post/MetadataFunctionPostProcessor.java
+++ b/src/main/java/com/ignfab/minalac/generator/processors/post/MetadataFunctionPostProcessor.java
@@ -9,36 +9,36 @@ import com.ignfab.minalac.generator.models.Model;
 /**
  * Post-processor parsing a metadata value in-place.
  *
- * @param <T> type of parsed value
+ * @param <T> type of the resulting value
  */
-public class MetadataParsePostProcessor<T> extends PostProcessor.Generic {
+public class MetadataFunctionPostProcessor<T> extends PostProcessor.Generic {
     private final String name;
     private final Class<T> type;
-    private final Function<Object, ? extends T> parser;
+    private final Function<Object, ? extends T> function;
     private final FailurePolicy ifMissingMetadata;
-    private final FailurePolicy ifParserFails;
+    private final FailurePolicy ifFunctionFails;
 
     /**
-     * Creates a new post-processor parsing metadata {@code name} as a {@code type}.
+     * Creates a new post-processor that applies a function on a metadata value.
      *
-     * @param type type of parsed value
-     * @param name name of the metadata to parse
-     * @param parser parsing function to use
+     * @param type type of the resulting value
+     * @param name name of the metadata to process
+     * @param function function to apply
      * @param ifMissingMetadata policy to apply when the metadata is absent
-     * @param ifParserFails policy to apply when the {@code parser} return error
+     * @param ifFunctionFails policy to apply when the {@code function} returns an error
      */
-    public MetadataParsePostProcessor(
+    public MetadataFunctionPostProcessor(
         Class<T> type,
         String name,
-        Function<Object, ? extends T> parser,
+        Function<Object, ? extends T> function,
         FailurePolicy ifMissingMetadata,
-        FailurePolicy ifParserFails
+        FailurePolicy ifFunctionFails
     ) {
         this.type = type;
         this.name = name;
-        this.parser = parser;
+        this.function = function;
         this.ifMissingMetadata = ifMissingMetadata;
-        this.ifParserFails = ifParserFails;
+        this.ifFunctionFails = ifFunctionFails;
     }
 
     @Override
@@ -57,14 +57,14 @@ public class MetadataParsePostProcessor<T> extends PostProcessor.Generic {
             return model;
 
         try {
-            T parsed = parser.apply(value);
+            T parsed = function.apply(value);
             model.setMetadata(name, parsed);
         } catch (Throwable e) {
-            switch (ifParserFails) {
+            switch (ifFunctionFails) {
                 case IGNORE -> {}
                 case REMOVE_METADATA -> model.setMetadata(name, null);
-                case DISCARD_MODEL -> throw new IgnorableException("Failed to parse metadata: " + name, e);
-                case ERROR -> throw new GenerationFailedException("Failed to parse metadata: " + name, e);
+                case DISCARD_MODEL -> throw new IgnorableException("Failed to process metadata: " + name, e);
+                case ERROR -> throw new GenerationFailedException("Failed to process metadata: " + name, e);
             }
         }
         return model;

--- a/src/main/java/com/ignfab/minalac/generator/tasks/RenderBuildingsTask.java
+++ b/src/main/java/com/ignfab/minalac/generator/tasks/RenderBuildingsTask.java
@@ -62,11 +62,8 @@ public class RenderBuildingsTask extends ModelTask<ShapesVoxelizable2d> {
 
     @Override
     protected void run(ShapesVoxelizable2d model, GenerationTile tile) {
-        // TODO: Implement a post-processor for value rounding to rollback this change
-        int height = (int) Math.round(
-            /* Casting to Number is needed to avoid a cast exception in RenderBuildingsTask */
-            ((Number) model.getMetadata("height")).doubleValue()
-        );
+        if (!(model.getMetadata("height") instanceof Integer height) || height <= 0)
+            return;
 
         ReadableHeightmap heightmap = tile.heightmaps().get(heightmapSpec);
         ShapesVoxelizer2d voxelizer = model.voxelize2d(tile.limits().to2d());

--- a/src/test/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataTruncatePostProcessorParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataTruncatePostProcessorParamsTest.java
@@ -1,0 +1,62 @@
+package com.ignfab.minalac.generator.parameters.processors.post;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.junit.jupiter.api.Test;
+
+import com.ignfab.minalac.generator.parameters.processors.post.MetadataTruncatePostProcessorParams.TruncationMethodParams;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MetadataTruncatePostProcessorParamsTest {
+    @Test
+    public void testCreate() {
+        assertDoesNotThrow(new MetadataTruncatePostProcessorParams("metadata", TruncationMethodParams.ROUND)::create);
+    }
+
+    @Test
+    public void testValidate() {
+        assertDoesNotThrow(
+            new MetadataTruncatePostProcessorParams("metadata", TruncationMethodParams.ROUND)::validate
+        );
+
+        assertThrows(
+            IllegalArgumentException.class,
+            new MetadataTruncatePostProcessorParams("", TruncationMethodParams.ROUND)::validate
+        );
+    }
+
+    @Test
+    public void testDeserialize() throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        mapper.registerSubtypes(new NamedType(MetadataTruncatePostProcessorParams.class, "truncate"));
+
+        MetadataTruncatePostProcessorParams params = assertDoesNotThrow(() -> mapper.readValue(
+            """
+                type: truncate
+                metadata: tata
+                method: round
+                ifMissing: discardModel
+                ifTruncationFail: removeMetadata
+            """,
+            MetadataTruncatePostProcessorParams.class
+        ));
+        assertEquals("tata", params.metadata);
+        assertEquals(TruncationMethodParams.ROUND, params.method);
+        assertEquals(FailurePolicyParams.DISCARD_MODEL, params.ifMissing);
+        assertEquals(FailurePolicyParams.REMOVE_METADATA, params.ifTruncationFail);
+
+        params = assertDoesNotThrow(() -> mapper.readValue(
+            """
+                type: truncate
+                metadata: tata
+                method: round
+            """,
+            MetadataTruncatePostProcessorParams.class
+        ));
+        assertEquals("tata", params.metadata);
+        assertEquals(TruncationMethodParams.ROUND, params.method);
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/processors/post/MetadataFunctionPostProcessorTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/processors/post/MetadataFunctionPostProcessorTest.java
@@ -13,7 +13,7 @@ import com.ignfab.minalac.generator.models.TestingModel;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class MetadataParsePostProcessorTest {
+public class MetadataFunctionPostProcessorTest {
     private Model model;
 
     @BeforeEach
@@ -24,14 +24,14 @@ public class MetadataParsePostProcessorTest {
         ));
     }
 
-    private TestingModel getProcessed(MetadataParsePostProcessor<?> postProcessor) {
+    private TestingModel getProcessed(MetadataFunctionPostProcessor<?> postProcessor) {
         Model processedModel = assertDoesNotThrow(() -> postProcessor.process(model));
         return assertInstanceOf(TestingModel.class, processedModel);
     }
 
     @Test
     public void testSimpleParse() {
-        TestingModel processed = getProcessed(new MetadataParsePostProcessor<>(
+        TestingModel processed = getProcessed(new MetadataFunctionPostProcessor<>(
             String.class,
             "int",
             Objects::toString,
@@ -45,7 +45,7 @@ public class MetadataParsePostProcessorTest {
 
     @Test
     public void testParsingError() {
-        assertThrows(GenerationFailedException.class, () -> new MetadataParsePostProcessor<>(
+        assertThrows(GenerationFailedException.class, () -> new MetadataFunctionPostProcessor<>(
             String.class,
             "int",
             obj -> {
@@ -58,7 +58,7 @@ public class MetadataParsePostProcessorTest {
 
     @Test
     public void testMissingAllowed() {
-        TestingModel processed = getProcessed(new MetadataParsePostProcessor<>(
+        TestingModel processed = getProcessed(new MetadataFunctionPostProcessor<>(
             String.class,
             "missing",
             Objects::toString,
@@ -70,7 +70,7 @@ public class MetadataParsePostProcessorTest {
 
     @Test
     public void testMissingForbidden() {
-        assertThrows(GenerationFailedException.class, () -> new MetadataParsePostProcessor<>(
+        assertThrows(GenerationFailedException.class, () -> new MetadataFunctionPostProcessor<>(
             String.class,
             "missing",
             Objects::toString,
@@ -81,7 +81,7 @@ public class MetadataParsePostProcessorTest {
 
     @Test
     public void testNullAllowed() {
-        TestingModel processed = getProcessed(new MetadataParsePostProcessor<>(
+        TestingModel processed = getProcessed(new MetadataFunctionPostProcessor<>(
             String.class,
             "int",
             obj -> null,
@@ -93,7 +93,7 @@ public class MetadataParsePostProcessorTest {
 
     @Test
     public void testFailurePolicyIgnore() {
-        TestingModel processed = getProcessed(new MetadataParsePostProcessor<>(
+        TestingModel processed = getProcessed(new MetadataFunctionPostProcessor<>(
             String.class,
             "int",
             obj -> {
@@ -107,7 +107,7 @@ public class MetadataParsePostProcessorTest {
 
     @Test
     public void testFailurePolicyRemove() {
-        TestingModel processed = getProcessed(new MetadataParsePostProcessor<>(
+        TestingModel processed = getProcessed(new MetadataFunctionPostProcessor<>(
             String.class,
             "int",
             obj -> {
@@ -121,7 +121,7 @@ public class MetadataParsePostProcessorTest {
 
     @Test
     public void testFailurePolicySkip() {
-        assertThrows(IgnorableException.class, () -> new MetadataParsePostProcessor<>(
+        assertThrows(IgnorableException.class, () -> new MetadataFunctionPostProcessor<>(
             String.class,
             "int",
             obj -> {
@@ -134,7 +134,7 @@ public class MetadataParsePostProcessorTest {
 
     @Test
     public void testFailurePolicyError() {
-        assertThrows(GenerationFailedException.class, () -> new MetadataParsePostProcessor<>(
+        assertThrows(GenerationFailedException.class, () -> new MetadataFunctionPostProcessor<>(
             String.class,
             "int",
             obj -> {


### PR DESCRIPTION
<!--
Thank you for contributing to this project!
You must fill out the information below before we can review this pull request.
Be sure to update the relevant sections of this template and to complete the list of self-checks at the end.

If you need more time to check everything, consider opening a draft pull request instead.
Don't forget to update this comment to track your progress.
-->

### Type of modification

Types:
- Code
  - Renderers
  - Post-Processor

#### Feature description

Added a post-processor which allow to use `round`, `ceil` and `floor` mathematic rounding method on metadata value, also it scaling the metadata value to horizontal and vertical voxel scale.

### Reason

In the future, when we going to implement the roof renderer, we must apply a rounding on value of `height` metadata. This rounding will be present on two renderers (maybe, will be present on more renderers later). 

To stay renderers stupid as possible, that's why i suggest this post-processor.

### Self-checks

- [x] The code has unit tests associated
- [x] The code has Javadoc Comments associated

~~[ ] Complex / Unexpected code is explained / justified with a small comment~~

- [x] Relevant documentation inside the `/docs` folder has been updated
- [x] All examples in `exemples/` work the same (or have been adapted if subject to changes in this PR)
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [x] The texts have been proofread (documentation, error messages, logs, comments...)
