### PR TITLE
perf(memory): Improve Minetest and Minecraft format by reducing memory allocations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,12 @@
             <artifactId>commons-cli</artifactId>
             <version>1.8.0</version>
         </dependency>
+        <!-- Type-specific collections -->
+        <dependency>
+            <groupId>it.unimi.dsi</groupId>
+            <artifactId>fastutil-core</artifactId>
+            <version>8.5.16</version>
+        </dependency>
 
         <!--
         TEST DEPENDENCIES

--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,12 @@
             <artifactId>fastutil-core</artifactId>
             <version>8.5.16</version>
         </dependency>
+        <!-- Apache pools utility -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-pool2</artifactId>
+            <version>2.12.1</version>
+        </dependency>
 
         <!--
         TEST DEPENDENCIES

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxel.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxel.java
@@ -25,6 +25,9 @@ public class MCVoxel implements Placeable {
      */
     protected final Map<String, String> properties;
 
+    // Lazily-initialized reusable block data
+    private CompoundTag block;
+
     /**
      * Constructs a new {@code MCVoxel}.
      *
@@ -85,12 +88,14 @@ public class MCVoxel implements Placeable {
      * @param z position z-coordinate
      */
     protected void place(MCVoxelTile tile, int x, int y, int z)  {
-        CompoundTag block = new CompoundTag();
-        block.putString("Name", type);
-        if (properties != null) {
-            CompoundTag state = new CompoundTag();
-            properties.forEach(state::putString);
-            block.put("Properties", state);
+        if (block == null) {
+            block = new CompoundTag();
+            block.putString("Name", type);
+            if (properties != null) {
+                CompoundTag state = new CompoundTag();
+                properties.forEach(state::putString);
+                block.put("Properties", state);
+            }
         }
         tile.setBlockState(x, z, -y - 1, block); // X/Y/Z => X/Z/-Y
     }

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelTile.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelTile.java
@@ -2,9 +2,10 @@ package com.ignfab.minalac.generator.outputs.minecraft;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import net.querz.mca.Chunk;
 import net.querz.mca.MCAUtil;
 import net.querz.nbt.tag.CompoundTag;
@@ -21,7 +22,7 @@ import com.ignfab.minalac.generator.world.VoxelTile;
 public class MCVoxelTile extends VoxelTile {
     private final File destination;
 
-    private final Map<Integer, Region> regions = new HashMap<>();
+    private final Int2ObjectMap<Region> regions = Int2ObjectMaps.synchronize(new Int2ObjectOpenHashMap<>());
 
     /**
      * Creates a new {@code MCVoxelTile}.
@@ -76,20 +77,7 @@ public class MCVoxelTile extends VoxelTile {
 
     // In-Game coords
     private Region getOrCreateRegion(int blockX, int blockZ)  {
-        int regionX = MCAUtil.blockToRegion(blockX);
-        int regionZ = MCAUtil.blockToRegion(blockZ);
-        int key = computeRegionKey(regionX, regionZ);
-        Region region = regions.get(key);
-        if (region == null) {
-            region = new Region(regionX, regionZ);
-            regions.put(key, region);
-        }
-        return region;
-    }
-
-    // In-Game coords
-    private int computeRegionKey(int regionX, int regionZ) {
-        return (regionX << 16) | (regionZ & 0xFFFF);
+        return regions.computeIfAbsent(Region.computeKeyFromBlock(blockX, blockZ), Region::new);
     }
 
     // In-Game coords
@@ -105,7 +93,7 @@ public class MCVoxelTile extends VoxelTile {
      */
     @Override
     public Placeable getVoxel(int x, int y, int z) {
-        Region region = regions.get(computeRegionKey(MCAUtil.blockToRegion(x), MCAUtil.blockToRegion(-y - 1)));
+        Region region = regions.get(Region.computeKeyFromBlock(x, -y - 1));
 
         if (region == null) return null;
 

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/Region.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/Region.java
@@ -36,6 +36,16 @@ public record Region(int regionX, int regionZ, MCAFile file) {
     }
 
     /**
+     * Constructs a new {@link Region}.
+     *
+     * @param regionKey the int-packed key of this region
+     * @see #computeKey(int, int)
+     */
+    public Region(int regionKey) {
+        this(keyToRegionX(regionKey), keyToRegionZ(regionKey));
+    }
+
+    /**
      * Returns the {@link Chunk} at the specified coordinates or creates it if it doesn't exist.
      *
      * @param chunkX the x-coordinate of the chunk
@@ -98,5 +108,43 @@ public record Region(int regionX, int regionZ, MCAFile file) {
     public MCVoxel getBlock(int blockX, int blockY, int blockZ) {
         CompoundTag block = file().getBlockStateAt(blockX, blockY, blockZ);
         return (block == null) ? null : MCVoxel.fromBlockState(block);
+    }
+
+    /**
+     * Computes the int-packed key of the region containing the blocks with given x/z.
+     * @param blockX the x-coordinate of the block
+     * @param blockZ the z-coordinate of the block
+     * @return the region key
+     */
+    public static int computeKeyFromBlock(int blockX, int blockZ) {
+        return computeKey(MCAUtil.blockToRegion(blockX), MCAUtil.blockToRegion(blockZ));
+    }
+
+    /**
+     * Computes the int-packed key of the region with given x/z.
+     * @param regionX the x-coordinate of the region
+     * @param regionZ the z-coordinate of the region
+     * @return the region key
+     */
+    public static int computeKey(int regionX, int regionZ) {
+        return (regionX << 16) | (regionZ & 0xFFFF);
+    }
+
+    /**
+     * Extracts the x-coordinate of the region from its key.
+     * @param regionKey the region key
+     * @return the x-coordinate of the region
+     */
+    public static int keyToRegionX(int regionKey) {
+        return (short) ((regionKey >> 16) & 0xFFFF); // cast to short to properly restore sign
+    }
+
+    /**
+     * Extracts the z-coordinate of the region from its key.
+     * @param regionKey the region key
+     * @return the z-coordinate of the region
+     */
+    public static int keyToRegionZ(int regionKey) {
+        return (short) (regionKey & 0xFFFF); // cast to short to properly restore sign
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelTile.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelTile.java
@@ -1,8 +1,10 @@
 package com.ignfab.minalac.generator.outputs.minetest;
 
 import java.io.File;
-import java.util.HashMap;
-import java.util.Map;
+
+import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
+import it.unimi.dsi.fastutil.longs.Long2ObjectMaps;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 
 import com.ignfab.minalac.generator.outputs.minetest.utils.SQLiteMapWriter;
 import com.ignfab.minalac.generator.placeables.Placeable;
@@ -16,7 +18,7 @@ import com.ignfab.minalac.generator.world.VoxelTile;
 public class MTVoxelTile extends VoxelTile {
     private final File destination;
 
-    private final HashMap<Long, Block> blocks = new HashMap<>();
+    private final Long2ObjectMap<Block> blocks = Long2ObjectMaps.synchronize(new Long2ObjectOpenHashMap<>());
 
     /**
      * Creates a new {@code MTVoxelTile}.
@@ -31,17 +33,7 @@ public class MTVoxelTile extends VoxelTile {
 
     // Retrieves or creates the mapblock corresponding to given voxel position.
     private Block getOrCreateBlock(int blockX, int blockY, int blockZ) {
-        Long pos = coordsToPos(blockX, blockY, blockZ);
-        Block block = blocks.get(pos);
-        if (block == null)
-            synchronized (blocks) {
-                block = blocks.get(pos);
-                if (block == null) {
-                    block = new Block();
-                    blocks.put(pos, block);
-                }
-            }
-        return block;
+        return blocks.computeIfAbsent(coordsToPos(blockX, blockY, blockZ), k -> new Block());
     }
 
     private Block getBlock(int blockX, int blockY, int blockZ) {
@@ -83,9 +75,8 @@ public class MTVoxelTile extends VoxelTile {
             return; // Save disabled if null destination
 
         SQLiteMapWriter database = new SQLiteMapWriter(destination);
-        for (Map.Entry<Long, Block> entry : blocks.entrySet()) {
-            database.insertBlock(entry.getKey(), entry.getValue());
-        }
+        for (Long2ObjectMap.Entry<Block> entry : Long2ObjectMaps.fastIterable(blocks))
+            database.insertBlock(entry.getLongKey(), entry.getValue());
     }
 
     /**

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelTile.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelTile.java
@@ -1,7 +1,5 @@
 package com.ignfab.minalac.generator.outputs.minetest;
 
-import java.io.File;
-
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMaps;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
@@ -16,19 +14,19 @@ import com.ignfab.minalac.generator.world.VoxelTile;
  * Implementation of {@link VoxelTile} for Minetest.
  */
 public class MTVoxelTile extends VoxelTile {
-    private final File destination;
+    private final SQLiteMapWriter mapWriter;
 
     private final Long2ObjectMap<Block> blocks = Long2ObjectMaps.synchronize(new Long2ObjectOpenHashMap<>());
 
     /**
      * Creates a new {@code MTVoxelTile}.
      *
-     * @param destination Destination database file
+     * @param mapWriter SQLite writer for map blocks
      * @param limits Limits of this tile (must be contained in world limits)
      */
-    public MTVoxelTile(File destination, WorldBBox3d limits) {
+    public MTVoxelTile(SQLiteMapWriter mapWriter, WorldBBox3d limits) {
         super(limits);
-        this.destination = destination;
+        this.mapWriter = mapWriter;
     }
 
     // Retrieves or creates the mapblock corresponding to given voxel position.
@@ -71,12 +69,11 @@ public class MTVoxelTile extends VoxelTile {
      */
     @Override
     public void save() throws MapWriteException {
-        if (destination == null)
-            return; // Save disabled if null destination
+        if (mapWriter == null)
+            return; // Save disabled if null writer
 
-        SQLiteMapWriter database = new SQLiteMapWriter(destination);
         for (Long2ObjectMap.Entry<Block> entry : Long2ObjectMaps.fastIterable(blocks))
-            database.insertBlock(entry.getLongKey(), entry.getValue());
+            mapWriter.insertBlock(entry.getLongKey(), entry.getValue());
     }
 
     /**

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelWorld.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelWorld.java
@@ -1,7 +1,6 @@
 package com.ignfab.minalac.generator.outputs.minetest;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.Collection;
 
 import com.ignfab.minalac.generator.generation.SquareUnitsTileGenerator;
@@ -26,7 +25,7 @@ public class MTVoxelWorld extends VoxelWorld {
     );
 
     private final File destination;
-    private final File mapDatabase;
+    private SQLiteMapWriter mapWriter;
 
     /**
      * Constructs a new {@code MTVoxelWorld}.
@@ -37,13 +36,6 @@ public class MTVoxelWorld extends VoxelWorld {
     public MTVoxelWorld(File destination) {
         super(new VoxelWorldMetadata());
         this.destination = destination;
-
-        // Prepare destination directory
-        if (destination == null) {
-            mapDatabase = null;
-        } else {
-            mapDatabase = new File(destination, "map.sqlite");
-        }
     }
 
     @Override
@@ -53,7 +45,7 @@ public class MTVoxelWorld extends VoxelWorld {
 
     @Override
     public MTVoxelTile newTile(WorldBBox3d limits) {
-        return new MTVoxelTile(mapDatabase, limits);
+        return new MTVoxelTile(mapWriter, limits);
     }
 
     @Override
@@ -64,7 +56,8 @@ public class MTVoxelWorld extends VoxelWorld {
         if (!destination.exists() || !destination.isDirectory())
             throw new MapWriteException("Directory %s can not be accessed".formatted(destination));
 
-        new SQLiteMapWriter(mapDatabase).createDatabase();
+        mapWriter = new SQLiteMapWriter(new File(destination, "map.sqlite"));
+        mapWriter.createDatabase();
     }
 
     /**
@@ -77,6 +70,8 @@ public class MTVoxelWorld extends VoxelWorld {
             return; // Save disabled if null destination
 
         try {
+            mapWriter.close();
+
             FileHelpers.write(new File(destination, "world.mt"), """
                 world_name = %s
                 enable_damage = true
@@ -93,7 +88,7 @@ public class MTVoxelWorld extends VoxelWorld {
             FileHelpers.write(new File(destination, "worldmods/ign_spawn/init.lua"), """
                 minetest.setting_set("static_spawnpoint", "%d, %d, %d")
                 """.formatted(metadata.getSpawn().x(), metadata.getSpawn().z(), metadata.getSpawn().y())); // XYZ => XZY
-        } catch (IOException e) {
+        } catch (Exception e) {
             throw new MapWriteException(e);
         }
     }

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/utils/SQLiteMapWriter.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/utils/SQLiteMapWriter.java
@@ -16,7 +16,7 @@ import com.ignfab.minalac.generator.world.MapWriteException;
  * which is used by Minetest to store all blocks of a world.
  * @see <a href="https://github.com/minetest/minetest/blob/master/doc/world_format.md#mapsqlite-1">Minetest's map world format</a>
  */
-public class SQLiteMapWriter {
+public class SQLiteMapWriter implements AutoCloseable {
     private final Connection connection;
     private final Serializer serializer;
 
@@ -25,13 +25,14 @@ public class SQLiteMapWriter {
      * It also creates and initializes {@code map.sqlite}.
      *
      * @param file database file to connect to (or create).
-     * @throws MapWriteException if the provided {@code File} is not a directory; doesn't exist, or if an {@link SQLException} occurs
+     * @throws MapWriteException if an {@link SQLException} occurs
      */
     public SQLiteMapWriter(File file) throws MapWriteException {
         try {
             connection = DriverManager.getConnection("jdbc:sqlite:" + file.getAbsolutePath());
-            Statement statement = connection.createStatement();
-            statement.execute("PRAGMA synchronous=OFF");
+            try (Statement statement = connection.createStatement()) {
+                statement.execute("PRAGMA synchronous=OFF");
+            }
         } catch (SQLException e) {
             throw new MapWriteException(e);
         }
@@ -44,9 +45,8 @@ public class SQLiteMapWriter {
      * Must be called once before any {@code insertBlock}.
      */
     public void createDatabase() throws MapWriteException {
-        try {
-            Statement statement = connection.createStatement();
-            statement.execute("CREATE TABLE `blocks` (`pos` INT NOT NULL PRIMARY KEY,`data` BLOB)");
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("CREATE TABLE `blocks` (`pos` INT NOT NULL PRIMARY KEY, `data` BLOB)");
         } catch (SQLException e) {
             throw new MapWriteException(e);
         }
@@ -60,13 +60,18 @@ public class SQLiteMapWriter {
      * @throws MapWriteException if an {@link SQLException} or {@link IOException} occurs during insertion
      */
     public void insertBlock(long pos, Block block) throws MapWriteException {
-        try {
-            PreparedStatement statement = connection.prepareStatement("INSERT INTO blocks VALUES (?,?)");
+        try (PreparedStatement statement = connection.prepareStatement("INSERT INTO blocks VALUES (?, ?)")) {
             statement.setLong(1, pos);
             statement.setBytes(2, this.serializer.serialize(block));
             statement.execute();
         } catch (SQLException | IOException e) {
             throw new MapWriteException("Failed to insert blocks %d into map".formatted(pos), e);
         }
+    }
+
+    @Override
+    public void close() throws Exception {
+        serializer.close();
+        connection.close();
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/utils/Serializer.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/utils/Serializer.java
@@ -7,6 +7,12 @@ import java.util.Map;
 import java.util.zip.Deflater;
 import java.util.zip.DeflaterOutputStream;
 
+import org.apache.commons.pool2.BasePooledObjectFactory;
+import org.apache.commons.pool2.ObjectPool;
+import org.apache.commons.pool2.PooledObject;
+import org.apache.commons.pool2.impl.DefaultPooledObject;
+import org.apache.commons.pool2.impl.SoftReferenceObjectPool;
+
 import com.ignfab.minalac.generator.outputs.minetest.Block;
 
 /**
@@ -14,70 +20,120 @@ import com.ignfab.minalac.generator.outputs.minetest.Block;
  * @see SQLiteMapWriter
  * @see com.ignfab.minalac.generator.outputs.minetest.MTVoxelTile#save()
  */
-public class Serializer {
+public class Serializer implements AutoCloseable {
+    // Shared pool of internal state objects to minimize memory allocations.
+    // When serializing blocks sequentially (by default), only one object
+    // will be created and reused, but parallel serialization will still
+    // be possible, by creating more objects from the pool.
+    // Soft-reference allows garbage collection of idle pool objects.
+    private final ObjectPool<InternalState> pool = new SoftReferenceObjectPool<>(new InternalStatePoolFactory());
 
-    // We use a static buffer to convert int32 and int64 to bytes.
-    // This avoids usage of DeflaterOutputStream.write(int) which performs something similar
-    // but with a byte array instantiation for each call.
-    private final byte[] buffer;
-
-    // Using a static deflater avoids many useless instantiations.
-    private final Deflater deflater;
-
-    /**
-     * Constructs a new {@code Serializer}.
-     */
-    public Serializer() {
-        buffer = new byte[8192];
-        deflater = new Deflater(Deflater.BEST_COMPRESSION);
-    }
-
-    private void write8Bits(OutputStream stream, int value) throws IOException {
-        buffer[0] = (byte) (value & 0xFF);
-        stream.write(buffer, 0, 1);
-    }
-
-    private void write16Bits(OutputStream stream, int value) throws IOException {
-        buffer[0] = (byte) ((value >> 8) & 0xFF);
-        buffer[1] = (byte) (value & 0xFF);
-        stream.write(buffer, 0, 2);
-    }
-
-    private void write32Bits(OutputStream stream, int value) throws IOException {
-        buffer[0] = (byte) ((value >> 24) & 0xFF);
-        buffer[1] = (byte) ((value >> 16) & 0xFF);
-        buffer[2] = (byte) ((value >> 8) & 0xFF);
-        buffer[3] = (byte) (value & 0xFF);
-        stream.write(buffer, 0, 4);
-    }
-
-    private void writeParam0IntoStream(OutputStream stream, Block block) throws IOException {
-        int i = 0;
-        for (short value : block.getParam0()) {
-            buffer[i++] = (byte) ((value >> 8) & 0xFF);
-            buffer[i++] = (byte) (value & 0xFF);
+    // Pool factory manages pool objects
+    private static final class InternalStatePoolFactory extends BasePooledObjectFactory<InternalState> {
+        @Override
+        public InternalState create() {
+            return new InternalState();
         }
-        stream.write(buffer);
+
+        @Override
+        public void activateObject(PooledObject<InternalState> p) {
+            p.getObject().stream.reset();
+        }
+
+        @Override
+        public void destroyObject(PooledObject<InternalState> p) {
+            p.getObject().deflater.end();
+        }
+
+        @Override
+        public PooledObject<InternalState> wrap(InternalState obj) {
+            return new DefaultPooledObject<>(obj);
+        }
     }
 
-    // See World Format Documentation for more information about block serialization
-    // https://github.com/minetest/minetest/blob/master/doc/world_format.md#node-timers
-    private void generateNameIdMapping(OutputStream stream, Block block) throws IOException {
-        // u8 name-id-mapping version
-        write8Bits(stream, 0);
+    private static final class InternalState {
+        // Reusing the same stream to avoid instantiating a new byte array each time.
+        private final ByteArrayOutputStream stream = new ByteArrayOutputStream(16384);
 
-        // u16 num_name_id_mappings
-        write16Bits(stream, block.getNameIdMapping().size());
+        // Using a single deflater avoids many useless instantiations.
+        private final Deflater deflater = new Deflater(Deflater.BEST_COMPRESSION);
 
-        for (Map.Entry<Integer, String> entry : block.getNameIdMapping().entrySet()) {
-            // u16 : id
-            write16Bits(stream, entry.getKey());
+        // We use a pre-allocated buffer to convert int32 and int64 to bytes.
+        // This avoids usage of DeflaterOutputStream#write(int) which performs
+        // something similar but with a byte array instantiation for each call.
+        private final byte[] buffer = new byte[8192];
 
-            // u16 : name_len
-            write16Bits(stream, entry.getValue().length());
+        public byte[] data() {
+            return stream.toByteArray();
+        }
 
-            // u8[name_len]
-            stream.write(entry.getValue().getBytes());
+        public void write8Bits(int value) throws IOException {
+            write8Bits(stream, value);
+        }
+
+        public void write8Bits(OutputStream stream, int value) throws IOException {
+            buffer[0] = (byte) (value & 0xFF);
+            stream.write(buffer, 0, 1);
+        }
+
+        public void write16Bits(int value) throws IOException {
+            write16Bits(stream, value);
+        }
+
+        public void write16Bits(OutputStream stream, int value) throws IOException {
+            buffer[0] = (byte) ((value >> 8) & 0xFF);
+            buffer[1] = (byte) (value & 0xFF);
+            stream.write(buffer, 0, 2);
+        }
+
+        public void write32Bits(int value) {
+            buffer[0] = (byte) ((value >> 24) & 0xFF);
+            buffer[1] = (byte) ((value >> 16) & 0xFF);
+            buffer[2] = (byte) ((value >> 8) & 0xFF);
+            buffer[3] = (byte) (value & 0xFF);
+            stream.write(buffer, 0, 4);
+        }
+
+        public void writeParam0IntoStream(OutputStream stream, Block block) throws IOException {
+            int i = 0;
+            for (short value : block.getParam0()) {
+                buffer[i++] = (byte) ((value >> 8) & 0xFF);
+                buffer[i++] = (byte) (value & 0xFF);
+            }
+            stream.write(buffer);
+        }
+
+        // See World Format Documentation for more information about block serialization
+        // https://github.com/minetest/minetest/blob/master/doc/world_format.md#node-timers
+        public void generateNameIdMapping(Block block) throws IOException {
+            // u8 name-id-mapping version
+            write8Bits(0);
+
+            // u16 num_name_id_mappings
+            write16Bits(block.getNameIdMapping().size());
+
+            for (Map.Entry<Integer, String> entry : block.getNameIdMapping().entrySet()) {
+                // u16 : id
+                write16Bits(entry.getKey());
+
+                // u16 : name_len
+                write16Bits(entry.getValue().length());
+
+                // u8[name_len]
+                stream.write(entry.getValue().getBytes());
+            }
+        }
+
+        public void compressed(CompressedWriter writer) throws IOException {
+            DeflaterOutputStream compressedStream = new DeflaterOutputStream(stream, deflater);
+            writer.write(compressedStream);
+            compressedStream.finish();
+            deflater.reset();
+        }
+
+        @FunctionalInterface
+        private interface CompressedWriter {
+            void write(DeflaterOutputStream stream) throws IOException;
         }
     }
 
@@ -87,65 +143,85 @@ public class Serializer {
      * @param block the block to serialize
      * @return a {@code byte[]} representing the serialized block
      * @throws IOException if an error occurs during serialization
-     * @see <a href="https://github.com/minetest/minetest/blob/master/doc/world_format.md#mapblock-serialization-format">Minetest world format documentation</a>
+     * @see <a href="https://github.com/luanti-org/luanti/blob/master/doc/world_format.md#mapblock-serialization-format">Minetest world format documentation</a>
      */
     public byte[] serialize(Block block) throws IOException {
-        ByteArrayOutputStream stream = new ByteArrayOutputStream(16384);
+        InternalState state;
+        try {
+            state = pool.borrowObject();
+        } catch (Exception e) {
+            throw new IOException("Unable to get an internal state from the pool", e);
+        }
 
-        // u8 : map version number
-        write8Bits(stream, 28);
+        try {
+            // u8 : map version number
+            state.write8Bits(28);
 
-        // u8 : flags
-        write8Bits(stream, 0);
+            // u8 : flags
+            state.write8Bits(0);
 
-        // u16 : lighting_complete
-        write16Bits(stream, 0);
+            // u16 : lighting_complete
+            state.write16Bits(0);
 
-        // u8 : content_width
-        write8Bits(stream, 2);
+            // u8 : content_width
+            state.write8Bits(2);
 
-        // u8 : params_width
-        write8Bits(stream, 2);
+            // u8 : params_width
+            state.write8Bits(2);
 
-        // Zlib Node data
-        DeflaterOutputStream nodeDataStream = new DeflaterOutputStream(stream, deflater);
+            // Zlib Node data
+            state.compressed(stream -> {
+                state.writeParam0IntoStream(stream, block);
+                stream.write(block.getParam1());
+                stream.write(block.getParam2());
+            });
 
-        writeParam0IntoStream(nodeDataStream, block);
-        nodeDataStream.write(block.getParam1());
-        nodeDataStream.write(block.getParam2());
+            // Zlib Node metadata
+            state.compressed(stream -> {
+                // u8 : version
+                state.write8Bits(stream, 2);
+                // u16 : count of metadata
+                state.write16Bits(stream, 0);
+            });
 
-        nodeDataStream.flush();
-        nodeDataStream.finish();
-        deflater.reset();
+            // u8 : static object version
+            state.write8Bits(0);
 
-        // Zlib Node metadata
-        DeflaterOutputStream nodeMetadataStream = new DeflaterOutputStream(stream, deflater);
+            // u16 : static object count
+            state.write16Bits(0);
 
-        // u8 : version
-        write16Bits(nodeMetadataStream, 2);
-        write16Bits(nodeMetadataStream, 0);
-        nodeMetadataStream.flush();
-        nodeMetadataStream.finish();
-        deflater.reset();
+            // u32 : timestamp
+            state.write32Bits(0);
 
-        // u8 : static object version
-        write8Bits(stream, 0);
+            // name id mapping
+            state.generateNameIdMapping(block);
 
-        // u16 : static object count
-        write16Bits(stream, 0);
+            // u8 : length of the data of a single time
+            state.write8Bits(10);
 
-        // u32 : timestamp
-        write32Bits(stream, 0);
+            // u16 : num_of_timers
+            state.write16Bits(0);
+        } catch (IOException e) {
+            try {
+                pool.invalidateObject(state);
+            } catch (Exception suppressed) {
+                e.addSuppressed(suppressed);
+            }
+            throw e;
+        }
 
-        // name id mapping
-        generateNameIdMapping(stream, block);
+        byte[] data = state.data();
 
-        // u8 : length of the data of a single time
-        write8Bits(stream, 10);
+        try {
+            pool.returnObject(state);
+        } catch (Exception e) {
+            throw new IOException("Unable to return the internal state to the pool", e);
+        }
+        return data;
+    }
 
-        // u16 : num_of_timers
-        write16Bits(stream, 0);
-
-        return stream.toByteArray();
+    @Override
+    public void close() {
+        pool.close();
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/placeables/PlaceableStructure.java
+++ b/src/main/java/com/ignfab/minalac/generator/placeables/PlaceableStructure.java
@@ -20,7 +20,10 @@ public class PlaceableStructure implements Placeable {
      */
     @Override
     public void place(VoxelTile tile, int x, int y, int z) {
-        placeables.forEach((c, placeable) -> placeable.place(tile, c.x() + x, c.y() + y, c.z() + z));
+        for (Map.Entry<WorldCoords3d, Placeable> entry : placeables.entrySet()) {
+            WorldCoords3d c = entry.getKey();
+            entry.getValue().place(tile, c.x() + x, c.y() + y, c.z() + z);
+        }
     }
 
     /**


### PR DESCRIPTION
### Type of modification

- Code
  - Outputs

### Changes

Reduces the amount of memory allocations in Minetest and Minecraft format by using type-specific collections and reusing / sharing already allocated memory.

#### Feature description

The Minetest voxel tile was using a `Map<Long, Block>` to store map-blocks internally before serializing and saving them. The first commit replaces this map by a type-specific `Long2ObjectMap` from fastutil-core. This results in a reduction of both real allocated memory (because this implementation stores primitive long values, instead of boxed values each containing a primitive long), and the amount of memory allocation requests (because we don't need to allocate a new `Long` to box the primitive value each time we need to query the map.

A similar case can be found for the Minecraft format, so a similar mitigation has been applied (it was however far less of an issue since it only concerned 512x512 regions).

The Minetest map-blocks serializer was creating a new byte array output stream of 16 KiB for every map-block serialized. For reference, a 5000x5000 generation involves serializing nearly 300 000 map-blocks, resulting in 4.58 GiB of memory allocation requests. By moving this output stream and refactoring some code into an internal state object, we can effectively reuse it for each map-block. The downside of having a single shared internal state would be to prevent parallel serialization. Thankfully, using a correctly configured pool of such internal state objects, we can have a single instance reused every time when operating sequentially, and being able to create more when needing to work in parallel (resulting in more memory being consumed, the same way as it is today). Furthermore, the pool uses soft-references, to allow the garbage collector to remove unused objects if memory runs low.

For this second optimization to work, it was required to keep the same `SQLiteMapWriter` amongst every tiles, which required a some minor refactoring of code in Minetest voxel world and tile as well.

The Minecraft voxel was creating the same block data object over and over again each time it was placed. The stupidly easy optimisation was to reuse the same data instead. This obviously reduced the amount of memory allocations by A LOT (saving more than 100 GB).

There is no noticeable impact on generation time. However, there is a 6.8 MB increase in JAR size (51.4 MB -> 58.2 MB), caused by the additional two dependencies.

#### Technical changes

Added [fastutil-core](https://github.com/vigna/fastutil), providing many type-specific alternative to standard Java collections using primitive elements when possible.

Added [Apache Commons Pool (v2)](https://commons.apache.org/proper/commons-pool/), providing pool implementation supporting memory related features such as soft-reference pools, and more.

### Reason

Memory allocation is critical in our context, and every large amount of allocation easily avoidable is generally worth it. Using a type-specific collection is easy to do, and reusing the same allocated buffers / data is a large gain.

The JAR size increase is negligible, especially in comparison with GeoTools' dependencies size.

### Self-checks

- ~~The code has unit tests associated~~
- [x] The code has Javadoc Comments associated
- [x] Complex / Unexpected code is explained / justified with a small comment
- ~~Relevant documentation inside the `/docs` folder has been updated~~
- ~~All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)~~
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [x] The texts have been proofread (documentation, error messages, logs, comments...)
