### PR TITLE
feat(input): Add GeoTiff format support

### DIFF
--- a/docs/usage/parameters/FetchDataTask.md
+++ b/docs/usage/parameters/FetchDataTask.md
@@ -11,11 +11,12 @@ Task of type `fetchData` fetches data from geographic data source, processes it,
   * [`gpkg` (GeoPackage)](#gpkg-geopackage)
   * [`shapefile` (Shapefile)](#shapefile-shapefile)
   * [`wmsFloat` (Web Map Service with floating point values)](#wmsfloat-web-map-service-with-floating-point-values)
+  * [`geotiff` (GeoTiff)](#geotiff-geotiff)
 * [Processors](#processors)
   * [`geoToolsVector` (GeoTools vector processor)](#geotoolsvector-geotools-vector-processor)
   * [`floatMatrix` (Float matrix processor)](#floatmatrix-float-matrix-processor)
 
-See also [post processing](PostProcessing.md) documentation.
+See also [post-processing](PostProcessing.md) documentation.
 
 ## Example
 
@@ -93,6 +94,15 @@ Provider of type `wmsFloat` fetches **float** data from a [Web Map Service](http
 
 **Suitable processors**: `floatMatrix`
 
+### `geotiff` (GeoTiff)
+Provider of type `geotiff` reads **float** (for now) raster data from a [GeoTiff](https://en.wikipedia.org/wiki/GeoTIFF) file.
+
+**Extra parameters**:
+- `filePath` (required): Path of the GeoTiff file (absolute, or relative to execution context)
+- `crsOverride` (optional, default none): CRS to use when reading data. By default, the CRS is read from the GeoTiff itself. You should only use this parameter if the CRS is invalid or missing from the file. This **DOES NOT** reproject data!
+
+**Suitable processors**: `floatMatrix`
+
 ## Processors
 
 A processor converts data from a provider into models. Processor type is identified by `type` field.
@@ -109,4 +119,4 @@ Processor of type `floatMatrix` translates a float data matrix to a model.
 
 **Extra parameters**: None
 
-**Suitable providers**: `wmsFloat`
+**Suitable providers**: `wmsFloat`, `geotiff`

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,11 @@
             <artifactId>gt-shapefile</artifactId>
             <version>${geotools.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-geotiff</artifactId>
+            <version>${geotools.version}</version>
+        </dependency>
         <!--
             Required to identify coordinates reference systems
             Example error: No code "EPSG:4326" from authority "EPSG"
@@ -222,6 +227,16 @@
                         <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                             <!-- With at least an entry "Main-Class: ..." to make it executable -->
                             <mainClass>com.ignfab.minalac.generator.MinalacGenerator</mainClass>
+                            <!-- And manifest entries from javax.media:jai_imageio, required for GeoTools GeoTiff module -->
+                            <manifestEntries>
+                                <Name>javax/media/jai/</Name>
+                                <Specification-Title>Java Advanced Imaging Image I/O Tools</Specification-Title>
+                                <Specification-Version>1.1</Specification-Version>
+                                <Specification-Vendor>Sun Microsystems, Inc.</Specification-Vendor>
+                                <Implementation-Title>com.sun.media.imageio</Implementation-Title>
+                                <Implementation-Version>1.1</Implementation-Version>
+                                <Implementation-Vendor>Sun Microsystems, Inc.</Implementation-Vendor>
+                            </manifestEntries>
                         </transformer>
                         <!-- Properly shades all resources, required for GeoTools HSQL embedded databases -->
                         <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />

--- a/src/main/java/com/ignfab/minalac/generator/MinalacGenerator.java
+++ b/src/main/java/com/ignfab/minalac/generator/MinalacGenerator.java
@@ -31,6 +31,7 @@ import com.ignfab.minalac.generator.parameters.processors.post.MetadataDefaultPo
 import com.ignfab.minalac.generator.parameters.processors.post.MetadataParsePostProcessorParams;
 import com.ignfab.minalac.generator.parameters.processors.post.MetadataValueMappingPostProcessorParams;
 import com.ignfab.minalac.generator.parameters.providers.GeoPackageProviderParams;
+import com.ignfab.minalac.generator.parameters.providers.GeoTiffProviderParams;
 import com.ignfab.minalac.generator.parameters.providers.ShapefileProviderParams;
 import com.ignfab.minalac.generator.parameters.providers.WFSProviderParams;
 import com.ignfab.minalac.generator.parameters.providers.WMSFloatBilProviderParams;
@@ -103,6 +104,7 @@ public final class MinalacGenerator {
         parser.registerParams("gpkg", GeoPackageProviderParams.class);
         parser.registerParams("shapefile", ShapefileProviderParams.class);
         parser.registerParams("wmsFloat", WMSFloatBilProviderParams.class);
+        parser.registerParams("geotiff", GeoTiffProviderParams.class);
 
         parser.registerParams("floatMatrix", FloatMatrixProcessorParams.class);
         parser.registerParams("geoToolsVector", GeoToolsVectorProcessorParams.class);

--- a/src/main/java/com/ignfab/minalac/generator/MinalacGeneratorCLI.java
+++ b/src/main/java/com/ignfab/minalac/generator/MinalacGeneratorCLI.java
@@ -14,6 +14,8 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
+import com.ignfab.minalac.generator.utils.FileHelpers;
+
 /**
  * A command line parser and basic processor.
  * MinalacGeneratorCLI performs parsing, basic validation and some basic tasks such as retrieving generation parameters.
@@ -127,21 +129,11 @@ public class MinalacGeneratorCLI {
      * @return Content of parameters file/variable
      */
     public String readParameters() {
-        String parameters = null; // Must please linter with uninitialized parameters
+        String parameters;
 
         if (parametersPath != null) {
-            if (!Files.exists(parametersPath)) {
-                System.err.printf("%s does not exist%n", parametersPath);
-                System.exit(1);
-            }
-
-            if (!Files.isRegularFile(parametersPath)) {
-                System.err.printf("%s is not a regular file%n", parametersPath);
-                System.exit(1);
-            }
-
-            if (!Files.isReadable(parametersPath)) {
-                System.err.printf("%s is not readable%n", parametersPath);
+            if (!FileHelpers.isReadableRegularFile(parametersPath)) {
+                System.err.printf("%s is not a regular readable file%n", parametersPath);
                 System.exit(1);
             }
 
@@ -151,16 +143,17 @@ public class MinalacGeneratorCLI {
                 System.err.printf("Error reading parameters from %s%n", parametersPath);
                 e.printStackTrace();
                 System.exit(1);
+                return null; // never actually reached
             }
         } else {
             parameters = System.getenv(PARAMS_ENVVAR_NAME);
+            if (parameters == null || parameters.isBlank()) {
+                System.err.printf("Please provide generation parameters (either with -p option or using %s environment variable)%n", PARAMS_ENVVAR_NAME);
+                usage();
+                System.exit(1);
+            }
         }
 
-        if (parameters == null) {
-            System.err.printf("Please provide generation parameters (either with -p option or using %s environment variable)%n", PARAMS_ENVVAR_NAME);
-            usage();
-            System.exit(1);
-        }
         return parameters;
     }
 

--- a/src/main/java/com/ignfab/minalac/generator/inputs/FloatArrayGeographicDataMatrix2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/FloatArrayGeographicDataMatrix2d.java
@@ -1,0 +1,43 @@
+package com.ignfab.minalac.generator.inputs;
+
+/**
+ * A matrix of float values.
+ * <p>
+ * Beware: y-axis start from bottom and ends on top of the matrix.
+ *
+ * @param data float data as an array (must have a size of {@code sizeX} * {@code sizeY})
+ * @param sizeX size of data matrix on x-axis
+ * @param sizeY size of data matrix on y-axis
+ * @param offsetX geographic offset for x-axis (position of matrix point 0 on map)
+ * @param offsetY geographic offset for y-axis (position of matrix point 0 on map)
+ * @param cellSizeX geographic size on x-axis of a matrix cell
+ * @param cellSizeY geographic size on y-axis of a matrix cell
+ */
+public record FloatArrayGeographicDataMatrix2d(
+    float[] data,
+    int sizeX,
+    int sizeY,
+    double offsetX,
+    double offsetY,
+    double cellSizeX,
+    double cellSizeY
+) implements FloatGeographicDataMatrix2d {
+
+    /**
+     * Creates a new FloatArrayGeographicDataMatrix2d with empty data.
+     * @param sizeX size of data matrix on x-axis
+     * @param sizeY size of data matrix on y-axis
+     * @param offsetX geographic offset for x-axis (position of matrix point 0 on map)
+     * @param offsetY geographic offset for y-axis (position of matrix point 0 on map)
+     * @param cellSizeX geographic size on x-axis of a matrix cell
+     * @param cellSizeY geographic size on y-axis of a matrix cell
+     */
+    public FloatArrayGeographicDataMatrix2d(int sizeX, int sizeY, double offsetX, double offsetY, double cellSizeX, double cellSizeY) {
+        this(new float[sizeX * sizeY], sizeX, sizeY, offsetX, offsetY, cellSizeX, cellSizeY);
+    }
+
+    @Override
+    public Float get(int x, int y) {
+        return data[x + (sizeY - y - 1) * sizeX];
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/inputs/FloatArrayGeographicDataMatrix2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/FloatArrayGeographicDataMatrix2d.java
@@ -37,7 +37,7 @@ public record FloatArrayGeographicDataMatrix2d(
     }
 
     @Override
-    public Float get(int x, int y) {
+    public float getFloat(int x, int y) {
         return data[x + (sizeY - y - 1) * sizeX];
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/inputs/FloatGeographicDataMatrix2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/FloatGeographicDataMatrix2d.java
@@ -2,42 +2,5 @@ package com.ignfab.minalac.generator.inputs;
 
 /**
  * A matrix of float values.
- * <p>
- * Beware: y-axis start from bottom and ends on top of the matrix.
- *
- * @param data float data as an array (must have a size of {@code sizeX} * {@code sizeY})
- * @param sizeX size of data matrix on x-axis
- * @param sizeY size of data matrix on y-axis
- * @param offsetX geographic offset for x-axis (position of matrix point 0 on map)
- * @param offsetY geographic offset for y-axis (position of matrix point 0 on map)
- * @param cellSizeX geographic size on x-axis of a matrix cell
- * @param cellSizeY geographic size on y-axis of a matrix cell
  */
-public record FloatGeographicDataMatrix2d(
-    float[] data,
-    int sizeX,
-    int sizeY,
-    double offsetX,
-    double offsetY,
-    double cellSizeX,
-    double cellSizeY
-) implements GeographicDataMatrix2d<Float> {
-
-    /**
-     * Creates a new FloatGeographicDataMatrix2d with empty data.
-     * @param sizeX size of data matrix on x-axis
-     * @param sizeY size of data matrix on y-axis
-     * @param offsetX geographic offset for x-axis (position of matrix point 0 on map)
-     * @param offsetY geographic offset for y-axis (position of matrix point 0 on map)
-     * @param cellSizeX geographic size on x-axis of a matrix cell
-     * @param cellSizeY geographic size on y-axis of a matrix cell
-     */
-    public FloatGeographicDataMatrix2d(int sizeX, int sizeY, double offsetX, double offsetY, double cellSizeX, double cellSizeY) {
-        this(new float[sizeX * sizeY], sizeX, sizeY, offsetX, offsetY, cellSizeX, cellSizeY);
-    }
-
-    @Override
-    public Float get(int x, int y) {
-        return data[x + (sizeY - y - 1) * sizeX];
-    }
-}
+public interface FloatGeographicDataMatrix2d extends GeographicDataMatrix2d<Float> {}

--- a/src/main/java/com/ignfab/minalac/generator/inputs/FloatGeographicDataMatrix2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/FloatGeographicDataMatrix2d.java
@@ -3,4 +3,23 @@ package com.ignfab.minalac.generator.inputs;
 /**
  * A matrix of float values.
  */
-public interface FloatGeographicDataMatrix2d extends GeographicDataMatrix2d<Float> {}
+public interface FloatGeographicDataMatrix2d extends GeographicDataMatrix2d<Float> {
+    /**
+     * @deprecated Use type-specific {@link #getFloat(int, int)}
+     */
+    @Override
+    @Deprecated
+    default Float get(int x, int y) {
+        return getFloat(x, y);
+    }
+
+    /**
+     * Returns a float value at a given coordinates in the matrix.
+     *
+     * @param x x-coordinate from {@code 0} to {@code sizeX() - 1}
+     * @param y y-coordinate from {@code 0} to {@code sizeY() - 1}
+     *
+     * @return float value at given coordinates
+     */
+    float getFloat(int x, int y);
+}

--- a/src/main/java/com/ignfab/minalac/generator/inputs/FloatImageGeographicDataMatrix2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/FloatImageGeographicDataMatrix2d.java
@@ -1,0 +1,35 @@
+package com.ignfab.minalac.generator.inputs;
+
+import javax.media.jai.iterator.RandomIter;
+
+/**
+ * A matrix of float values.
+ * <p>
+ * Beware: y-axis start from bottom and ends on top of the matrix.
+ *
+ * @param data float data as a view of an image (must be of size {@code sizeX} * {@code sizeY})
+ * @param dataOriginX pixel offset inside the data view on x-axis
+ * @param dataOriginY pixel offset inside the data view on y-axis
+ * @param sizeX size of data matrix on x-axis
+ * @param sizeY size of data matrix on y-axis
+ * @param offsetX geographic offset for x-axis (position of matrix point 0 on map)
+ * @param offsetY geographic offset for y-axis (position of matrix point 0 on map)
+ * @param cellSizeX geographic size on x-axis of a matrix cell
+ * @param cellSizeY geographic size on y-axis of a matrix cell
+ */
+public record FloatImageGeographicDataMatrix2d(
+    RandomIter data,
+    int dataOriginX,
+    int dataOriginY,
+    int sizeX,
+    int sizeY,
+    double offsetX,
+    double offsetY,
+    double cellSizeX,
+    double cellSizeY
+) implements FloatGeographicDataMatrix2d {
+    @Override
+    public Float get(int x, int y) {
+        return data.getSampleFloat(dataOriginX + x, dataOriginY + sizeY - y - 1, 0);
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/inputs/FloatImageGeographicDataMatrix2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/FloatImageGeographicDataMatrix2d.java
@@ -29,7 +29,7 @@ public record FloatImageGeographicDataMatrix2d(
     double cellSizeY
 ) implements FloatGeographicDataMatrix2d {
     @Override
-    public Float get(int x, int y) {
+    public float getFloat(int x, int y) {
         return data.getSampleFloat(dataOriginX + x, dataOriginY + sizeY - y - 1, 0);
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/inputs/GeoTiffDataProvider.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/GeoTiffDataProvider.java
@@ -1,0 +1,105 @@
+package com.ignfab.minalac.generator.inputs;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Iterator;
+import javax.media.jai.iterator.RandomIter;
+import javax.media.jai.iterator.RandomIterFactory;
+
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.coverage.grid.GridCoverage2D;
+import org.geotools.coverage.grid.GridEnvelope2D;
+import org.geotools.gce.geotiff.GeoTiffReader;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.util.factory.Hints;
+
+import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
+import com.ignfab.minalac.generator.exceptions.RetryableException;
+import com.ignfab.minalac.generator.exceptions.TransformException;
+import com.ignfab.minalac.generator.utils.coordinates.EnvelopeProvider;
+import com.ignfab.minalac.generator.utils.iterator.Iterators;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+
+/**
+ * Data provider for GeoTiff files (raster data).
+ */
+public class GeoTiffDataProvider implements Provider<FloatGeographicDataMatrix2d> {
+    private final File file;
+    private final CoordinateReferenceSystem crsOverride;
+    private final EnvelopeProvider envelopeProvider;
+
+    /**
+     * Creates a new {@code GeoTiffDataProvider}.
+     *
+     * @param file the GeoTiff file
+     * @param crsOverride the CRS to use regardless of one found in data.
+     * @param envelopeProvider function to use to compute envelopes from bounding boxes
+     */
+    public GeoTiffDataProvider(File file, CoordinateReferenceSystem crsOverride, EnvelopeProvider envelopeProvider) {
+        this.file = file;
+        this.crsOverride = crsOverride;
+        this.envelopeProvider = envelopeProvider;
+    }
+
+    @Override
+    public Class<FloatGeographicDataMatrix2d> providedType() {
+        return FloatGeographicDataMatrix2d.class;
+    }
+
+    @Override
+    public Provider.Result<FloatGeographicDataMatrix2d> provide(WorldBBox3d bbox) throws GenerationFailedException, RetryableException {
+        GridCoverage2D grid;
+        try {
+            grid = new GeoTiffReader(file, crsOverride == null ? null : new Hints(Hints.DEFAULT_COORDINATE_REFERENCE_SYSTEM, crsOverride)).read(null);
+        } catch (IOException e) {
+            throw new RetryableException(e);
+        }
+        CoordinateReferenceSystem crs = grid.getCoordinateReferenceSystem();
+
+        ReferencedEnvelope envelope;
+        GridEnvelope2D gridEnvelope;
+        try {
+            envelope = envelopeProvider.computeForCRS(crs, bbox).intersection(grid.getGridGeometry().getEnvelope2D());
+            gridEnvelope = grid.getGridGeometry().worldToGrid(envelope);
+        } catch (FactoryException | TransformException | org.geotools.api.referencing.operation.TransformException e) {
+            throw new GenerationFailedException(e);
+        }
+
+        // RandomIter provides a view of the underlying image to read arbitrary pixel values
+        RandomIter data = RandomIterFactory.create(grid.getRenderedImage(), gridEnvelope);
+
+        FloatGeographicDataMatrix2d result = new FloatImageGeographicDataMatrix2d(
+            data,
+            gridEnvelope.x,
+            gridEnvelope.y,
+            gridEnvelope.width,
+            gridEnvelope.height,
+            envelope.getMinX(),
+            envelope.getMinY(),
+            envelope.getWidth() / gridEnvelope.width,
+            envelope.getHeight() / gridEnvelope.height
+        );
+
+        return new Result(crs, result);
+    }
+
+    private record Result(CoordinateReferenceSystem crs, Iterator<FloatGeographicDataMatrix2d> iterator) implements Provider.Result<FloatGeographicDataMatrix2d> {
+        Result(CoordinateReferenceSystem crs, FloatGeographicDataMatrix2d data) {
+            this(crs, Iterators.iterator(data));
+        }
+
+        @Override
+        public void close() {}
+
+        @Override
+        public boolean hasNext() {
+            return iterator.hasNext();
+        }
+
+        @Override
+        public FloatGeographicDataMatrix2d next() {
+            return iterator.next();
+        }
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/inputs/GeographicDataMatrix2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/GeographicDataMatrix2d.java
@@ -2,6 +2,8 @@ package com.ignfab.minalac.generator.inputs;
 
 /**
  * A matrix of values.
+ * This class is generic and should only be used through one of its concrete extension.
+ * @see FloatGeographicDataMatrix2d
  *
  * @param <T> type of the value
  */

--- a/src/main/java/com/ignfab/minalac/generator/inputs/GeographicDataMatrix2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/GeographicDataMatrix2d.java
@@ -12,8 +12,8 @@ public interface GeographicDataMatrix2d<T> {
     /**
      * Returns a value at a given coordinates in the matrix.
      *
-     * @param x x-coordinate from 0 to maxX()
-     * @param y y-coordinate from 0 to maxY()
+     * @param x x-coordinate from {@code 0} to {@code sizeX() - 1}
+     * @param y y-coordinate from {@code 0} to {@code sizeY() - 1}
      *
      * @return value at given coordinates
      */

--- a/src/main/java/com/ignfab/minalac/generator/inputs/WMSFloatBilDataProvider.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/WMSFloatBilDataProvider.java
@@ -117,13 +117,14 @@ public class WMSFloatBilDataProvider implements Provider<FloatGeographicDataMatr
         if (total != size)
             throw new RetryableException("Incomplete data read from stream");
 
-        FloatGeographicDataMatrix2d result = new FloatGeographicDataMatrix2d(
+        FloatArrayGeographicDataMatrix2d result = new FloatArrayGeographicDataMatrix2d(
             width,
             height,
             envelope.getMinX(),
             envelope.getMinY(),
             envelope.getWidth() / width,
-            envelope.getHeight() / height);
+            envelope.getHeight() / height
+        );
 
         ByteBuffer.wrap(data).order(ByteOrder.LITTLE_ENDIAN).asFloatBuffer().get(result.data());
 
@@ -133,8 +134,8 @@ public class WMSFloatBilDataProvider implements Provider<FloatGeographicDataMatr
     /**
      * Result returned by provide method. Here, only one result is provided.
      */
-    public class Result implements Provider.Result<FloatGeographicDataMatrix2d> {
-        private Iterator<FloatGeographicDataMatrix2d> iterator;
+    private class Result implements Provider.Result<FloatGeographicDataMatrix2d> {
+        private final Iterator<FloatGeographicDataMatrix2d> iterator;
 
         Result(FloatGeographicDataMatrix2d data) {
             iterator = Iterators.iterator(data);

--- a/src/main/java/com/ignfab/minalac/generator/models/FloatMatrixModel.java
+++ b/src/main/java/com/ignfab/minalac/generator/models/FloatMatrixModel.java
@@ -77,8 +77,8 @@ public class FloatMatrixModel extends ModelImpl implements Matrix2d<Float> {
         float fx = x - xf;
         float fy = y - yf;
 
-        return (1 - fy) * ((1 - fx) * data.get(xf, yf) + fx * data.get(xc, yf))
-            + fy * ((1 - fx) * data.get(xf, yc) + fx * data.get(xc, yc));
+        return (1 - fy) * ((1 - fx) * data.getFloat(xf, yf) + fx * data.getFloat(xc, yf))
+            + fy * ((1 - fx) * data.getFloat(xf, yc) + fx * data.getFloat(xc, yc));
     }
 
     @Override

--- a/src/main/java/com/ignfab/minalac/generator/models/FloatMatrixModel.java
+++ b/src/main/java/com/ignfab/minalac/generator/models/FloatMatrixModel.java
@@ -1,7 +1,7 @@
 package com.ignfab.minalac.generator.models;
 
 import com.ignfab.minalac.generator.exceptions.TransformException;
-import com.ignfab.minalac.generator.inputs.GeographicDataMatrix2d;
+import com.ignfab.minalac.generator.inputs.FloatGeographicDataMatrix2d;
 import com.ignfab.minalac.generator.utils.coordinates.MapCoordinates;
 import com.ignfab.minalac.generator.utils.coordinates.MapToWorldConverter;
 import com.ignfab.minalac.generator.utils.coordinates.WorldToMapConverter;
@@ -13,7 +13,7 @@ import com.ignfab.minalac.generator.voxelization.Matrix2d;
  * A model based on a matrix of floats (usually a heightmap model).
  */
 public class FloatMatrixModel extends ModelImpl implements Matrix2d<Float> {
-    private GeographicDataMatrix2d<Float> data;
+    private FloatGeographicDataMatrix2d data;
     private MapToWorldConverter mapToWorld;
     private WorldToMapConverter worldToMap;
     private WorldBBox2d bbox;
@@ -25,7 +25,7 @@ public class FloatMatrixModel extends ModelImpl implements Matrix2d<Float> {
      * @param converter coordinates converter from matrix to world
      * @throws TransformException
      */
-    public FloatMatrixModel(GeographicDataMatrix2d<Float> data, MapToWorldConverter converter) throws TransformException {
+    public FloatMatrixModel(FloatGeographicDataMatrix2d data, MapToWorldConverter converter) throws TransformException {
         mapToWorld = converter;
         try {
             worldToMap = mapToWorld.inverse();

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelWorld.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelWorld.java
@@ -1,13 +1,12 @@
 package com.ignfab.minalac.generator.outputs.minetest;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
-import java.io.PrintWriter;
 import java.util.Collection;
 
 import com.ignfab.minalac.generator.generation.SquareUnitsTileGenerator;
 import com.ignfab.minalac.generator.outputs.minetest.utils.SQLiteMapWriter;
+import com.ignfab.minalac.generator.utils.FileHelpers;
 import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
@@ -77,33 +76,23 @@ public class MTVoxelWorld extends VoxelWorld {
         if (destination == null)
             return; // Save disabled if null destination
 
-        createFile(new File(destination, "world.mt"), """
+        try {
+            FileHelpers.write(new File(destination, "world.mt"), """
                 world_name = %s
                 enable_damage = true
                 creative_mode = true
                 auth_backend = sqlite3
                 player_backend = sqlite3
-                gameid = minetest""".formatted(metadata.getWorldName()));
-        createFile(new File(destination, "map_meta.txt"), """
+                gameid = minetest
+                """.formatted(metadata.getWorldName()));
+            FileHelpers.write(new File(destination, "map_meta.txt"), """
                 mapgen_limit = 31000
                 mg_name = singlenode
-                [end_of_params]""");
-        createFile(new File(destination, "worldmods/ign_spawn/init.lua"), """
-                minetest.setting_set("static_spawnpoint", "%d, %d, %d")""".formatted(metadata.getSpawn().x(), metadata.getSpawn().z(), metadata.getSpawn().y())); // XYZ => XZY
-    }
-
-    private void createFile(File file, String content) throws MapWriteException {
-        file.getParentFile().mkdirs();
-        try {
-            file.createNewFile();
-        } catch (IOException e) {
-            throw new MapWriteException(e);
-        }
-        try (
-            FileWriter fileWriter = new FileWriter(file);
-            PrintWriter printWriter = new PrintWriter(fileWriter)
-        ) {
-            printWriter.println(content);
+                [end_of_params]
+                """);
+            FileHelpers.write(new File(destination, "worldmods/ign_spawn/init.lua"), """
+                minetest.setting_set("static_spawnpoint", "%d, %d, %d")
+                """.formatted(metadata.getSpawn().x(), metadata.getSpawn().z(), metadata.getSpawn().y())); // XYZ => XZY
         } catch (IOException e) {
             throw new MapWriteException(e);
         }

--- a/src/main/java/com/ignfab/minalac/generator/parameters/providers/GeoPackageProviderParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/providers/GeoPackageProviderParams.java
@@ -13,6 +13,7 @@ import org.geotools.referencing.CRS;
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.inputs.GeoPackageDataProvider;
 import com.ignfab.minalac.generator.inputs.Provider;
+import com.ignfab.minalac.generator.utils.FileHelpers;
 
 /**
  * Parameters for GeoPackage providers.
@@ -64,7 +65,7 @@ public class GeoPackageProviderParams extends ProviderParams {
             crsOverride = null;
 
         File file = new File(filePath);
-        if (!file.isFile())
+        if (!FileHelpers.isReadableRegularFile(file))
             throw new IllegalArgumentException("File \"%s\" does not exist".formatted(file.getAbsolutePath()));
 
         return new GeoPackageDataProvider(file, typeName, crsOverride, generation::getEnvelopeForCRS);

--- a/src/main/java/com/ignfab/minalac/generator/parameters/providers/GeoTiffProviderParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/providers/GeoTiffProviderParams.java
@@ -13,6 +13,7 @@ import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.inputs.FloatGeographicDataMatrix2d;
 import com.ignfab.minalac.generator.inputs.GeoTiffDataProvider;
 import com.ignfab.minalac.generator.inputs.Provider;
+import com.ignfab.minalac.generator.utils.FileHelpers;
 
 /**
  * Parameters for GeoTiff providers.
@@ -56,7 +57,7 @@ public class GeoTiffProviderParams extends ProviderParams {
             crsOverride = null;
 
         File file = new File(filePath);
-        if (!file.isFile())
+        if (!FileHelpers.isReadableRegularFile(file))
             throw new IllegalArgumentException("File \"%s\" does not exist".formatted(file.getAbsolutePath()));
 
         return new GeoTiffDataProvider(file, crsOverride, generation::getEnvelopeForCRS);

--- a/src/main/java/com/ignfab/minalac/generator/parameters/providers/GeoTiffProviderParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/providers/GeoTiffProviderParams.java
@@ -1,0 +1,64 @@
+package com.ignfab.minalac.generator.parameters.providers;
+
+import java.beans.ConstructorProperties;
+import java.io.File;
+
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.referencing.CRS;
+
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.inputs.FloatGeographicDataMatrix2d;
+import com.ignfab.minalac.generator.inputs.GeoTiffDataProvider;
+import com.ignfab.minalac.generator.inputs.Provider;
+
+/**
+ * Parameters for GeoTiff providers.
+ */
+public class GeoTiffProviderParams extends ProviderParams {
+    /**
+     * Path to GeoTiff (required).
+     */
+    @JsonSetter(nulls = Nulls.FAIL)
+    public String filePath;
+
+    /**
+     * Coordinate reference system to use when reading data (optional, default: none).
+     * By default, the CRS is read from the GeoTiff itself. You should only use this
+     * parameter if the CRS is invalid or missing from the file.
+     * This DOES NOT reproject data!
+     */
+    @JsonSetter(nulls = Nulls.SKIP)
+    public String crsOverride;
+
+    /**
+     * Creates a new GeoTiffProviderParams with mandatory fields.
+     *
+     * @param filePath Path to GeoTiff (absolute, or relative to current execution context)
+     */
+    @ConstructorProperties("filePath")
+    public GeoTiffProviderParams(String filePath) {
+        this.filePath = filePath;
+    }
+
+    @Override
+    public Provider<FloatGeographicDataMatrix2d> create(Generation generation) {
+        CoordinateReferenceSystem crsOverride;
+        if (this.crsOverride != null)
+            try {
+                crsOverride = CRS.decode(this.crsOverride);
+            } catch (FactoryException e) {
+                throw new IllegalArgumentException("CRS code \"%s\" is invalid".formatted(this.crsOverride), e);
+            }
+        else
+            crsOverride = null;
+
+        File file = new File(filePath);
+        if (!file.isFile())
+            throw new IllegalArgumentException("File \"%s\" does not exist".formatted(file.getAbsolutePath()));
+
+        return new GeoTiffDataProvider(file, crsOverride, generation::getEnvelopeForCRS);
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/parameters/providers/ShapefileProviderParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/providers/ShapefileProviderParams.java
@@ -13,6 +13,7 @@ import org.geotools.referencing.CRS;
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.inputs.Provider;
 import com.ignfab.minalac.generator.inputs.ShapefileDataProvider;
+import com.ignfab.minalac.generator.utils.FileHelpers;
 
 /**
  * Parameters for Shapefile providers.
@@ -56,7 +57,7 @@ public class ShapefileProviderParams extends ProviderParams {
             crsOverride = null;
 
         File file = new File(filePath);
-        if (!file.isFile())
+        if (!FileHelpers.isReadableRegularFile(file))
             throw new IllegalArgumentException("File \"%s\" does not exist".formatted(file.getAbsolutePath()));
 
         return new ShapefileDataProvider(file, crsOverride, generation::getEnvelopeForCRS);

--- a/src/main/java/com/ignfab/minalac/generator/utils/FileHelpers.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/FileHelpers.java
@@ -1,0 +1,49 @@
+package com.ignfab.minalac.generator.utils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * A utility class for files operations.
+ */
+public final class FileHelpers {
+    private FileHelpers() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Tests if the given file is a regular readable file.
+     * Shortcut for {@code FileHelpers.isReadableRegularFile(file.toPath())}
+     * @param file the file to test
+     * @return {@code true} if the file is regular and readable, {@code false} otherwise
+     * @see #isReadableRegularFile(Path)
+     */
+    public static boolean isReadableRegularFile(File file) {
+        return isReadableRegularFile(file.toPath());
+    }
+
+    /**
+     * Tests if the given path points to a regular readable file.
+     * @param path the path to test
+     * @return {@code true} if the target file is regular and readable, {@code false} otherwise
+     */
+    public static boolean isReadableRegularFile(Path path) {
+        return Files.isRegularFile(path) && Files.isReadable(path);
+    }
+
+    /**
+     * Puts the given content into the file, creating any necessary directories.
+     * @param file the file to write content to
+     * @param content the content to write as UTF-8 into the file
+     * @throws IOException if content cannot be written to the file for any reason
+     */
+    public static void write(File file, String content) throws IOException {
+        File parent = file.getParentFile();
+        if (parent.isDirectory() || parent.mkdirs())
+            Files.writeString(file.toPath(), content);
+        else
+            throw new IOException("Unable to create parent directories to write to file: " + file.getAbsolutePath());
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/models/FloatMatrixModelTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/models/FloatMatrixModelTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.util.AffineTransformation;
 
 import com.ignfab.minalac.generator.exceptions.TransformException;
+import com.ignfab.minalac.generator.inputs.FloatArrayGeographicDataMatrix2d;
 import com.ignfab.minalac.generator.inputs.FloatGeographicDataMatrix2d;
 import com.ignfab.minalac.generator.utils.coordinates.MapToWorldConverter;
 import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
@@ -16,7 +17,7 @@ public class FloatMatrixModelTest {
     @Test
     public void testBBox() throws TransformException {
 
-        FloatGeographicDataMatrix2d data = new FloatGeographicDataMatrix2d(3, 4, 1.0, 2.0, 1.0, 1.0);
+        FloatGeographicDataMatrix2d data = new FloatArrayGeographicDataMatrix2d(3, 4, 1.0, 2.0, 1.0, 1.0);
 
         MapToWorldConverter converter = new MapToWorldConverter(IdentityTransform.create(2), new AffineTransformation());
         FloatMatrixModel model = new FloatMatrixModel(data, converter);
@@ -36,7 +37,7 @@ public class FloatMatrixModelTest {
             1.0f, 2.0f, 3.0f
         };
 
-        FloatGeographicDataMatrix2d data = new FloatGeographicDataMatrix2d(values, 3, 4, 1.0, 2.0, 1.0, 1.0);
+        FloatGeographicDataMatrix2d data = new FloatArrayGeographicDataMatrix2d(values, 3, 4, 1.0, 2.0, 1.0, 1.0);
 
         FloatMatrixModel model = new FloatMatrixModel(data, converter);
         assertNull(model.get(new WorldCoords2d(0, 2)));
@@ -61,7 +62,7 @@ public class FloatMatrixModelTest {
             -1.0f, 1.0f,
             -3.0f, 5.0f,
         };
-        FloatGeographicDataMatrix2d data = new FloatGeographicDataMatrix2d(values, 2, 2, 0.0, 0.0, 10.0, 10.0);
+        FloatGeographicDataMatrix2d data = new FloatArrayGeographicDataMatrix2d(values, 2, 2, 0.0, 0.0, 10.0, 10.0);
 
         FloatMatrixModel model = new FloatMatrixModel(data, converter);
         // Borders

--- a/src/test/java/com/ignfab/minalac/generator/parameters/providers/GeoTiffProviderParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/providers/GeoTiffProviderParamsTest.java
@@ -1,0 +1,35 @@
+package com.ignfab.minalac.generator.parameters.providers;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.referencing.CRS;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
+import com.ignfab.minalac.generator.utils.random.TestingSeed;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class GeoTiffProviderParamsTest {
+    @Test
+    public void testCreate(@TempDir File tmp) throws FactoryException, IOException {
+        CoordinateReferenceSystem crs = CRS.decode("EPSG:2154");
+        Generation generation = new Generation(new TestingVoxelWorld(), TestingSeed.UNUSED, crs, 0, 0, 20, 20, 1, 1, 0, 100);
+        File file = new File(tmp, "fake.tif");
+        if (!file.createNewFile())
+            fail("Unable to setup test file");
+
+        // A simple OK test
+        GeoTiffProviderParams params = new GeoTiffProviderParams(file.getAbsolutePath());
+        assertDoesNotThrow(() -> params.create(generation));
+
+        // Missing file test
+        params.filePath = "/tmp/invalid/path.tif";
+        assertThrows(IllegalArgumentException.class, () -> params.create(generation));
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/tasks/PopulateHeightmapTaskTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/tasks/PopulateHeightmapTaskTest.java
@@ -8,13 +8,14 @@ import com.ignfab.minalac.generator.exceptions.TransformException;
 import com.ignfab.minalac.generator.generation.TestingGenerationTile;
 import com.ignfab.minalac.generator.generation.heightmaps.ReadableHeightmap;
 import com.ignfab.minalac.generator.generation.heightmaps.TestingHeightmap;
+import com.ignfab.minalac.generator.inputs.FloatArrayGeographicDataMatrix2d;
 import com.ignfab.minalac.generator.inputs.FloatGeographicDataMatrix2d;
 import com.ignfab.minalac.generator.models.FloatMatrixModel;
 import com.ignfab.minalac.generator.models.ModelSelection;
 import com.ignfab.minalac.generator.utils.coordinates.MapToWorldConverter;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class PopulateHeightmapTaskTest {
     @Test
@@ -31,7 +32,7 @@ public class PopulateHeightmapTaskTest {
             1.0f, 2.0f, 3.0f
         };
 
-        FloatGeographicDataMatrix2d data = new FloatGeographicDataMatrix2d(values, 3, 4, 0, -1, 1.0, 1.0);
+        FloatGeographicDataMatrix2d data = new FloatArrayGeographicDataMatrix2d(values, 3, 4, 0, -1, 1.0, 1.0);
         FloatMatrixModel model = new FloatMatrixModel(data, converter);
 
         tile.models().add("matrix", model);

--- a/src/test/java/com/ignfab/minalac/generator/utils/FileHelpersTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/FileHelpersTest.java
@@ -1,0 +1,70 @@
+package com.ignfab.minalac.generator.utils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.AclEntry;
+import java.nio.file.attribute.AclEntryPermission;
+import java.nio.file.attribute.AclEntryType;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class FileHelpersTest {
+    @Test
+    public void testIsReadableRegularFile(@TempDir File tmp) throws IOException {
+        File missing = new File(tmp, "missing");
+        assertFalse(FileHelpers.isReadableRegularFile(missing));
+        assertFalse(FileHelpers.isReadableRegularFile(missing.toPath()));
+
+        File dir = new File(tmp, "dir");
+        if (!dir.mkdir())
+            fail("Unable to setup test data");
+        assertFalse(FileHelpers.isReadableRegularFile(dir));
+
+        File unreadable = new File(tmp, "unreadable");
+        if (!unreadable.createNewFile())
+            fail("Unable to setup test data");
+        Path unreadablePath = unreadable.toPath();
+        if (unreadablePath.getFileSystem().supportedFileAttributeViews().contains("acl")) { // Windows file-system
+            Files.setAttribute(unreadablePath, "acl:acl", List.of(AclEntry.newBuilder()
+                .setType(AclEntryType.DENY)
+                .setPermissions(AclEntryPermission.READ_DATA)
+                .setPrincipal(Files.getOwner(unreadablePath))
+                .build()));
+        } else if (!unreadable.setReadable(false))
+            fail("Unable to setup test data");
+        assertFalse(FileHelpers.isReadableRegularFile(unreadable));
+
+        File readable = new File(tmp, "readable");
+        if (!readable.createNewFile())
+            fail("Unable to setup test data");
+        assertTrue(FileHelpers.isReadableRegularFile(readable));
+    }
+
+    @Test
+    public void testWrite(@TempDir File tmp) throws IOException {
+        File simple = new File(tmp, "simple.txt");
+        String simpleContent = "Simple content";
+        FileHelpers.write(simple, simpleContent);
+        assertEquals(simpleContent, Files.readString(simple.toPath()));
+
+        File nested = new File(tmp, "deeply/nested/file.txt");
+        String multilineContent = """
+            Multiline
+            content
+            """;
+        FileHelpers.write(nested, multilineContent);
+        assertEquals(multilineContent, Files.readString(nested.toPath()));
+
+        File dir = new File(tmp, "dir");
+        if (!dir.mkdir())
+            fail("Unable to setup test data");
+        assertThrows(IOException.class, () -> FileHelpers.write(dir, "invalid"));
+        assertThrows(IOException.class, () -> FileHelpers.write(new File(simple, "illegal/parent.txt"), "invalid"));
+    }
+}


### PR DESCRIPTION
### Type of modification

- Code
  - Inputs
- Documentation
  - Javadoc Comments
  - Markdown Files

### Changes

Add a new GeoTiff data provider

#### Feature description

As a kind of follow-up of #59, this PR adds a new data provider based on GeoTools, to read float matrix data from GeoTiff files.

It is fully compatible with `FloatMatrixProcessor` and can be interchanged with `WMSFloatBilDataProvider`.

Using one of the existing GeoPackage or Shapefile data provider, and this new GeoTiff data provider, the generator can now be run fully offline, on local data.

#### Technical changes

`gt-geotiff` are GeoTiff bindings for GeoTools.

### Reason

We had a way to load local vector data, using either GeoPackage or Shapefile format, but nothing to load local raster data. GeoTiff is an established standard in the GIS domain to store raster data.

### Self-checks

- [x] The code has unit tests associated
- [x] The code has Javadoc Comments associated
- [x] Complex / Unexpected code is explained / justified with a small comment
- [x] Relevant documentation inside the `/docs` folder has been updated
- ~~All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)~~
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [x] The texts have been proofread (documentation, error messages, logs, comments...)
