### PR TITLE
Support HStore format used by OSM

### DIFF
--- a/docs/usage/parameters/PostProcessing.md
+++ b/docs/usage/parameters/PostProcessing.md
@@ -15,6 +15,7 @@ Each post-processor has a field `type` which is used to identify it.
   * [Metadata parse](#metadata-parse)
   * [Metadata remap](#metadata-remap)
   * [Metadata truncate](#metadata-truncate)
+  * [Metadata explode](#metadata-explode)
 * [Geometry post-processors](#geometry-post-processors)
   * [Geometry buffer](#geometry-buffer)
 
@@ -223,6 +224,16 @@ Avaliable policies:
 | `removeMetadata` | The metadata is removed (no effect for `ifMissing`). |
 | `ignore`         | Metadata is not modified.                            |
 | `error`          | An error occurs, and the generation stops.           |
+
+### Metadata explode
+
+A post-processor exploding a nested metadata map into flat values.
+
+**Type**: `explode`
+
+**Extra parameters**:
+- `metadata` (required, `text`): Name of the metadata to explode. The metadata must be a map (can be the result of parsing an `hstore`).
+- `prefix` (optional, `text`, default none): Optional prefix to prepend to exploded metadata names.
 
 ## Geometry post-processors
 

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,11 @@
             <artifactId>gt-geotiff</artifactId>
             <version>${geotools.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.geotools.jdbc</groupId>
+            <artifactId>gt-jdbc-postgis</artifactId>
+            <version>${geotools.version}</version>
+        </dependency>
         <!--
             Required to identify coordinates reference systems
             Example error: No code "EPSG:4326" from authority "EPSG"

--- a/src/main/java/com/ignfab/minalac/generator/MinalacGenerator.java
+++ b/src/main/java/com/ignfab/minalac/generator/MinalacGenerator.java
@@ -28,6 +28,7 @@ import com.ignfab.minalac.generator.parameters.processors.post.IdentityPostProce
 import com.ignfab.minalac.generator.parameters.processors.post.JTSGeometryBufferPostProcessorParams;
 import com.ignfab.minalac.generator.parameters.processors.post.MetadataCopyPostProcessorParams;
 import com.ignfab.minalac.generator.parameters.processors.post.MetadataDefaultPostProcessorParams;
+import com.ignfab.minalac.generator.parameters.processors.post.MetadataExplodePostProcessorParams;
 import com.ignfab.minalac.generator.parameters.processors.post.MetadataParsePostProcessorParams;
 import com.ignfab.minalac.generator.parameters.processors.post.MetadataTruncatePostProcessorParams;
 import com.ignfab.minalac.generator.parameters.processors.post.MetadataValueMappingPostProcessorParams;
@@ -123,6 +124,7 @@ public final class MinalacGenerator {
         parser.registerParams("truncate", MetadataTruncatePostProcessorParams.class);
         parser.registerParams("geometryBuffer", JTSGeometryBufferPostProcessorParams.class);
         parser.registerParams("remap", MetadataValueMappingPostProcessorParams.class);
+        parser.registerParams("explode", MetadataExplodePostProcessorParams.class);
 
         HStoreValueParser.INSTANCE.register("hstore");
 

--- a/src/main/java/com/ignfab/minalac/generator/MinalacGenerator.java
+++ b/src/main/java/com/ignfab/minalac/generator/MinalacGenerator.java
@@ -46,6 +46,7 @@ import com.ignfab.minalac.generator.parameters.tasks.RenderHeightmapTaskParams;
 import com.ignfab.minalac.generator.parameters.tasks.RenderLinesTaskParams;
 import com.ignfab.minalac.generator.parameters.tasks.RenderSurfacesTaskParams;
 import com.ignfab.minalac.generator.parameters.tasks.SetSpawnTaskParams;
+import com.ignfab.minalac.generator.utils.HStoreValueParser;
 import com.ignfab.minalac.generator.utils.execution.TaskFailedException;
 import com.ignfab.minalac.generator.utils.network.HttpTrustAllSSL;
 import com.ignfab.minalac.generator.world.MapWriteException;
@@ -122,6 +123,8 @@ public final class MinalacGenerator {
         parser.registerParams("truncate", MetadataTruncatePostProcessorParams.class);
         parser.registerParams("geometryBuffer", JTSGeometryBufferPostProcessorParams.class);
         parser.registerParams("remap", MetadataValueMappingPostProcessorParams.class);
+
+        HStoreValueParser.INSTANCE.register("hstore");
 
         Generation generation = parser.parse(cli.readParameters()).create(maxTileSize);
 

--- a/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataExplodePostProcessorParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataExplodePostProcessorParams.java
@@ -1,0 +1,48 @@
+package com.ignfab.minalac.generator.parameters.processors.post;
+
+import java.beans.ConstructorProperties;
+
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+
+import com.ignfab.minalac.generator.models.Model;
+import com.ignfab.minalac.generator.processors.post.MetadataExplodePostProcessor;
+import com.ignfab.minalac.generator.processors.post.PostProcessor;
+
+/**
+ * Parameters for {@link MetadataExplodePostProcessor}.
+ */
+public class MetadataExplodePostProcessorParams extends PostProcessorParams {
+    /**
+     * Name of the metadata to explode (required).
+     */
+    @JsonSetter(nulls = Nulls.FAIL)
+    public String metadata;
+
+    /**
+     * Optional prefix to prepend to exploded metadata names (optional, default none).
+     */
+    @JsonSetter(nulls = Nulls.AS_EMPTY)
+    public String prefix;
+
+    /**
+     * Constructor used to ensure that the required fields are present during deserialization.
+     *
+     * @param metadata name of the metadata to explode
+     */
+    @ConstructorProperties("metadata")
+    public MetadataExplodePostProcessorParams(String metadata) {
+        this.metadata = metadata;
+    }
+
+    @Override
+    public void validate() throws IllegalArgumentException {
+        if (metadata.isBlank())
+            throw new IllegalArgumentException("The 'metadata' field cannot be empty or contain only whitespace.");
+    }
+
+    @Override
+    public PostProcessor<Model, ?> create() {
+        return new MetadataExplodePostProcessor(metadata, prefix);
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/processors/post/MetadataExplodePostProcessor.java
+++ b/src/main/java/com/ignfab/minalac/generator/processors/post/MetadataExplodePostProcessor.java
@@ -1,0 +1,33 @@
+package com.ignfab.minalac.generator.processors.post;
+
+import java.util.Map;
+
+import com.ignfab.minalac.generator.models.Model;
+
+/**
+ * Post-processor exploding a nested metadata map into flat values.
+ * <p>
+ * The same model object is returned after post-processing.
+ */
+public class MetadataExplodePostProcessor extends PostProcessor.Generic {
+    private final String metadata;
+    private final String prefix;
+
+    /**
+     * Creates a new post-processor exploding {@code metadata}.
+     * @param metadata the name of the metadata to explode
+     * @param prefix optional prefix to prepend to exploded metadata names, empty if no prefix wanted
+     */
+    public MetadataExplodePostProcessor(String metadata, String prefix) {
+        this.metadata = metadata;
+        this.prefix = prefix;
+    }
+
+    @Override
+    public Model process(Model model) {
+        // TODO add a failure policy?
+        if (model.getMetadata(metadata) instanceof Map<?, ?> map)
+            map.forEach((key, value) -> model.setMetadata(prefix + key, value));
+        return model;
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/utils/HStoreValueParser.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/HStoreValueParser.java
@@ -1,0 +1,29 @@
+package com.ignfab.minalac.generator.utils;
+
+import java.util.function.Function;
+
+import org.geotools.data.postgis.HStore;
+import org.postgresql.util.HStoreConverter;
+
+import com.ignfab.minalac.generator.parameters.ValueParser;
+
+/**
+ * {@link ValueParser} for HStore formatted string.
+ * @see <a href="https://www.postgresql.org/docs/current/hstore.html">HStore format</a>
+ */
+public final class HStoreValueParser implements Function<Object, HStore> {
+    /**
+     * Simple instance ready to be registered.
+     */
+    public static final ValueParser<HStore> INSTANCE = new ValueParser<>(HStore.class, new HStoreValueParser());
+
+    /**
+     * @see #INSTANCE
+     */
+    private HStoreValueParser() {}
+
+    @Override
+    public HStore apply(Object obj) {
+        return new HStore(HStoreConverter.fromString(obj.toString()));
+    }
+}


### PR DESCRIPTION
Ajout d'un `ValueParser` pour le format [HStore](https://www.postgresql.org/docs/current/hstore.html) (utilisé par OSM dans l'attribut `other_tags`, qui contient la majeure partie des informations). Utilisable comme type cible dans le post-processeur `parse` :

```yaml
type: parse
metadata: other_tags
as: hstore
```

Ajout d'un `PostProcessor` pour exploser une `Map` dans une métadonnée en valeurs individuelles. Notamment utile puisque `HStore` est une `Map<String, String>` :

```yaml
type: explode
metadata: other_tags
```

# TODO avant de merger dans main
- Reprendre la discussion sur l'éclatement ou un operateur `get` qui le rendrait inutile et statuer