### PR TITLE
Add fetched data and heightmap margins to improve tile transition ☼

### DIFF
--- a/docs/usage/parameters/TileTasks.md
+++ b/docs/usage/parameters/TileTasks.md
@@ -2,10 +2,11 @@
 
 Tile tasks will be performed on each tile. They only can be used in a "tile schedule" (for now `forEachTile` only).
 
-Each task has a `type`, optional dependencies to other tasks (in `after`), and other parameters depending on its type.
+Each task has a `type`, some common parameters and specific parameters depending on its type.
 
 ## Table of contents
 
+* [Common parameters](#common-parameters)
 * [Tasks fetching data](#tasks-fetching-data)
   * [`fetchData`](#fetchdata)
 * [Tasks operating on world](#tasks-operating-on-world)
@@ -19,6 +20,22 @@ Each task has a `type`, optional dependencies to other tasks (in `after`), and o
   * [`populateHeightmap`](#populateheightmap)
   * [`copyHeightmap`](#copyheightmap)
   * [`computeHeightmapStats`](#computeheightmapstats)
+
+## Common parameters
+
+- `type`: Type of the task (required).
+
+This type will define what this task will do and what extra parameters it needs. Available types are listed below in different categories.
+
+- `after`: Task that must run before this task (optional).
+
+A single task name or a list of task names can be provided. This task will start only once all mentioned tasks have successfully completed.
+
+- `addMarginsTo`: Model types to add margins to (optional).
+
+In order to perfectly stitch tiles together, rendering tasks may need to get a bit data overpassing the tile area/volume. This field indicates which model type(s) are concerned. This field could contain a single model type name or a list of model type names.
+
+Margins are given by the tasks before starting to work. If a task needs to add margins according to fetched model, it must use another mechanism. Please refer to task documentation.
 
 ## Tasks fetching data
 

--- a/examples/processes/full.yaml
+++ b/examples/processes/full.yaml
@@ -156,6 +156,9 @@ forEachTile:
       - renderGround
       - fetchVegetation
     type: renderSurfaces
+    addMarginsTo:
+      - vegetation
+      - altitude
     models:
       type: vegetation
       filter:

--- a/src/main/java/com/ignfab/minalac/generator/generation/Generation.java
+++ b/src/main/java/com/ignfab/minalac/generator/generation/Generation.java
@@ -1,6 +1,8 @@
 package com.ignfab.minalac.generator.generation;
 
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.geotools.api.referencing.FactoryException;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
@@ -44,6 +46,8 @@ public class Generation {
     private final HeightmapDeclarationStore heightmaps = new HeightmapDeclarationStore();
 
     private final Scheduler<GenerationTile> scheduler = new Scheduler<>();
+
+    private final Map<String, WorldBBox3d> modelTypeMargins = new HashMap<>();
 
     private final int maxTileSize;
     private final Collection<WorldBBox2d> tiles;
@@ -215,5 +219,36 @@ public class Generation {
         return Iterables.remap(tiles,
             bbox -> new GenerationTile(this, bbox.to3d(world.limits().minZ(), world.limits().sizeZ()))
         );
+    }
+
+    /**
+     * Get margins for a model type as a bbox.
+     * <p>
+     * Returned bounding boxes represent the margin around future fetched areas.
+     * (0, 0, 0) is the point belonging to the base fetched area.
+     * Actual fetched area will include every bbox placed around each base area point.
+     *
+     * @return a map associating model type names to model types margins
+     */
+    public Map<String, WorldBBox3d> modelTypeMargins() {
+        return modelTypeMargins;
+    }
+
+    /**
+     * Ensures given margins will be included for the given model type.
+     * <p>
+     * Margins are represented by a bounding box. Negative part of bounding box
+     * will be added to min* and positive to max* limits of model type bounding box.
+     *
+     * @param modelType model type
+     * @param margins margins to include
+     */
+    public void includeModelTypeMargins(String modelType, WorldBBox3d margins) {
+        WorldBBox3d actual = modelTypeMargins.get(modelType);
+        if (actual == null)
+            // At least we include tile bbox points
+            actual = WorldBBox3d.ORIGIN;
+
+        modelTypeMargins.put(modelType, WorldBBox3d.surrounding(actual, margins));
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/generation/GenerationTile.java
+++ b/src/main/java/com/ignfab/minalac/generator/generation/GenerationTile.java
@@ -1,7 +1,11 @@
 package com.ignfab.minalac.generator.generation;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import com.ignfab.minalac.generator.generation.heightmaps.HeightmapStore;
 import com.ignfab.minalac.generator.models.ModelStore;
+import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.world.MapWriteException;
 import com.ignfab.minalac.generator.world.VoxelTile;
@@ -14,6 +18,8 @@ public class GenerationTile {
     private final VoxelTile voxels;
     private final HeightmapStore heightmaps;
     private final ModelStore models = new ModelStore();
+
+    private final Map<String, ModelTypeVolume> modelTypeVolumes = new HashMap<>();
 
     /**
      * Creates a new {@code GenerationTile} for a generation and a volume.
@@ -29,6 +35,11 @@ public class GenerationTile {
 
         // Create heightmap store populated with stored heigthmaps
         heightmaps = new HeightmapStore(generation.heightmaps(), limits.to2d());
+
+        // Set already known margins for model types
+        generation.modelTypeMargins().forEach((name, margins) ->
+            modelTypeVolumes.put(name, new ModelTypeVolume(limits.enlarged(margins)))
+        );
     }
 
     /**
@@ -75,5 +86,91 @@ public class GenerationTile {
 
         // Heightmaps are discarded, only voxels are saved
         voxels().save();
-   }
+    }
+
+    /**
+     * Returns volume information for model type.
+     * <p>
+     * A volume information is attached to each model type. By default, volume is the tile volume.
+     *
+     * @param modelType model type name
+     * @return volume information
+     *
+     * {@see GenerationTile#ModelTypeVolume}
+     */
+    public ModelTypeVolume modelTypeVolume(String modelType) {
+        ModelTypeVolume volume = modelTypeVolumes.get(modelType);
+        if (volume == null) {
+            volume = new ModelTypeVolume(this.limits());
+            modelTypeVolumes.put(modelType, volume);
+        }
+        return volume;
+    }
+
+    /**
+     * Model type volume information.
+     * <p>
+     * Model type volume can be expanded (never shrunk) to include margins
+     * or other volumes, until it is read for usage.
+     * Aftewards it's locked and can't be modified anymore.
+     **/
+    public static class ModelTypeVolume {
+        private WorldBBox3d volume;
+        private boolean locked;
+
+        /**
+         * Creates a new {@code ModelTypeVolume}.
+         *
+         * Margins will be added to base volume only (and not to volumes included later).
+         *
+         * @param volume base volume
+         */
+        public ModelTypeVolume(WorldBBox3d volume) {
+            this.volume = volume;
+            locked = false;
+        }
+
+        /**
+         * Returns volume value.
+         * Volume won't be updatable anymore afterwards.
+         *
+         * @return model type volume as a bounding box
+         */
+        public WorldBBox3d get() {
+            locked = true;
+            return volume;
+        }
+
+        private void checkLock() {
+            if (locked)
+                throw new IllegalStateException("Can't enlarge limits that have already been used");
+        }
+
+        /**
+         * Include given area.
+         * <p>
+         * The volume xy-area will grow enough to include both its former area and given area.
+         * Volume height is unchanged.
+         *
+         * @param area area to include
+         */
+        public void include(WorldBBox2d area) {
+            checkLock();
+            volume = WorldBBox2d.surrounding(volume.to2d(), area).to3d(volume.minZ(), volume.sizeZ());
+        }
+
+        /**
+         * Include given volume.
+         * <p>
+         * The volume will grow enough to include both its former volume and given volume.
+         *
+         * @param volume volume to include
+         *
+         */
+        public void include(WorldBBox3d volume) {
+            checkLock();
+            this.volume = WorldBBox3d.surrounding(this.volume, volume);
+        }
+    }
+
 }

--- a/src/main/java/com/ignfab/minalac/generator/generation/heightmaps/Heightmap.java
+++ b/src/main/java/com/ignfab/minalac/generator/generation/heightmaps/Heightmap.java
@@ -9,8 +9,9 @@ import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
  * A 2d heightmap in voxel world units.
  */
 public class Heightmap implements WritableHeightmap {
-    private final WorldBBox2d bbox;
-    private final int[] values;
+    private WorldBBox2d bbox; // Bbox of values array
+    private final int defaultValue;
+    private int[] values; // Will be created at first write attempt
 
     /**
      * Creates a new {@link Heightmap}.
@@ -33,9 +34,8 @@ public class Heightmap implements WritableHeightmap {
      */
     public Heightmap(WorldBBox2d bbox, int defaultValue) {
         this.bbox = bbox;
-        values = new int[bbox.size().area()];
-        if (defaultValue != 0)
-            Arrays.fill(values, defaultValue);
+        this.defaultValue = defaultValue;
+        values = null;
     }
 
     /**
@@ -45,14 +45,20 @@ public class Heightmap implements WritableHeightmap {
      */
     public Heightmap(ReadableHeightmap other) {
         this.bbox = other.bbox();
+        this.defaultValue = 0; // TODO: Something better ? ReadableHeightmap may not have default value
         values = new int[bbox.size().area()];
         copyValues(other);
     }
 
-    private int index(int x, int y) {
-        if (!bbox.contains(x, y))
-            throw new IndexOutOfBoundsException("Index out of range at (x=%d, y=%d)".formatted(x, y));
-        return (x - bbox.minX()) * bbox.sizeY() + (y - bbox.minY());
+    @Override
+    public void includeArea(WorldBBox2d area) {
+        if (bbox.contains(area))
+            return;
+
+        if (values != null)
+            throw new IllegalStateException("Can't change an already populated heightmap size");
+
+        bbox = WorldBBox2d.surrounding(bbox, area);
     }
 
     @Override
@@ -62,17 +68,32 @@ public class Heightmap implements WritableHeightmap {
 
     @Override
     public int get(int x, int y) {
-        return values[index(x, y)];
+        if (values == null || !bbox.contains(x, y))
+            return defaultValue;
+
+        return values[x - bbox.minX() + bbox.sizeX() * (y - bbox.minY())];
     }
 
     @Override
     public void set(int x, int y, int height) {
-        values[index(x, y)] = height;
+        if (!bbox.contains(x, y))
+            throw new IndexOutOfBoundsException("Index out of range at (x=%d, y=%d)".formatted(x, y));
+
+        if (values == null) {
+            values = new int[bbox.size().area()];
+            if (defaultValue != 0)
+                Arrays.fill(values, defaultValue);
+        }
+
+        values[x - bbox.minX() + bbox.sizeX() * (y - bbox.minY())] = height;
     }
 
     @Override
     public void copyValues(ReadableHeightmap other) {
-        if (other instanceof Heightmap hm && other.bbox().equals(bbox)) {
+        if (values == null)
+            values = new int[bbox.size().area()];
+
+        if (other instanceof Heightmap hm && hm.values != null && other.bbox().equals(bbox)) {
             // If same bbox and same class, we can go faster
             System.arraycopy(hm.values, 0, values, 0, values.length);
             return;

--- a/src/main/java/com/ignfab/minalac/generator/generation/heightmaps/HeightmapDeclaration.java
+++ b/src/main/java/com/ignfab/minalac/generator/generation/heightmaps/HeightmapDeclaration.java
@@ -8,7 +8,6 @@ import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
 public class HeightmapDeclaration {
     private final String name;
     private final int defaultValue;
-    // TODO: Later, margins could be added here
 
     private final WritableHeightmapSpec spec = new WritableHeightmapSpec();
 

--- a/src/main/java/com/ignfab/minalac/generator/generation/heightmaps/WritableHeightmap.java
+++ b/src/main/java/com/ignfab/minalac/generator/generation/heightmaps/WritableHeightmap.java
@@ -1,5 +1,6 @@
 package com.ignfab.minalac.generator.generation.heightmaps;
 
+import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
 import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
 
 /**
@@ -46,4 +47,13 @@ public interface WritableHeightmap extends ReadableHeightmap {
      * @param other Heightmap to copy values from
      */
     void copyValues(ReadableHeightmap other);
+
+    /**
+     * Extends heightmap area so it includes given area.
+     * <p>
+     * Can be called only before heighmap contains any data (before any write/copy).
+     *
+     * @param area area to include in heightmap
+     */
+    void includeArea(WorldBBox2d area);
 }

--- a/src/main/java/com/ignfab/minalac/generator/models/ModelSelection.java
+++ b/src/main/java/com/ignfab/minalac/generator/models/ModelSelection.java
@@ -34,4 +34,11 @@ public class ModelSelection {
         List<Model> models = tile.models().getByType(type);
         return filter == null ? models : Iterables.filter(models, filter);
     }
+
+    /**
+     * {@return model type name for this selection}
+     */
+    public String type() {
+        return type;
+    }
 }

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxel.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxel.java
@@ -8,6 +8,7 @@ import net.querz.nbt.tag.CompoundTag;
 import net.querz.nbt.tag.StringTag;
 
 import com.ignfab.minalac.generator.placeables.Placeable;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.world.VoxelTile;
 
 /**
@@ -117,5 +118,10 @@ public class MCVoxel implements Placeable {
     @Override
     public int hashCode() {
         return Objects.hash(type, properties);
+    }
+
+    @Override
+    public WorldBBox3d bbox() {
+        return WorldBBox3d.ORIGIN;
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxel.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxel.java
@@ -3,6 +3,7 @@ package com.ignfab.minalac.generator.outputs.minetest;
 import java.util.Objects;
 
 import com.ignfab.minalac.generator.placeables.Placeable;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.world.VoxelTile;
 
 /**
@@ -103,5 +104,10 @@ public class MTVoxel implements Placeable {
     @Override
     public int hashCode() {
         return Objects.hash(type, param1, param2);
+    }
+
+    @Override
+    public WorldBBox3d bbox() {
+        return WorldBBox3d.ORIGIN;
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/parameters/GenerationCreator.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/GenerationCreator.java
@@ -68,6 +68,10 @@ public final class GenerationCreator {
         params.forEachTile.forEach((name, taskParams) -> {
             TileTask task = taskParams.create(generation);
             generation.scheduler().schedule(name, task);
+            taskParams.addMarginsTo.forEach((modelType) -> {
+                // Add placement margins to implied models
+                generation.includeModelTypeMargins(modelType, task.placementMargins());
+            });
         });
         params.forEachTile.forEach((name, taskParams) -> {
             for (String depName : taskParams.after)

--- a/src/main/java/com/ignfab/minalac/generator/parameters/tasks/TileTaskParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/tasks/TileTaskParams.java
@@ -23,6 +23,13 @@ public abstract class TileTaskParams extends PolymorphicParams {
     public List<String> after = new ArrayList<>();
 
     /**
+     * Model types to apply margin on (optional).
+     */
+    @JsonSetter(nulls = Nulls.SKIP)
+    @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+    public List<String> addMarginsTo = new ArrayList<>();
+
+    /**
      * Creates the corresponding {@code TileTask}.
      *
      * @param generation the generation context.

--- a/src/main/java/com/ignfab/minalac/generator/placeables/CombinedPlaceable.java
+++ b/src/main/java/com/ignfab/minalac/generator/placeables/CombinedPlaceable.java
@@ -3,6 +3,7 @@ package com.ignfab.minalac.generator.placeables;
 import java.util.LinkedList;
 import java.util.List;
 
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.world.VoxelTile;
 
 /**
@@ -11,6 +12,7 @@ import com.ignfab.minalac.generator.world.VoxelTile;
  */
 public class CombinedPlaceable implements Placeable {
     private final List<Placeable> placeables = new LinkedList<>();
+    private WorldBBox3d bbox;
 
     /**
      * Add a placeable at the end of the {@code CombinedPlaceable}'s placeables list.
@@ -19,10 +21,19 @@ public class CombinedPlaceable implements Placeable {
      */
     public void add(Placeable placeable) {
         placeables.add(placeable);
+        bbox = null; // Force recompute bbox
     }
 
     @Override
     public void place(VoxelTile tile, int x, int y, int z) {
         placeables.forEach((placeable) -> placeable.place(tile, x, y, z));
+    }
+
+    @Override
+    public WorldBBox3d bbox() {
+        if (bbox == null)
+            bbox = WorldBBox3d.surrounding(placeables);
+
+        return bbox;
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/placeables/Nothing.java
+++ b/src/main/java/com/ignfab/minalac/generator/placeables/Nothing.java
@@ -1,5 +1,6 @@
 package com.ignfab.minalac.generator.placeables;
 
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.world.VoxelTile;
 
 /**
@@ -30,5 +31,10 @@ public final class Nothing implements Pattern {
     @Override
     public Placeable get(int x, int y, int z) {
         return this;
+    }
+
+    @Override
+    public WorldBBox3d bbox() {
+        return WorldBBox3d.EMPTY;
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/placeables/Placeable.java
+++ b/src/main/java/com/ignfab/minalac/generator/placeables/Placeable.java
@@ -1,12 +1,15 @@
 package com.ignfab.minalac.generator.placeables;
 
+import com.ignfab.minalac.generator.utils.world3d.Bounded3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
 import com.ignfab.minalac.generator.world.VoxelTile;
 
 /**
  * The {@code Placeable} interface represents something placeable in voxel world.
+ *
+ * {@code Placeable} are bounded. In their bounding boxes, (0, 0, 0) is the placing point.
  */
-public interface Placeable {
+public interface Placeable extends Bounded3d {
     /**
      * Places the placeable at given position in {@link VoxelTile}.
      * Coordinates are expressed using the system used in {@link WorldCoords3d}.

--- a/src/main/java/com/ignfab/minalac/generator/placeables/PlaceableStructure.java
+++ b/src/main/java/com/ignfab/minalac/generator/placeables/PlaceableStructure.java
@@ -3,6 +3,7 @@ package com.ignfab.minalac.generator.placeables;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.ignfab.minalac.generator.utils.world3d.Bounded3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
 import com.ignfab.minalac.generator.world.VoxelTile;
@@ -14,6 +15,7 @@ import com.ignfab.minalac.generator.world.VoxelTile;
 public class PlaceableStructure implements Placeable {
     private final Map<WorldCoords3d, Placeable> placeables = new HashMap<>();
     private WorldBBox3d limits = null;
+    private WorldBBox3d bbox = null;
 
     /**
      * {@inheritDoc}
@@ -40,8 +42,9 @@ public class PlaceableStructure implements Placeable {
         else
             placeables.put(coords, placeable);
 
-        // Force limits recompute
+        // Force limits & bbox recompute (likely to be useless as they should be used only once structure built)
         limits = null;
+        bbox = null;
     }
 
     /**
@@ -144,5 +147,19 @@ public class PlaceableStructure implements Placeable {
                 : new WorldBBox3d(placeables.keySet().toArray(new WorldCoords3d[0]));
 
         return limits;
+    }
+
+    @Override
+    public WorldBBox3d bbox() {
+        // Bbox won't be updated if one of childs bbox changes but this is not supposed to happen
+        // as all structures are build before any of them are used.
+
+        if (bbox == null)
+            bbox = WorldBBox3d.surrounding(() ->
+                placeables.entrySet().stream().map(
+                    (Map.Entry<WorldCoords3d, Placeable> e) -> (Bounded3d) e.getValue().bbox().shift(e.getKey())
+                ).iterator()
+            );
+        return bbox;
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/placeables/patterns/RandomPattern.java
+++ b/src/main/java/com/ignfab/minalac/generator/placeables/patterns/RandomPattern.java
@@ -5,6 +5,7 @@ import com.ignfab.minalac.generator.placeables.Pattern;
 import com.ignfab.minalac.generator.placeables.Placeable;
 import com.ignfab.minalac.generator.utils.random.Random;
 import com.ignfab.minalac.generator.utils.random.Seed;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 
 /**
  * A pattern placing something or not according to a simple "dice roll".
@@ -33,5 +34,11 @@ public class RandomPattern implements Pattern {
         if (random.nextDouble() < chance)
             return placeable;
         return Nothing.INSTANCE;
+    }
+
+    @Override
+    public WorldBBox3d bbox() {
+        // bbox() is the largest possible bbox, not the actual which depends on position and seed.
+        return placeable.bbox();
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/placeables/patterns/RepeatPattern.java
+++ b/src/main/java/com/ignfab/minalac/generator/placeables/patterns/RepeatPattern.java
@@ -3,6 +3,8 @@ package com.ignfab.minalac.generator.placeables.patterns;
 import com.ignfab.minalac.generator.placeables.Pattern;
 import com.ignfab.minalac.generator.placeables.Placeable;
 import com.ignfab.minalac.generator.placeables.PlaceableStructure;
+import com.ignfab.minalac.generator.utils.iterator.Iterables;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldSize3d;
 
@@ -16,6 +18,7 @@ public class RepeatPattern implements Pattern {
     private final WorldCoords3d zd;
 
     private final WorldSize3d size;
+    private final WorldBBox3d bbox;
 
     /**
      * Create a new {@code RepeatPattern}.
@@ -41,6 +44,10 @@ public class RepeatPattern implements Pattern {
             structure.limits().sizeY() + yd.y(),
             structure.limits().sizeZ() + zd.z()
         );
+
+        // BBox is the largest bbox of underlying placables.
+        // Actual bbox depends on position but we have none.
+        bbox = WorldBBox3d.surrounding(Iterables.remap(structure.limits(), (pos) -> structure.get(pos).bbox()));
     }
 
     @Override
@@ -57,5 +64,10 @@ public class RepeatPattern implements Pattern {
             min.y() + Math.floorMod(y - min.y() - xd.y() * nx - zd.y() * nz, size.y()),
             min.z() + Math.floorMod(z - min.z() - xd.z() * nx - yd.z() * ny, size.z())
         );
+    }
+
+    @Override
+    public WorldBBox3d bbox() {
+        return bbox;
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/tasks/FetchDataTask.java
+++ b/src/main/java/com/ignfab/minalac/generator/tasks/FetchDataTask.java
@@ -57,7 +57,7 @@ public class FetchDataTask implements TileTask {
      * @param tile tile for which data is fetched (it gives the wanted area)
      */
     public void run(GenerationTile tile) {
-        try (Provider.Result<?> result = provider.provide(tile.limits())) {
+        try (Provider.Result<?> result = provider.provide(tile.modelTypeVolume(modelType).get())) {
             processor.initialize(result.crs());
             while (result.hasNext()) {
                 Object data = result.next();

--- a/src/main/java/com/ignfab/minalac/generator/tasks/ModelTask.java
+++ b/src/main/java/com/ignfab/minalac/generator/tasks/ModelTask.java
@@ -11,7 +11,11 @@ import com.ignfab.minalac.generator.models.ModelSelection;
  */
 public abstract class ModelTask<M extends Model> implements TileTask {
     private final Class<M> cls;
-    private final ModelSelection selection;
+
+    /**
+     * Selection of models to be processed by this task.
+     */
+    protected final ModelSelection selection;
 
     protected ModelTask(Class<M> cls, ModelSelection selection) {
         this.cls = cls;

--- a/src/main/java/com/ignfab/minalac/generator/tasks/PopulateHeightmapTask.java
+++ b/src/main/java/com/ignfab/minalac/generator/tasks/PopulateHeightmapTask.java
@@ -5,7 +5,6 @@ import com.ignfab.minalac.generator.generation.heightmaps.WritableHeightmap;
 import com.ignfab.minalac.generator.generation.heightmaps.WritableHeightmapSpec;
 import com.ignfab.minalac.generator.models.FloatMatrixModel;
 import com.ignfab.minalac.generator.models.ModelSelection;
-import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
 import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
 import com.ignfab.minalac.generator.voxelization.Matrix2d;
 
@@ -30,11 +29,12 @@ public class PopulateHeightmapTask extends ModelTask<FloatMatrixModel> {
     @Override
     protected void run(FloatMatrixModel model, GenerationTile tile) {
         WritableHeightmap heightmap = tile.heightmaps().get(heightmapSpec);
-        WorldBBox2d intersection = tile.limits().to2d().intersection(heightmap.bbox());
+        heightmap.includeArea(tile.modelTypeVolume(selection.type()).get().to2d());
         // Iterate over matrix and fill heightmap altitude
+        // TODO: Use clip iterator once #113 merged
         for (Matrix2d.Value<Float> value : model) {
             WorldCoords2d c = value.coords();
-            if (intersection.contains(c))
+            if (heightmap.bbox().contains(c))
                 heightmap.set(c, Math.round(value.value()));
         }
     }

--- a/src/main/java/com/ignfab/minalac/generator/tasks/RenderHeightmapTask.java
+++ b/src/main/java/com/ignfab/minalac/generator/tasks/RenderHeightmapTask.java
@@ -5,6 +5,7 @@ import com.ignfab.minalac.generator.generation.heightmaps.ReadableHeightmap;
 import com.ignfab.minalac.generator.generation.heightmaps.ReadableHeightmapSpec;
 import com.ignfab.minalac.generator.placeables.Placeable;
 import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 
 /**
  * A {@link TileTask} placing things between a minimum and maximum heightmap.
@@ -25,6 +26,11 @@ public class RenderHeightmapTask implements TileTask {
         this.minimum = minimum;
         this.maximum = maximum;
         this.placeable = placeable;
+    }
+
+    @Override
+    public WorldBBox3d placementMargins() {
+        return placeable.bbox().symetric();
     }
 
     @Override

--- a/src/main/java/com/ignfab/minalac/generator/tasks/TileTask.java
+++ b/src/main/java/com/ignfab/minalac/generator/tasks/TileTask.java
@@ -3,6 +3,7 @@ package com.ignfab.minalac.generator.tasks;
 import java.util.function.Consumer;
 
 import com.ignfab.minalac.generator.generation.GenerationTile;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 
 /**
  * A task running on a generation tile.
@@ -15,6 +16,18 @@ public interface TileTask extends Consumer<GenerationTile> {
      * @param tile tile to render into
      */
     void run(GenerationTile tile);
+
+    /**
+     * Returns margins resulting from involved placeable or other
+     * things that needs to have a greater model volume than tile volume.
+     * <p>
+     * Default implementation means no margin needed.
+     *
+     * @return margin bounding box.
+     */
+    default WorldBBox3d placementMargins() {
+        return WorldBBox3d.EMPTY;
+    };
 
     @Override
     default void accept(GenerationTile tile) {

--- a/src/main/java/com/ignfab/minalac/generator/utils/world2d/WorldBBox2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world2d/WorldBBox2d.java
@@ -1,5 +1,6 @@
 package com.ignfab.minalac.generator.utils.world2d;
 
+import java.util.Arrays;
 import java.util.Iterator;
 
 import com.ignfab.minalac.generator.utils.iterator.Iterators;
@@ -137,6 +138,16 @@ public class WorldBBox2d implements Bounded2d, Iterable<WorldCoords2d> {
         }
 
         return new WorldBBox2d(minX, minY, maxX - minX + 1, maxY - minY + 1);
+    }
+
+    /**
+     * Creates a new {@link WorldBBox2d} containing all bounded items.
+     *
+     * @param items a list of bounded items to contain
+     * @return a bounding box containing all items
+     */
+    public static WorldBBox2d surrounding(Bounded2d... items) {
+        return surrounding(Arrays.asList(items));
     }
 
     /**
@@ -286,6 +297,28 @@ public class WorldBBox2d implements Bounded2d, Iterable<WorldCoords2d> {
      */
     public int maxY() {
         return max.y();
+    }
+
+    /**
+     * Creates a new bounding box enlarged by given bounding box.
+     *
+     * This operation consist in placing a {@code by} bounding box at each point
+     * of current bounding box (centered at (0, 0)) and taking the union of all these bounding boxes.
+     *
+     * @param by area which enlarge bounding box by
+     * @return enlarged bounding box
+     */
+    public WorldBBox2d enlarged(WorldBBox2d by) {
+        return new WorldBBox2d(
+            new WorldCoords2d(
+                Math.min(min.x(), min.x() + by.min.x()),
+                Math.min(min.y(), min.y() + by.min.y())
+            ),
+            new WorldCoords2d(
+                Math.max(max.x(), max.x() + by.max.x()),
+                Math.max(max.y(), max.y() + by.max.y())
+            )
+        );
     }
 
     /**

--- a/src/main/java/com/ignfab/minalac/generator/utils/world3d/WorldBBox3d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world3d/WorldBBox3d.java
@@ -1,5 +1,6 @@
 package com.ignfab.minalac.generator.utils.world3d;
 
+import java.util.Arrays;
 import java.util.Iterator;
 
 import com.ignfab.minalac.generator.utils.iterator.Iterators;
@@ -143,6 +144,16 @@ public class WorldBBox3d implements Bounded3d, Iterable<WorldCoords3d> {
         }
 
         return new WorldBBox3d(minX, minY, minZ, maxX - minX + 1, maxY - minY + 1, maxZ - minZ + 1);
+    }
+
+    /**
+     * Creates a new {@link WorldBBox2d} containing all bounded items.
+     *
+     * @param items a list of bounded items to contain
+     * @return a bounding box containing all items
+     */
+    public static WorldBBox3d surrounding(Bounded3d... items) {
+        return surrounding(Arrays.asList(items));
     }
 
     /**
@@ -320,6 +331,39 @@ public class WorldBBox3d implements Bounded3d, Iterable<WorldCoords3d> {
      */
     public int maxZ() {
         return max.z();
+    }
+
+    /**
+     * Creates a new bounding box enlarged by given bounding box.
+     *
+     * This operation consist in placing a {@code by} bounding box at each point
+     * of current bounding box (centered at (0, 0, 0)) and taking the union of all these bounding boxes.
+     *
+     * @param by volume which enlarge bounding box by
+     * @return enlarged bounding box
+     */
+    public WorldBBox3d enlarged(WorldBBox3d by) {
+        return new WorldBBox3d(
+            new WorldCoords3d(
+                Math.min(min.x(), min.x() + by.min.x()),
+                Math.min(min.y(), min.y() + by.min.y()),
+                Math.min(min.z(), min.z() + by.min.z())
+            ),
+            new WorldCoords3d(
+                Math.max(max.x(), max.x() + by.max.x()),
+                Math.max(max.y(), max.y() + by.max.y()),
+                Math.max(max.z(), max.z() + by.max.z())
+            )
+        );
+    }
+
+    /**
+     * Creates a new bounding box which is symetric of this one around given point.
+     *
+     * @return symetric bounding box
+     */
+    public WorldBBox3d symetric() {
+        return new WorldBBox3d(-maxX(), -maxY(), -maxZ(), sizeX(), sizeY(), sizeZ());
     }
 
     /**

--- a/src/main/java/com/ignfab/minalac/generator/utils/world3d/WorldBBox3d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world3d/WorldBBox3d.java
@@ -323,6 +323,16 @@ public class WorldBBox3d implements Bounded3d, Iterable<WorldCoords3d> {
     }
 
     /**
+     * Returns the bounding box shifted by given coordinates.
+     *
+     * @param by coordinate to shift the bounding box by
+     * @return shifted bounding box
+     */
+    public WorldBBox3d shift(WorldCoords3d by) {
+        return new WorldBBox3d(min().add(by), size());
+    }
+
+    /**
      * Convert this {@link WorldBBox3d} to {@link WorldBBox2d}, dropping its components along the z-axis.
      * The region represented by this bbox will be flattened.
      *

--- a/src/test/java/com/ignfab/minalac/generator/generation/GenerationTileTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/generation/GenerationTileTest.java
@@ -1,0 +1,48 @@
+package com.ignfab.minalac.generator.generation;
+
+import org.junit.jupiter.api.Test;
+
+import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
+import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+public class GenerationTileTest {
+
+    @Test
+    public void testModelTypeVolumeMethod() {
+        Generation generation = new Generation(
+            new TestingVoxelWorld(),
+            null, // Seed
+            null, // CRS
+            0.0, 0.0, // Center
+            100, 100, // extent
+            1.0, 1.0, // Scales
+            0, // Angle
+            100 // Max tile size)
+        );
+
+        GenerationTile tile = new GenerationTile(generation, WorldBBox3d.ORIGIN);
+        GenerationTile.ModelTypeVolume volume;
+
+        volume = assertInstanceOf(GenerationTile.ModelTypeVolume.class,
+            assertDoesNotThrow(() -> tile.modelTypeVolume("TOTO"))
+        );
+        assertEquals(WorldBBox3d.ORIGIN, volume.get());
+    }
+
+    @Test
+    public void testModelTypeVolumeClass() {
+        GenerationTile.ModelTypeVolume volume = new GenerationTile.ModelTypeVolume(new WorldBBox3d(0, 0, 0, 5, 5, 5));
+
+        assertDoesNotThrow(() -> volume.include(new WorldBBox2d(-5, 0, 1, 1)));
+        assertDoesNotThrow(() -> volume.include(new WorldBBox3d(-2, -2, -2, 5, 5, 5)));
+
+        WorldBBox3d bbox = assertDoesNotThrow(() -> volume.get());
+        assertEquals(new WorldBBox3d(-5, -2, -2, 10, 7, 7), bbox);
+
+        assertThrows(IllegalStateException.class, () -> volume.include(new WorldBBox3d(-2, -2, -2, 5, 5, 5)));
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/generation/heightmaps/HeightmapTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/generation/heightmaps/HeightmapTest.java
@@ -66,9 +66,28 @@ public class HeightmapTest {
 
     @Test
     public void testOut() {
-        Heightmap heightmap = new Heightmap(0, 0, 3, 2, 0);
+        Heightmap heightmap = new Heightmap(0, 0, 3, 2, -3);
         assertThrows(IndexOutOfBoundsException.class, () -> heightmap.set(25, 25, 0));
-        assertThrows(IndexOutOfBoundsException.class, () -> heightmap.get(25, 25));
+        assertEquals(-3, assertDoesNotThrow(() -> heightmap.get(25, 25)));
+    }
+
+    @Test
+    public void testIncludeArea() {
+        Heightmap heightmap = new Heightmap(0, 0, 3, 2, -4);
+        heightmap.includeArea(new WorldBBox2d(-1, 3, 1, 2));
+
+        assertEquals(new WorldBBox2d(-1, 0, 4, 5), heightmap.bbox());
+
+        assertDoesNotThrow(() -> heightmap.set(-1, 0, 10));
+        assertDoesNotThrow(() -> heightmap.set(2, 4, 10));
+
+        assertThrows(IndexOutOfBoundsException.class, () -> heightmap.set(-1, -1, 10));
+
+        // Should not be able to change heightmap size anymore
+        assertThrows(IllegalStateException.class, () -> heightmap.includeArea(new WorldBBox2d(5, 4, 3, 2)));
+
+        // But should ignore if area already included
+        assertDoesNotThrow(() -> heightmap.includeArea(heightmap.bbox()));
     }
 
     @Test

--- a/src/test/java/com/ignfab/minalac/generator/outputs/testing/TestingVoxel.java
+++ b/src/test/java/com/ignfab/minalac/generator/outputs/testing/TestingVoxel.java
@@ -3,6 +3,7 @@ package com.ignfab.minalac.generator.outputs.testing;
 import java.util.Objects;
 
 import com.ignfab.minalac.generator.placeables.Placeable;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.world.VoxelTile;
 
 /**
@@ -56,5 +57,10 @@ public class TestingVoxel implements Placeable {
     @Override
     public int hashCode() {
         return Objects.hash(name);
+    }
+
+    @Override
+    public WorldBBox3d bbox() {
+        return WorldBBox3d.ORIGIN;
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/placeables/CombinedPlaceableTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/placeables/CombinedPlaceableTest.java
@@ -2,7 +2,9 @@ package com.ignfab.minalac.generator.placeables;
 
 import org.junit.jupiter.api.Test;
 
+import com.ignfab.minalac.generator.outputs.testing.TestingVoxel;
 import com.ignfab.minalac.generator.outputs.testing.TestingVoxelTile;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -46,5 +48,29 @@ public class CombinedPlaceableTest {
         assertDoesNotThrow(() -> combined2.place(null, 7, 8, 9));
         assertEquals(new WorldCoords3d(7, 8, 9), placeable1.lastPlaced());
         assertEquals(new WorldCoords3d(7, 8, 9), placeable2.lastPlaced());
+    }
+
+    @Test
+    public void testBbox() {
+        Placeable p = new TestingVoxel("X");
+        CombinedPlaceable placeable = new CombinedPlaceable();
+        PlaceableStructure s1 = new PlaceableStructure();
+        PlaceableStructure s2 = new PlaceableStructure();
+        PlaceableStructure s3 = new PlaceableStructure();
+        s1.set(1, 0, 0, p);
+        s2.set(0, -2, 0, p);
+        s3.set(0, 0, 3, p);
+
+        // Empty placable
+        assertEquals(WorldBBox3d.EMPTY, placeable.bbox());
+
+        // One structure
+        placeable.add(s1);
+        assertEquals(new WorldBBox3d(1, 0, 0, 1, 1, 1), placeable.bbox());
+
+        // All structures
+        placeable.add(s2);
+        placeable.add(s3);
+        assertEquals(new WorldBBox3d(0, -2, 0, 2, 3, 4), placeable.bbox());
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/placeables/PlaceableStructureTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/placeables/PlaceableStructureTest.java
@@ -155,6 +155,9 @@ public class PlaceableStructureTest {
         Placeable vt = new TestingVoxel("X");
         PlaceableStructure structure = new PlaceableStructure();
 
+        // Empty structure
+        assertEquals(WorldBBox3d.EMPTY, structure.limits());
+
         // Basic checks
         structure.set(1, 2, 3, vt);
         assertEquals(new WorldBBox3d(1, 2, 3, 1, 1, 1), structure.limits());
@@ -174,5 +177,27 @@ public class PlaceableStructureTest {
         PlaceableStructure superStructure = new PlaceableStructure();
         superStructure.set(3, 2, 1, structure);
         assertEquals(new WorldBBox3d(3, 2, 1, 1, 1, 1), superStructure.limits());
+    }
+
+    @Test
+    public void testBbox() {
+        Placeable p = new TestingVoxel("X");
+        PlaceableStructure structure = new PlaceableStructure();
+        PlaceableStructure substruct = new PlaceableStructure();
+
+        // Empty structure
+        assertEquals(WorldBBox3d.EMPTY, structure.bbox());
+
+        // Simple structure
+        structure.set(0, 0, 0, p);
+        assertEquals(new WorldBBox3d(0, 0, 0, 1, 1, 1), structure.bbox());
+
+        // Substructures
+        substruct.set(new WorldBBox3d(-1, -1, -1, 3, 3, 3), p);
+        structure.set(0, 0, 10, substruct);
+        structure.set(0, -10, 0, substruct);
+
+        // (x: -1 to 1, y: -11 to 1, z: -1 to 11)
+        assertEquals(new WorldBBox3d(-1, -11, -1, 3, 13, 13), structure.bbox());
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/placeables/TestingPlaceable.java
+++ b/src/test/java/com/ignfab/minalac/generator/placeables/TestingPlaceable.java
@@ -1,5 +1,6 @@
 package com.ignfab.minalac.generator.placeables;
 
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
 import com.ignfab.minalac.generator.world.VoxelTile;
 
@@ -20,5 +21,10 @@ public class TestingPlaceable implements Placeable {
     public void place(VoxelTile tile, int x, int y, int z) {
         timesPlaced++;
         lastPlaced = new WorldCoords3d(x, y, z);
+    }
+
+    @Override
+    public WorldBBox3d bbox() {
+        return WorldBBox3d.ORIGIN;
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/utils/world2d/WorldBBox2dTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/world2d/WorldBBox2dTest.java
@@ -276,6 +276,15 @@ public class WorldBBox2dTest {
     }
 
     @Test
+    @DisplayName("Test enlarged() method")
+    public void testEnlarged() {
+        assertEquals(new WorldBBox2d(0, 0, 4, 6),
+            new WorldBBox2d(1, 2, 3, 4).enlarged(new WorldBBox2d(-1, -2, 1, 1)));
+        assertEquals(new WorldBBox2d(1, 2, 4, 6),
+            new WorldBBox2d(1, 2, 3, 4).enlarged(new WorldBBox2d(1, 2, 1, 1)));
+    }
+
+    @Test
     public void testCenter() {
         // sizeX odd, sizeY even
         assertEquals(new WorldCoords2d(-1, 1), new WorldBBox2d(-2, -1, 3, 4).center());

--- a/src/test/java/com/ignfab/minalac/generator/utils/world3d/WorldBBox3dTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/world3d/WorldBBox3dTest.java
@@ -249,6 +249,29 @@ public class WorldBBox3dTest {
     }
 
     @Test
+    @DisplayName("Test enlarged() method")
+    public void testEnlarged() {
+        assertEquals(new WorldBBox3d(0, 0, 0, 5, 7, 9),
+            new WorldBBox3d(1, 2, 3, 4, 5, 6).enlarged(new WorldBBox3d(-1, -2, -3, 1, 1, 1)));
+        assertEquals(new WorldBBox3d(1, 2, 3, 5, 7, 9),
+            new WorldBBox3d(1, 2, 3, 4, 5, 6).enlarged(new WorldBBox3d(1, 2, 3, 1, 1, 1)));
+    }
+
+    @Test
+    @DisplayName("Test symetric() method")
+    public void testSymetric() {
+        assertEquals(
+            new WorldBBox3d(
+                new WorldCoords3d(-4, -5, -6),
+                new WorldCoords3d(3, 2, 1)
+            ),
+            new WorldBBox3d(
+                new WorldCoords3d(4, 5, 6),
+                new WorldCoords3d(-3, -2, -1)
+            ).symetric());
+    }
+
+    @Test
     @DisplayName("Test shift() method")
     public void testShift() {
         WorldBBox3d shifted;

--- a/src/test/java/com/ignfab/minalac/generator/utils/world3d/WorldBBox3dTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/world3d/WorldBBox3dTest.java
@@ -249,6 +249,18 @@ public class WorldBBox3dTest {
     }
 
     @Test
+    @DisplayName("Test shift() method")
+    public void testShift() {
+        WorldBBox3d shifted;
+        WorldBBox3d box = new WorldBBox3d(1, 2, 3, 4, 5, 6);
+
+        shifted = box.shift(new WorldCoords3d(-2, -4, -6));
+
+        assertEquals(box.size(), shifted.size());
+        assertEquals(new WorldCoords3d(-1, -2, -3), shifted.min());
+    }
+
+    @Test
     public void testCenter() {
         // Odd sizes
         assertEquals(new WorldCoords3d(-2, 0, 2), new WorldBBox3d(-3, -2, -1, 3, 5, 7).center());


### PR DESCRIPTION
### Changes

Add margins around heightmaps, models and voxelization area.

To make tile edges totally invisible, renderers need to know a bit about what's around current tile, in order to be able to draw things that overpass neighbor tile borders (placeable structures in particular).

**Voxelization areas**

Enlarging voxelization area is quite straightforward. The renderers know what they have to place and can enlarge voxelization area accordingly. They only needed that `Placeable`s tells what space they could take. A `bbox` method has been added for that to `Placeable` interface.

**Model fetch areas**

To perform proper voxelization, model fetch area also needs to be enlarged according to renderer needs. For example, a rendrer placing trees needs to know about forest area near the edge of other tiles. It also needs to know about what altitude trees outside have to be placed.

This means that a renderer may add margins to several model types (in the above example : vegetation areas and altitude).

To manage that, a list of model type margins have been added to `Generation`, to store all the needs. Margins don't add but they overlap. A list of model type volumes have also been added to `GenerationTile`. It stores actual needed volume per model type (this will be really useful for further development, see below).

`TileTaskParams` has a new `AddMarginsTo` field where can be told which model types should be enlarged according to the task needs. `placementMargins` method has been added to `TileTask` interface to express that volume need as a 'margin' bounding box (margins the six +X/-X/+Y/-Y/+Z/-Z directions stored in a bounding box).

**Heightmap areas**

Heightmaps may also need to overpass tile limits. This is the responsibility of task writing data to the heightmap to do that. 

`WritableHeightmap` interface have been modified so its now possible to increase its area, until some data is written.

#### Showcase

Before the PR:
<img width="775" height="752" alt="Capture d’écran du 2025-09-03 14-32-03" src="https://github.com/user-attachments/assets/f7b4172d-06c8-4610-9dc4-119fcf28f704" />
Some tree parts are missing around tile edge (in the middle of the image). Tile transition can be guessed.

After the PR:
<img width="775" height="752" alt="Capture d’écran du 2025-09-03 14-34-23" src="https://github.com/user-attachments/assets/49b195f7-872a-4689-85dd-91b162b16457" />
No missing tree parts. Tile edge is totally invisible.

### Next step

This PR makes it possible to create tasks enlarging model type volumes according to other already fetched models (typically buildings).

This is not included in this PR as it implies some more development (extra needed volume depends on vector feature voxelization and this may be complex).

--> It would be better to wait for #113 to be merged before developing something new on voxelizers.

### TODOs

- [ ] Check everything has been updated with new features (for example: water rendering code and yaml parameters)

### Self-checks

- [x] The code has unit tests associated
- [x] The code has Javadoc Comments associated
- [x] Complex / Unexpected code is explained / justified with a small comment
- [x] Relevant documentation inside the `/docs` folder has been updated
- [x] All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [x] The texts have been proofread (documentation, error messages, logs, comments...)
