### PR TITLE
fix(inputs): Change WFS `OUTPUTFORMAT` value

### DIFF
--- a/src/main/java/com/ignfab/minalac/generator/inputs/WFS1_1_GML3_1_DataProvider.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/WFS1_1_GML3_1_DataProvider.java
@@ -70,7 +70,7 @@ public class WFS1_1_GML3_1_DataProvider implements Provider<SimpleFeature> {
             .parameter("SERVICE", SERVICE)
             .parameter("VERSION", VERSION)
             .parameter("REQUEST", "GetFeature")
-            .parameter("OUTPUTFORMAT", "GML3")
+            .parameter("OUTPUTFORMAT", "gml3")
             .parameter("TYPENAMES", type)
             .parameter("SRSNAME", srsName)
             .build();


### PR DESCRIPTION

### Changes

A change in data.geopf.fr made the previous value `GML3` not allowed for `outputFormat` making not possible to fetch WFS data. This a dirt and quick fix for that.

### Self-checks

- ~~[ ] The code has unit tests associated~~
- ~~[ ] The code has Javadoc Comments associated~~
- ~~[ ] Complex / Unexpected code is explained / justified with a small comment~~
- ~~[ ] Relevant documentation inside the `/docs` folder has been updated~~
- ~~[ ] All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)~~
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [x] The texts have been proofread (documentation, error messages, logs, comments...)
