### PR TITLE
Upgrade Jackson to version 2.20 and get rid of SnakeYAML

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,6 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <geotools.version>31.0</geotools.version>
-        <jackson.version>2.17.2</jackson.version>
     </properties>
 
     <repositories>
@@ -116,29 +115,23 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
+            <version>2.20.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-        <!-- SnakeYAML (Yaml processing) -->
-        <dependency>
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-            <version>2.3</version>
+            <version>2.20.0</version>
         </dependency>
         <!-- Transitive dependencies for databind (If missing they might have a NoSuchMethodError)-->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${jackson.version}</version>
+            <version>2.20</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>${jackson.version}</version>
+            <version>2.20.0</version>
         </dependency>
         <!-- Apache command line argument parsing -->
         <dependency>

--- a/src/main/java/com/ignfab/minalac/generator/parameters/ParamsParser.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/ParamsParser.java
@@ -1,21 +1,16 @@
 package com.ignfab.minalac.generator.parameters;
 
-import java.util.Map;
-
+import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
 import com.fasterxml.jackson.databind.jsontype.NamedType;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import org.yaml.snakeyaml.DumperOptions;
-import org.yaml.snakeyaml.LoaderOptions;
-import org.yaml.snakeyaml.Yaml;
-import org.yaml.snakeyaml.composer.ComposerException;
-import org.yaml.snakeyaml.constructor.DuplicateKeyException;
+import com.fasterxml.jackson.dataformat.yaml.YAMLAnchorReplayingFactory;
 
 /**
  * A Json/Yaml parser able to decode parameters into a {@code Generation} object.
@@ -28,7 +23,7 @@ public class ParamsParser {
      * Creates a new Parser.
      */
     public ParamsParser() {
-        mapper = new ObjectMapper(new YAMLFactory());
+        mapper = new ObjectMapper(new YAMLAnchorReplayingFactory());
         mapper.configure(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES, true);
         // To prevent duplicates in map type parameters.
         mapper.enable(JsonParser.Feature.STRICT_DUPLICATE_DETECTION);
@@ -46,41 +41,31 @@ public class ParamsParser {
         GenerationParams params;
         SimpleModule module;
 
-        // Resolve Yaml anchors and pick up format
-        // (Jackson is not able to do it by itself but it is still very good at deserializing)
-
-        LoaderOptions loaderOptions = new LoaderOptions();
-        loaderOptions.setAllowDuplicateKeys(false);
-
-        DumperOptions dumperOptions = new DumperOptions();
-        dumperOptions.setDereferenceAliases(true); // Prevents new anchor generation on dumping
-
-        Yaml yaml = new Yaml(loaderOptions, dumperOptions);
-
-        Map<Object, Object> document;
-        try {
-            document = yaml.load(serialized);
-        } catch (DuplicateKeyException | ComposerException e) {
-            throw new ParseException(e);
-        }
-
         // Custom deserializers
         module = new SimpleModule("MinalacParserModule");
         module.addDeserializer(OutputFormat.class, formatDeserializer);
         module.setDeserializerModifier(new JsonDelegateDeserialize.BeanModifier());
         mapper.registerModule(module);
 
-        if (!document.containsKey("format"))
+        JsonNode document;
+        try {
+            document = mapper.readTree(serialized);
+        } catch (JsonParseException e) {
+            throw new ParseException(e);
+        }
+
+        if (!document.has("format"))
             throw new ParseException("Missing format field!");
 
-        OutputFormat format = mapper.readValue(yaml.dump(document.get("format")), OutputFormat.class);
+        // Deserialize output format only
+        OutputFormat format = mapper.readValue(document.get("format").asText(), OutputFormat.class);
 
         // Register format specific deserializer
         format.registerPlaceableDeserializer(mapper);
 
         // Deserialize the whole parameter object
         try {
-            params = mapper.readValue(yaml.dump(document), GenerationParams.class);
+            params = mapper.treeToValue(document, GenerationParams.class);
         } catch (MismatchedInputException | ValueInstantiationException e) {
             throw new ParseException(e);
         }

--- a/src/main/java/com/ignfab/minalac/generator/parameters/models/filters/ModelFilterParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/models/filters/ModelFilterParams.java
@@ -19,7 +19,8 @@ import com.ignfab.minalac.generator.models.Model;
     @JsonSubTypes.Type(ModelFilterMetadataInParams.class),
     @JsonSubTypes.Type(ModelFilterHasMetadataParams.class),
     @JsonSubTypes.Type(ModelFilterMetadataLowerThanParams.class),
-    @JsonSubTypes.Type(ModelFilterMetadataGreaterThanParams.class)
+    @JsonSubTypes.Type(ModelFilterMetadataGreaterThanParams.class),
+    @JsonSubTypes.Type(ModelFilterEmptyGeometryParams.class)
 })
 public abstract class ModelFilterParams {
     /**


### PR DESCRIPTION
### Changes

Upgrade Jackson to version 2.20 which includes the ability to process Yaml anchors and references and remove SnakeYaml that became useless.

### Reason

Avoids an extra parsing, simplifies the code and may make it possible to retrieve original Yaml file line number.

### Self-checks

- ~~The code has unit tests associated~~
- ~~The code has Javadoc Comments associated~~
- ~~Complex / Unexpected code is explained / justified with a small comment~~
- ~~Relevant documentation inside the `/docs` folder has been updated~~
- [x] All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- ~~The texts have been proofread (documentation, error messages, logs, comments...)~~
