### PR TITLE
feat(filter): Add model filter on empty geometry

### DIFF
--- a/docs/usage/parameters/ModelSelection.md
+++ b/docs/usage/parameters/ModelSelection.md
@@ -20,6 +20,8 @@ Models are always selected on their type and that selection may be narrowed down
      * [In](#in)
      * [Lower Than](#lower-than)
      * [Greater Than](#greater-than)
+  * [Filtering on geometry](#filtering-on-geometry)
+    * [Empty](#empty)
 
 ## Example
 
@@ -187,3 +189,19 @@ Example:
 Fields:
   - `metadata` (required): Name of the metadata to check
   - `greaterThan` (required): Threshold value that the metadata must be greater than. (Only possible to compare numbers with this filter)
+
+### Filtering on geometry
+
+These filters rely on models geometry. If the model does not come from the `geoToolsVector` processor, these filters won't match.
+
+#### Empty
+
+Returns true if model geometry is empty.
+
+Examples:
+```yaml
+   emptyGeometry:
+```
+
+Fields:
+- `emptyGeometry` (required): This field has no value

--- a/docs/usage/parameters/PostProcessing.md
+++ b/docs/usage/parameters/PostProcessing.md
@@ -212,4 +212,3 @@ Post-processor that applies a buffer around the geometry of the model.
 
 **Extra parameters**:
 - `buffer` (required): the signed distance of the buffer to apply, can be negative.
-- `discardEmptyResults` (optional, default `no`): `yes` to discard models resulting in an empty geometry, `no` to keep them. This can happen with a negative `buffer` value, when the original geometry was smaller than that value.

--- a/src/main/java/com/ignfab/minalac/generator/models/filters/ModelFilterEmptyGeometry.java
+++ b/src/main/java/com/ignfab/minalac/generator/models/filters/ModelFilterEmptyGeometry.java
@@ -1,0 +1,27 @@
+package com.ignfab.minalac.generator.models.filters;
+
+import java.util.function.Predicate;
+
+import com.ignfab.minalac.generator.models.JTSGeometryModel;
+import com.ignfab.minalac.generator.models.Model;
+
+/**
+ * A model filter testing emptiness of geometry.
+ * Only {@link JTSGeometryModel}s can be tested by this filter (otherwise returns {@code false}).
+ */
+public final class ModelFilterEmptyGeometry implements Predicate<Model> {
+    /**
+     * Singleton instance.
+     */
+    public static final ModelFilterEmptyGeometry INSTANCE = new ModelFilterEmptyGeometry();
+
+    /**
+     * @see #INSTANCE
+     */
+    private ModelFilterEmptyGeometry() {}
+
+    @Override
+    public boolean test(Model model) {
+        return model instanceof JTSGeometryModel geoModel && geoModel.getGeometry().isEmpty();
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/parameters/models/filters/ModelFilterEmptyGeometryParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/models/filters/ModelFilterEmptyGeometryParams.java
@@ -1,0 +1,21 @@
+package com.ignfab.minalac.generator.parameters.models.filters;
+
+import java.util.function.Predicate;
+
+import com.ignfab.minalac.generator.models.Model;
+import com.ignfab.minalac.generator.models.filters.ModelFilterEmptyGeometry;
+
+/**
+ * Parameters for a {@link ModelFilterEmptyGeometry}.
+ */
+public class ModelFilterEmptyGeometryParams extends ModelFilterParams {
+    /**
+     * Unused unique property to disambiguate from other filters because deduction is used...
+     */
+    public Object emptyGeometry;
+
+    @Override
+    public Predicate<Model> create() {
+        return ModelFilterEmptyGeometry.INSTANCE;
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/JTSGeometryBufferPostProcessorParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/JTSGeometryBufferPostProcessorParams.java
@@ -20,12 +20,6 @@ public class JTSGeometryBufferPostProcessorParams extends PostProcessorParams {
     public double buffer;
 
     /**
-     * Whether to discard models resulting in empty geometry (optional, default false).
-     */
-    @JsonSetter(nulls = Nulls.SKIP)
-    public boolean discardEmptyResults = false;
-
-    /**
      * Constructor used to ensure that the required fields are present during deserialization.
      * @param buffer The buffer value
      */
@@ -42,6 +36,6 @@ public class JTSGeometryBufferPostProcessorParams extends PostProcessorParams {
 
     @Override
     public PostProcessor<JTSGeometryModel, ?> create() {
-        return new JTSGeometryBufferPostProcessor(buffer, discardEmptyResults);
+        return new JTSGeometryBufferPostProcessor(buffer);
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/processors/post/JTSGeometryBufferPostProcessor.java
+++ b/src/main/java/com/ignfab/minalac/generator/processors/post/JTSGeometryBufferPostProcessor.java
@@ -11,31 +11,24 @@ import com.ignfab.minalac.generator.models.JTSGeometryModel;
  * {@link org.locationtech.jts.geom.Geometry#buffer(double) .buffer(d)}
  * JTS method on the geometry with a buffer value {@code d}.
  * <p>
- * Models resulting in empty geometries can be discarded.
- * <p>
  * The same model object is returned after post-processing.
  */
 public class JTSGeometryBufferPostProcessor extends PostProcessor.Simple<JTSGeometryModel> {
     private final double buffer;
-    private final boolean discardEmptyResults;
 
     /**
      * Creates a new {@code JTSGeometryBufferPostProcessor}.
      * @param buffer The buffer distance value to apply
-     * @param discardEmptyResults Whether to discard models resulting in empty geometry
      */
-    public JTSGeometryBufferPostProcessor(double buffer, boolean discardEmptyResults) {
+    public JTSGeometryBufferPostProcessor(double buffer) {
         super(JTSGeometryModel.class);
         this.buffer = buffer;
-        this.discardEmptyResults = discardEmptyResults;
     }
 
     @Override
     public JTSGeometryModel process(JTSGeometryModel model) throws GenerationFailedException, IgnorableException {
         if (buffer != 0)
             model.setGeometry(model.getGeometry().buffer(buffer));
-        if (discardEmptyResults && model.getGeometry().isEmpty())
-            return null;
         return model;
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/models/filters/ModelFilterEmptyGeometryTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/models/filters/ModelFilterEmptyGeometryTest.java
@@ -1,0 +1,40 @@
+package com.ignfab.minalac.generator.models.filters;
+
+import java.util.function.Predicate;
+
+import org.geotools.referencing.operation.transform.IdentityTransform;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.util.AffineTransformation;
+
+import com.ignfab.minalac.generator.exceptions.TransformException;
+import com.ignfab.minalac.generator.models.JTSGeometryModel;
+import com.ignfab.minalac.generator.models.Model;
+import com.ignfab.minalac.generator.models.TestingModel;
+import com.ignfab.minalac.generator.utils.coordinates.MapToWorldConverter;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ModelFilterEmptyGeometryTest {
+    private static final MapToWorldConverter IDENTITY_CONVERTER = new MapToWorldConverter(IdentityTransform.create(2), new AffineTransformation());
+    private static final GeometryFactory FACTORY = new GeometryFactory();
+
+    @Test
+    public void testIsSelected() throws TransformException {
+        Model geometryModel = new JTSGeometryModel(FACTORY.createPolygon(new Coordinate[] {
+            new Coordinate(0, 0),
+            new Coordinate(0, 1),
+            new Coordinate(1, 1),
+            new Coordinate(1, 0),
+            new Coordinate(0, 0)
+        }), IDENTITY_CONVERTER);
+        Model emptyGeometryModel = new JTSGeometryModel(FACTORY.createEmpty(2), IDENTITY_CONVERTER);
+        Model other = new TestingModel();
+
+        Predicate<Model> filter = ModelFilterEmptyGeometry.INSTANCE;
+        assertFalse(filter.test(geometryModel));
+        assertTrue(filter.test(emptyGeometryModel));
+        assertFalse(filter.test(other));
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/parameters/models/filters/ModelFilterEmptyGeometryParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/models/filters/ModelFilterEmptyGeometryParamsTest.java
@@ -1,0 +1,14 @@
+package com.ignfab.minalac.generator.parameters.models.filters;
+
+import org.junit.jupiter.api.Test;
+
+import com.ignfab.minalac.generator.models.filters.ModelFilterEmptyGeometry;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ModelFilterEmptyGeometryParamsTest {
+    @Test
+    public void testCreate() {
+        assertSame(ModelFilterEmptyGeometry.INSTANCE, new ModelFilterEmptyGeometryParams().create());
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/parameters/processors/post/JTSGeometryBufferPostProcessorParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/processors/post/JTSGeometryBufferPostProcessorParamsTest.java
@@ -27,7 +27,6 @@ public class JTSGeometryBufferPostProcessorParamsTest {
     @DisplayName("JTS geometry buffer post-processor params creates a JTS geometry post-processor")
     public void testCreate() {
         JTSGeometryBufferPostProcessorParams params = new JTSGeometryBufferPostProcessorParams(-2);
-        params.discardEmptyResults = true;
         PostProcessor<?, ?> postProcessor = assertDoesNotThrow(params::create);
         assertInstanceOf(JTSGeometryBufferPostProcessor.class, postProcessor);
     }

--- a/src/test/java/com/ignfab/minalac/generator/processors/post/JTSGeometryBufferPostProcessorTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/processors/post/JTSGeometryBufferPostProcessorTest.java
@@ -26,8 +26,8 @@ public class JTSGeometryBufferPostProcessorTest {
         model = new JTSGeometryModel(WKT_READER.read("POLYGON ((0 0, 5 0, 5 5, 0 5, 0 0))"), IDENTITY_CONVERTER);
     }
 
-    private JTSGeometryModel process(JTSGeometryBufferPostProcessor postProcessor) {
-        JTSGeometryModel processed = assertDoesNotThrow(() -> postProcessor.process(model));
+    private JTSGeometryModel process(double buffer) {
+        JTSGeometryModel processed = assertDoesNotThrow(() -> new JTSGeometryBufferPostProcessor(buffer).process(model));
         if (processed != null)
             assertSame(model, processed);
         return processed;
@@ -36,28 +36,21 @@ public class JTSGeometryBufferPostProcessorTest {
     @Test
     @DisplayName("JTS geometry buffer post-processor with positive buffer distance")
     public void testPositive() {
-        JTSGeometryModel processed = process(new JTSGeometryBufferPostProcessor(2, true));
+        JTSGeometryModel processed = process(2);
         assertEquals(new Envelope(-2, 7, -2, 7), processed.getGeometry().getEnvelopeInternal());
     }
 
     @Test
     @DisplayName("JTS geometry buffer post-processor with negative buffer distance")
     public void testNegative() {
-        JTSGeometryModel processed = process(new JTSGeometryBufferPostProcessor(-1, true));
+        JTSGeometryModel processed = process(-1);
         assertEquals(new Envelope(1, 4, 1, 4), processed.getGeometry().getEnvelopeInternal());
     }
 
     @Test
-    @DisplayName("JTS geometry buffer post-processor discarding model")
-    public void testDiscard() {
-        JTSGeometryModel processed = process(new JTSGeometryBufferPostProcessor(-3, true));
-        assertNull(processed);
-    }
-
-    @Test
-    @DisplayName("JTS geometry buffer post-processor keeping model")
+    @DisplayName("JTS geometry buffer post-processor resulting in empty geometry model")
     public void testKeep() {
-        JTSGeometryModel processed = process(new JTSGeometryBufferPostProcessor(-3, false));
+        JTSGeometryModel processed = process(-3);
         assertNotNull(processed);
         assertTrue(processed.getGeometry().isEmpty());
     }


### PR DESCRIPTION
### Type of modification

- Code
  - Inputs
- Documentation
  - Markdown Files

### Changes

This PR introduces a new model filter on empty geometry, previously only available in the geometry buffer post-processor.

#### Feature description

In #95, I added a post-processor to make a buffer around the geometry of a model. One parameter of that post-processor was to discard the model if the resulting geometry was empty.

In this PR, I removed that parameter from that post-processor, and introduced instead an empty geometry model filter. It has no parameter, and matches `JTSGeometryModel`s with an empty geometry. It will never match a model with a wrong type.

#### Showcase

Before this PR:
```yaml
postProcessing:
  type: geometryBuffer
  buffer: -5
  discardEmptyResults: true
```

After this PR:
```yaml
postProcessing:
  - type: geometryBuffer
    buffer: -5
  - type: conditional
    if:
      emptyGeometry:
    then:
      type: discard
```

From a before/after point of view, it just looks longer. But, the longer the better, right??

### Reason

During discussions that came after that PR, the idea of refactoring post-processors was proposed. The goal would be to extract the existing post-processors that does not replace the model, and rename those "model processors" or something. Then, create a new post-processor able to run a "model processor", to keep existing functionality. Finally, create a new task also able to run "model processors", to allow modifying models in-place after they were fetched.

In order to do so, we first need to identify which of the existing post-processors could be transformed into "model processors". However, in its current state, the geometry buffer post-processor was unsuitable, because of its parameter to discard empty models.

Now, this post-processor is suitable to become a "model processor", and its existing functionality can still be accomplished using a combination of the new empty geometry model filter, the conditional post-processor, and the discard post-processor.

### TODOs

Because the only way to use model filters in parameters is currently by deduction, I needed to add a single `emptyGeometry` useless parameter. A better solution based on `type: emptyGeometry` should be explored (in other words: tell Jackson to use `type` if present, and fallback to deduction otherwise).

### Self-checks

- [x] The code has unit tests associated
- [x] The code has Javadoc Comments associated
- [x] Complex / Unexpected code is explained / justified with a small comment
- [x] Relevant documentation inside the `/docs` folder has been updated
- ~~All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)~~
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [x] The texts have been proofread (documentation, error messages, logs, comments...)
