### PR TITLE
docs(javadoc): Simplify getters JavaDoc using inline return tag

### DIFF
--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           checkstyle_config: checkstyle.xml
-          checkstyle_version: "10.19.0"
+          checkstyle_version: "11.0.1"
           level: error
           reporter: github-check # Check may be reported on wrong checksuite, but it's a known issue of GitHub Checks API: https://github.com/reviewdog/reviewdog/issues/403
           reviewdog_flags: -name checkstyle

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -103,10 +103,12 @@
     <!-- Checks for Javadoc comments.                     -->
     <!-- See https://checkstyle.org/config_javadoc.html -->
     <module name="InvalidJavadocPosition"/>
-    <module name="JavadocMethod"/>
+    <module name="JavadocMethod">
+      <property name="allowInlineReturn" value="true"/>
+    </module>
     <module name="JavadocType"/>
     <module name="JavadocVariable">
-      <property name="scope" value="protected"/>
+      <property name="accessModifiers" value="public,protected"/>
     </module>
     <module name="JavadocStyle"/>
    <module name="MissingJavadocMethod"/>

--- a/pom.xml
+++ b/pom.xml
@@ -294,7 +294,7 @@
                         <!-- Overrides checkstyle version -->
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>10.19.0</version>
+                        <version>11.0.1</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/src/main/java/com/ignfab/minalac/generator/generation/Generation.java
+++ b/src/main/java/com/ignfab/minalac/generator/generation/Generation.java
@@ -129,8 +129,7 @@ public class Generation {
     }
 
     /**
-     * Returns the generation scheduler.
-     * @return the scheduler.
+     * {@return the generation scheduler}
      */
     public Scheduler<GenerationTile> scheduler() {
         return scheduler;
@@ -174,9 +173,7 @@ public class Generation {
     }
 
     /**
-     * Returns the vertical scale.
-     *
-     * @return the vertical scale
+     * {@return the vertical scale}
      */
     // To be removed when vertical is used by this class. (Renderers will probably contain that value)
     public double getVerticalScale() {
@@ -184,45 +181,35 @@ public class Generation {
     }
 
     /**
-     * Returns the random number seed for this generation.
-     *
-     * @return the seed
+     * {@return random number seed for this generation}
      */
     public Seed seed() {
         return seed;
     }
 
     /**
-     * Returns target CRS.
-     *
-     * @return CRS used for world rendering
+     * {@return target CRS, used for world rendering}
      */
     public CoordinateReferenceSystem crs() {
         return crs;
     }
 
     /**
-     * Returns maximum generation tile size.
-     *
-     * @return maximum generation tile size
+     * {@return maximum generation tile size}
      */
     public int maxTileSize() {
         return this.maxTileSize;
     }
 
     /**
-     * Returns number of generation tiles.
-     *
-     * @return number of generation tiles
+     * {@return number of generation tiles}
      */
     public int numberOfTiles() {
         return this.tiles.size();
     }
 
     /**
-     * Returns an itereable over generation tiles.
-     *
-     * @return an itereable over generation tiles
+     * {@return an iterable over generation tiles}
      */
     public Iterable<GenerationTile> tiles() {
         return Iterables.remap(tiles,

--- a/src/main/java/com/ignfab/minalac/generator/generation/GenerationTile.java
+++ b/src/main/java/com/ignfab/minalac/generator/generation/GenerationTile.java
@@ -32,44 +32,35 @@ public class GenerationTile {
     }
 
     /**
-     * Gives the generation which this tile belongs to.
-     *
-     * @return generation
+     * {@return the generation which this tile belongs to}
      */
     public Generation generation() {
         return generation;
     }
 
     /**
-     * Returns the {@link ModelStore}.
-     * @return the model store
+     * {@return the model store}
      */
     public ModelStore models() {
         return models;
     }
 
     /**
-     * Gives the limits of the tile.
-     *
-     * @return limits of the tile
+     * {@return the limits of the tile}
      */
     public WorldBBox3d limits() {
         return voxels.limits();
     }
 
     /**
-     * Gives the {@link HeightmapStore} for this generation tile.
-     *
-     * @return heightmap store for the generation tile
+     * {@return heightmap store for the generation tile}
      */
     public HeightmapStore heightmaps() {
         return heightmaps;
     }
 
     /**
-     * Gives the {@link VoxelTile} for this generation tile.
-     *
-     * @return voxel world tile corresponding to the generation tile
+     * {@return voxel world tile for this generation tile}
      */
     public VoxelTile voxels() {
         return voxels;

--- a/src/main/java/com/ignfab/minalac/generator/generation/heightmaps/HeightmapDeclaration.java
+++ b/src/main/java/com/ignfab/minalac/generator/generation/heightmaps/HeightmapDeclaration.java
@@ -24,18 +24,14 @@ public class HeightmapDeclaration {
     }
 
     /**
-     * Returns the name of this declaration.
-     *
-     * @return name
+     * {@return the name of this declaration}
      */
     public String name() {
         return name;
     }
 
     /**
-     * Returns spec object to use as key in readable/writable heightmap stores in order to retrieve it.
-     *
-     * @return {@link WritableHeightmapSpec} object
+     * {@return spec object to use as key in readable/writable heightmap stores in order to retrieve it}
      */
     public WritableHeightmapSpec spec() {
         return spec;

--- a/src/main/java/com/ignfab/minalac/generator/generation/heightmaps/HeightmapDeclarationStore.java
+++ b/src/main/java/com/ignfab/minalac/generator/generation/heightmaps/HeightmapDeclarationStore.java
@@ -41,19 +41,14 @@ public class HeightmapDeclarationStore {
     }
 
     /**
-     * Returns existing names in store.
-     *
-     * @return the set of existing names
-     *
+     * {@return the set of existing names in store}
      */
     public Set<String> names() {
         return store.keySet();
     }
 
     /**
-     * Returns existing declarations in store.
-     *
-     * @return the collection of existing declarations
+     * {@return the collection of existing declarations in store}
      */
     public Collection<HeightmapDeclaration> declarations() {
         return store.values();

--- a/src/main/java/com/ignfab/minalac/generator/generation/heightmaps/ReadableHeightmap.java
+++ b/src/main/java/com/ignfab/minalac/generator/generation/heightmaps/ReadableHeightmap.java
@@ -32,9 +32,7 @@ public interface ReadableHeightmap {
     }
 
     /**
-     * Returns the bounding box of the heightmap.
-     *
-     * @return the {@link WorldBBox2d} associated to the heightmap.
+     * {@return the bounding box associated to the heightmap}
      */
     WorldBBox2d bbox();
 }

--- a/src/main/java/com/ignfab/minalac/generator/generation/heightmaps/computed/BinaryOperationHeightmapSpec.java
+++ b/src/main/java/com/ignfab/minalac/generator/generation/heightmaps/computed/BinaryOperationHeightmapSpec.java
@@ -35,7 +35,7 @@ public class BinaryOperationHeightmapSpec extends ReadableHeightmapSpec {
     /**
      * Usable heightmap corresponding to this {@code BinaryOperationHeightmapSpec}.
      *
-     * {@see ReadableHeightmapSpec}
+     * @see ReadableHeightmapSpec
      */
     private final class Created implements ReadableHeightmap {
         private final ReadableHeightmap firstOperand;

--- a/src/main/java/com/ignfab/minalac/generator/generation/heightmaps/computed/UnaryOperationHeightmapSpec.java
+++ b/src/main/java/com/ignfab/minalac/generator/generation/heightmaps/computed/UnaryOperationHeightmapSpec.java
@@ -32,7 +32,7 @@ public class UnaryOperationHeightmapSpec extends ReadableHeightmapSpec {
     /**
      * Usable heightmap corresponding to this {@code UnaryOperationHeightmapSpec}.
      *
-     * {@see ReadableHeightmapSpec}
+     * @see ReadableHeightmapSpec
      */
     private final class Created implements ReadableHeightmap {
         private final ReadableHeightmap operand;

--- a/src/main/java/com/ignfab/minalac/generator/inputs/GeographicDataMatrix2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/GeographicDataMatrix2d.java
@@ -20,44 +20,32 @@ public interface GeographicDataMatrix2d<T> {
     T get(int x, int y);
 
     /**
-     * Returns matrix size on x-axis (aka width).
-     *
-     * @return matrix width
+     * {@return matrix size on x-axis (aka width)}
      */
     int sizeX();
 
     /**
-     * Returns matrix size on y-axis (aka height).
-     *
-     * @return matrix height
+     * {@return matrix size on y-axis (aka height)}
      */
     int sizeY();
 
     /**
-     * Return x-axis component of geographical offset.
-     *
-     * @return offset x-axis component
+     * {@return x-axis component of geographical offset}
      */
     double offsetX();
 
     /**
-     * Return y-axis component of geographical offset.
-     *
-     * @return offset y-axis component
+     * {@return y-axis component of geographical offset}
      */
     double offsetY();
 
     /**
-     * Return x-axis geographical size of matrix cells.
-     *
-     * @return size x-axis component
+     * {@return x-axis geographical size of matrix cells}
      */
     double cellSizeX();
 
     /**
-     * Return y-axis geographical size of matrix cells.
-     *
-     * @return size y-axis component
+     * {@return y-axis geographical size of matrix cells}
      */
     double cellSizeY();
 }

--- a/src/main/java/com/ignfab/minalac/generator/inputs/Provider.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/Provider.java
@@ -24,9 +24,7 @@ import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
  */
 public interface Provider<T> {
     /**
-     * Returns the type of provided elements.
-     *
-     * @return the type of provided elements
+     * {@return the type of provided elements}
      */
     Class<T> providedType();
 
@@ -58,9 +56,7 @@ public interface Provider<T> {
      */
     interface Result<T> extends Closeable {
         /**
-         * Returns the coordinate reference system of resulting data.
-         *
-         * @return CRS of resulting data
+         * {@return the coordinate reference system of resulting data}
          */
         CoordinateReferenceSystem crs();
 

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/Region.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/Region.java
@@ -52,9 +52,7 @@ public record Region(int regionX, int regionZ, MCAFile file) {
     }
 
     /**
-     * Returns the filename of this region.
-     *
-     * @return the filename of this region
+     * {@return the filename of this region}
      */
     public String getFileName() {
         return MCAUtil.createNameFromRegionLocation(regionX, regionZ);

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxel.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxel.java
@@ -64,26 +64,23 @@ public class MTVoxel implements Placeable {
     }
 
     /**
-     * Returns the node type string.
-     * @return the node type string
+     * {@return the node type string}
      */
     public String getType() {
         return type;
     }
 
     /**
-     * Returns the param1 data of the node.
+     * {@return the param1 data of the node}
      * This parameter usually contains information about the node's light intensity.
-     * @return the param1 data of the node.
      */
     public byte getParam1() {
         return param1;
     }
 
     /**
-     * Returns the param2 data of the node.
+     * {@return the param2 data of the node}
      * This parameter usually contains information about the node's spacial orientation.
-     * @return the param2 data of the node
      */
     public byte getParam2() {
         return param2;

--- a/src/main/java/com/ignfab/minalac/generator/parameters/tasks/FetchDataTaskParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/tasks/FetchDataTaskParams.java
@@ -52,11 +52,7 @@ public class FetchDataTaskParams extends TileTaskParams {
         this.processor = processor;
     }
 
-    /**
-     * Checks if there are any blatantly invalid parameters.
-     *
-     * @throws IllegalArgumentException is any of the parameters is invalid.
-     */
+    @Override
     public void validate() throws IllegalArgumentException {
         if (modelType.isBlank())
             throw new IllegalArgumentException("The 'modelType' field cannot be empty or contain only whitespace.");
@@ -66,12 +62,7 @@ public class FetchDataTaskParams extends TileTaskParams {
         postProcessing.validate();
     }
 
-    /**
-     * Creates the corresponding {@code DataSource}.
-     *
-     * @param generation the generation context
-     * @return the created data source
-     */
+    @Override
     public FetchDataTask create(Generation generation) {
         return new FetchDataTask(
             modelType,

--- a/src/main/java/com/ignfab/minalac/generator/utils/IntegerInterval.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/IntegerInterval.java
@@ -25,9 +25,8 @@ public record IntegerInterval(int begin, int end) implements Comparable<IntegerI
     }
 
     /**
-     * Size in terms of how many integers are in interval (3 to 3 has size 1).
-     *
-     * @return size of the interval
+     * {@return the size of this interval}
+     * It corresponds to how many integers are in interval (3 to 3 has size 1).
      */
     public int size() {
         return end - begin + 1;

--- a/src/main/java/com/ignfab/minalac/generator/utils/execution/ScheduledTask.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/execution/ScheduledTask.java
@@ -102,18 +102,14 @@ public class ScheduledTask<T> {
     }
 
     /**
-     * Returns the ID of the task.
-     *
-     * @return the ID of the task
+     * {@return the ID of the task}
      */
     public String id() {
         return id;
     }
 
     /**
-     * Returns the state of this task.
-     *
-     * @return the state of this task
+     * {@return the state of this task}
      */
     public ScheduledTaskState state() {
         return state;

--- a/src/main/java/com/ignfab/minalac/generator/utils/execution/TaskFailedException.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/execution/TaskFailedException.java
@@ -18,9 +18,7 @@ public class TaskFailedException extends Exception {
     }
 
     /**
-     * Returns the failed task.
-     *
-     * @return the failed task
+     * {@return the failed task}
      */
     public ScheduledTask<?> getTask() {
         return task;

--- a/src/main/java/com/ignfab/minalac/generator/utils/world2d/Bounded2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world2d/Bounded2d.java
@@ -5,9 +5,7 @@ package com.ignfab.minalac.generator.utils.world2d;
  */
 public interface Bounded2d {
     /**
-     * Gives the bounding box of the object.
-     *
-     * @return the bounding box
+     * {@return the bounding box of the object}
      */
     WorldBBox2d bbox();
 }

--- a/src/main/java/com/ignfab/minalac/generator/utils/world2d/Positioned2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world2d/Positioned2d.java
@@ -5,9 +5,7 @@ package com.ignfab.minalac.generator.utils.world2d;
  */
 public interface Positioned2d {
     /**
-     * The position of the object in voxel world.
-     *
-     * @return the voxel coordinate.
+     * {@return the position of the object in voxel world}
      */
     WorldCoords2d coords();
 }

--- a/src/main/java/com/ignfab/minalac/generator/utils/world2d/WorldBBox2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world2d/WorldBBox2d.java
@@ -252,81 +252,63 @@ public class WorldBBox2d implements Bounded2d, Iterable<WorldCoords2d> {
     }
 
     /**
-     * Returns the size of the bounding box.
-     *
-     * @return the size of the bounding box as a {@code WorldSize2d}.
+     * {@return the size of the bounding box}
      */
     public WorldSize2d size() {
         return size;
     }
 
     /**
-     * Returns the bounding box size along the x-axis.
-     *
-     * @return the bounding box size along the x-axis.
+     * {@return the bounding box size along the x-axis}
      */
     public int sizeX() {
         return size.x();
     }
 
     /**
-     * Returns the bounding box size along the y-axis.
-     *
-     * @return the bounding box size along the y-axis.
+     * {@return the bounding box size along the y-axis}
      */
     public int sizeY() {
         return size.y();
     }
 
     /**
-     * Returns the minimum point.
-     *
-     * @return the {@code WorldCoords2d} of the minimum point.
+     * {@return the minimum point}
      */
     public WorldCoords2d min() {
         return min;
     }
 
     /**
-     * Returns the minimum point x-coordinate.
-     *
-     * @return the x-coordinate of the minimum point.
+     * {@return the x-coordinate of the minimum point}
      */
     public int minX() {
         return min.x();
     }
 
     /**
-     * Returns the minimum point y-coordinate.
-     *
-     * @return the y-coordinate of the minimum point.
+     * {@return the y-coordinate of the minimum point}
      */
     public int minY() {
         return min.y();
     }
 
     /**
-     * Returns the maximum point.
-     *
-     * @return the {@code WorldCoords2d} of the maximum point.
+     * {@return the maximum point}
      */
     public WorldCoords2d max() {
         return max;
     }
 
     /**
-     * Returns the maximum point x-coordinate.
-     *
-     * @return the x-coordinate of the maximum point.
+     * {@return the x-coordinate of the maximum point}
      */
     public int maxX() {
         return max.x();
     }
 
     /**
-     * Returns the maximum point y-coordinate.
-     *
-     * @return the y-coordinate of the maximum point.
+     * {@return the y-coordinate of the maximum point}
      */
     public int maxY() {
         return max.y();

--- a/src/main/java/com/ignfab/minalac/generator/utils/world2d/iterator/WorldBBox2dIterator.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world2d/iterator/WorldBBox2dIterator.java
@@ -41,21 +41,12 @@ public class WorldBBox2dIterator implements Iterator<WorldCoords2d> {
         }
     }
 
-    /**
-     * Indicates if there are more elements.
-     *
-     * @return {@code true} if the iteration has more elements.
-     */
+    @Override
     public boolean hasNext() {
         return hasNext;
     }
 
-    /**
-     * Returns the next element.
-     *
-     * @return the next {@code WorldCoords2d} in the iteration.
-     * @throws NoSuchElementException if the iteration has no more elements.
-     */
+    @Override
     public WorldCoords2d next() throws NoSuchElementException {
         if (!hasNext)
             throw new NoSuchElementException();

--- a/src/main/java/com/ignfab/minalac/generator/utils/world3d/Bounded3d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world3d/Bounded3d.java
@@ -9,9 +9,7 @@ package com.ignfab.minalac.generator.utils.world3d;
  */
 public interface Bounded3d {
     /**
-     * Gives the bounding box of the object.
-     *
-     * @return the bounding box
+     * {@return the bounding box of the object}
      */
     WorldBBox3d bbox();
 }

--- a/src/main/java/com/ignfab/minalac/generator/utils/world3d/Positioned3d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world3d/Positioned3d.java
@@ -10,9 +10,7 @@ package com.ignfab.minalac.generator.utils.world3d;
  */
 public interface Positioned3d {
     /**
-     * The position of the object in voxel world.
-     *
-     * @return the voxel coordinate.
+     * {@return the position of the object in voxel world}
      */
     WorldCoords3d coords();
 }

--- a/src/main/java/com/ignfab/minalac/generator/utils/world3d/WorldBBox3d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world3d/WorldBBox3d.java
@@ -239,108 +239,84 @@ public class WorldBBox3d implements Bounded3d, Iterable<WorldCoords3d> {
     }
 
     /**
-     * Returns the size of the bounding box.
-     *
-     * @return the size of the bounding box as a {@link WorldSize3d}.
+     * {@return the size of the bounding box}
      */
     public WorldSize3d size() {
         return size;
     }
 
     /**
-     * Returns the bounding box size along the x-axis.
-     *
-     * @return the bounding box size along the x-axis.
+     * {@return the bounding box size along the x-axis}
      */
     public int sizeX() {
         return size.x();
     }
 
     /**
-     * Returns the bounding box size along the y-axis.
-     *
-     * @return the bounding box size along the y-axis.
+     * {@return the bounding box size along the y-axis}
      */
     public int sizeY() {
         return size.y();
     }
 
     /**
-     * Returns the bounding box size along the z-axis.
-     *
-     * @return the bounding box size along the z-axis.
+     * {@return the bounding box size along the z-axis}
      */
     public int sizeZ() {
         return size.z();
     }
 
     /**
-     * Returns the minimum point.
-     *
-     * @return the {@link WorldCoords3d} of the minimum point.
+     * {@return the minimum point}
      */
     public WorldCoords3d min() {
         return min;
     }
 
     /**
-     * Returns the minimum point x-coordinate.
-     *
-     * @return the x-coordinate of the minimum point.
+     * {@return the x-coordinate of the minimum point}
      */
     public int minX() {
         return min.x();
     }
 
     /**
-     * Returns the minimum point y-coordinate.
-     *
-     * @return the y-coordinate of the minimum point.
+     * {@return the y-coordinate of the minimum point}
      */
     public int minY() {
         return min.y();
     }
 
     /**
-     * Returns the minimum point z-coordinate.
-     *
-     * @return the z-coordinate of the minimum point.
+     * {@return the z-coordinate of the minimum point}
      */
     public int minZ() {
         return min.z();
     }
 
     /**
-     * Returns the maximum point.
-     *
-     * @return the {@link WorldCoords3d} of the maximum point.
+     * {@return the maximum point}
      */
     public WorldCoords3d max() {
         return max;
     }
 
     /**
-     * Returns the maximum point x-coordinate.
-     *
-     * @return the x-coordinate of the maximum point.
+     * {@return the x-coordinate of the maximum point}
      */
     public int maxX() {
         return max.x();
     }
 
     /**
-     * Returns the maximum point y-coordinate.
-     *
-     * @return the y-coordinate of the maximum point.
+     * {@return the y-coordinate of the maximum point}
      */
     public int maxY() {
         return max.y();
     }
 
     /**
-     * Returns the maximum point z-coordinate.
-     *
-     * @return the z-coordinate of the maximum point.
+     * {@return the z-coordinate of the maximum point}
      */
     public int maxZ() {
         return max.z();

--- a/src/main/java/com/ignfab/minalac/generator/utils/world3d/iterator/WorldBBox3dIterator.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world3d/iterator/WorldBBox3dIterator.java
@@ -47,21 +47,12 @@ public class WorldBBox3dIterator implements Iterator<WorldCoords3d> {
         }
     }
 
-    /**
-     * Indicates if there are more elements.
-     *
-     * @return {@code true} if the iteration has more elements.
-     */
+    @Override
     public boolean hasNext() {
         return hasNext;
     }
 
-    /**
-     * Returns the next element.
-     *
-     * @return the next {@link WorldCoords3d} in the iteration.
-     * @throws NoSuchElementException if the iteration has no more elements.
-     */
+    @Override
     public WorldCoords3d next() throws NoSuchElementException {
         if (!hasNext)
             throw new NoSuchElementException();

--- a/src/main/java/com/ignfab/minalac/generator/world/VoxelTile.java
+++ b/src/main/java/com/ignfab/minalac/generator/world/VoxelTile.java
@@ -36,9 +36,7 @@ public abstract class VoxelTile {
     }
 
     /**
-     * Return the limits of this tile.
-     *
-     * @return the {@code WorldBBox3d} representing the limits of the world
+     * {@return the limits of this tile}
      */
     public WorldBBox3d limits() {
         return limits;

--- a/src/main/java/com/ignfab/minalac/generator/world/VoxelWorld.java
+++ b/src/main/java/com/ignfab/minalac/generator/world/VoxelWorld.java
@@ -43,25 +43,19 @@ public abstract class VoxelWorld {
     }
 
     /**
-     * Return the limits of this world.
-     *
-     * @return the {@code WorldBBox3d} representing the limits of the world
+     * {@return the limits of this world}
      */
     public WorldBBox3d limits() {
         return limits;
     }
 
     /**
-     * Return the maximum limits of the world (hard limit of the format).
-     *
-     * @return the {@code WorldBBox3d} representing the maximum limits of the world
+     * {@return the maximum limits of the world (hard limit of the format)}
      */
     public abstract WorldBBox3d maxLimits();
 
     /**
-     * Returns the metadata of this {@code VoxelWorld}.
-     *
-     * @return the {@link VoxelWorldMetadata}
+     * {@return the metadata of this world}
      */
     public VoxelWorldMetadata getMetadata() {
         return metadata;

--- a/src/main/java/com/ignfab/minalac/generator/world/VoxelWorldMetadata.java
+++ b/src/main/java/com/ignfab/minalac/generator/world/VoxelWorldMetadata.java
@@ -16,27 +16,23 @@ public class VoxelWorldMetadata {
     protected String worldName;
 
     /**
-     * Returns the initial position of the player.
-     *
-     * @return the spawn of the player
+     * {@return the initial spawn position of the player}
      */
     public WorldCoords3d getSpawn() {
         return spawn;
     }
 
     /**
-     * Sets the initial position of the player.
+     * Sets the initial spawn position of the player.
      *
-     * @param spawn the initial position of the player
+     * @param spawn the initial spawn position of the player
      */
     public void setSpawn(WorldCoords3d spawn) {
         this.spawn = spawn;
     }
 
     /**
-     * Returns the name of the world.
-     *
-     * @return the name of the world
+     * {@return the name of the world}
      */
     public String getWorldName() {
         return worldName;


### PR DESCRIPTION
### Type of modification

- Documentation
  - Javadoc Comments

### Changes

This PR simplifies some JavaDoc comments (especially on getters) using the concise inline @return tag syntax.

#### Feature description

In modern Java version, the @return tag can be used in an inline form, as well as its block form. It then gets interpreted as both the method specification (by automatically prepending "Returns ") and the return value documentation.

It aims at simplifying the documentation of getters, by reducing the need for repetition.

I decided to apply that syntax on every getter or effective getter in the code. The criteria for selection was any method with a non-void return type, no parameter, and a trivial implementation (returning either a simple field, or a combination / derived value of so). As such, some helper methods offering shortcuts to avoid calling multiple getters in succession were also included.

Note: I did not update any code inside the `com.ignfab.minalac.generator.voxelization` package, so avoid unnecessary rebase headache with #113, reworking nearly every class of that package anyway.

To comply with our code-style rules, I needed to update checkstyle to at least 10.23.0, so I decided to go for the current latest version, 11.0.1 (the only breaking change affecting us was in fact in 10.22.0 anyway...).

#### Technical changes

Updated checkstyle to 11.0.1

#### Showcase

This code:

```java
/**
 * Returns the thing.
 * @return the thing
 */
Object get();
```

Produces the exact same JavaDoc as:

```java
/**
 * {@return the thing}
 */
Object get();
```

### Reason

Duplication in the documentation is the best way to miss an occurrence when updating it, and outdated documentation is worse than no documentation at all...

### Self-checks

- ~~The code has unit tests associated~~
- [x] The code has Javadoc Comments associated
- ~~Complex / Unexpected code is explained / justified with a small comment~~
- ~~Relevant documentation inside the `/docs` folder has been updated~~
- ~~All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)~~
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [x] The texts have been proofread (documentation, error messages, logs, comments...)