### PR TITLE
Include CityJson renderer

### DIFF
--- a/docs/usage/parameters/FetchDataTask.md
+++ b/docs/usage/parameters/FetchDataTask.md
@@ -14,11 +14,17 @@ Task of type `fetchData` fetches data from geographic data source, processes it,
   * [`geotiff` (GeoTiff)](#geotiff-geotiff)
   * [`las` (Point cloud from LAS/LAZ file)](#las-point-cloud-from-laslaz-file)
   * [`lasTiled` (Point clouds from multiple tiled LAS/LAZ files)](#lastiled-point-clouds-from-multiple-tiled-laslaz-files)
+  * [`cityjson` (CityJSON)](#cityjson-cityjson)
 * [Processors](#processors)
   * [`geoToolsVector` (GeoTools vector processor)](#geotoolsvector-geotools-vector-processor)
   * [`floatMatrix` (Float matrix processor)](#floatmatrix-float-matrix-processor)
   * [`lasPoints` (Individual LAS points processor)](#laspoints-individual-las-points-processor)
   * [`lasMerged` (Merged LAS points processor)](#lasmerged-merged-las-points-processor)
+  * [`cityjson` (CityJSON)](#cityjson-cityjson)
+* [Processors](#processors)
+  * [`geoToolsVector` (GeoTools vector processor)](#geotoolsvector-geotools-vector-processor)
+  * [`floatMatrix` (Float matrix processor)](#floatmatrix-float-matrix-processor)
+  * [`cityjsonBuilding` (CityJSON building processor)](#cityjsonbuilding-cityjson-building-processor)
 
 See also [post-processing](PostProcessing.md) documentation.
 
@@ -129,6 +135,16 @@ A provider capable of reading points from multiple tiled [LAS/LAZ](https://en.wi
 
 **Suitable processors**: `lasPoints`, `lasMerged`
 
+### `cityjson` (CityJSON)
+
+A provider capable of reading JSON-encoded data from a [CityGML](https://en.wikipedia.org/wiki/CityGML) file.
+
+**Extra parameters**:
+- `filePath` (required): Path of the CityJSON file (absolute, or relative to execution context)
+- `overrideCrs` (optional, default none): Cordinate Reference System to use when reading data. By default, the CRS is read from the file itself. You should only use this parameter if the CRS is invalid or missing from the file. This **DOES NOT** reproject data!
+
+**Suitable processors**: `cityjsonBuilding`
+
 ## Processors
 
 A processor converts data from a provider into models. Processor type is identified by `type` field.
@@ -162,3 +178,12 @@ Processor merging LAS points into a small number of models (at least one per cla
 **Extra parameters**: None
 
 **Suitable providers**: `las`, `lasTiled`
+
+### `cityjsonBuilding` (CityJSON building processor)
+
+Processor converting city object into a city building model. Other types of city objects are dropped.
+
+**Extra parameters**: None
+
+**Suitable providers**: `cityjson`
+

--- a/examples/formats/minecraft.yaml
+++ b/examples/formats/minecraft.yaml
@@ -11,6 +11,8 @@ references:
   - &road-paint minecraft:white_concrete
   - &road-tar minecraft:black_concrete
   - &path minecraft:dirt_path
+  - &default-roof minecraft:stone
+  - &default-wall minecraft:stone
   - &forest-grass minecraft:fern
   - &forest-tree1
     structure:

--- a/examples/formats/minetest.yaml
+++ b/examples/formats/minetest.yaml
@@ -11,6 +11,8 @@ references:
   - &road-paint wool:white
   - &road-tar wool:black
   - &path default:dirt_with_coniferous_litter
+  - &default-wall default:sandstonebrick
+  - &default-roof default:stone_block
   - &forest-grass default:junglegrass
   - &forest-tree1
     structure:

--- a/examples/places/fds.yaml
+++ b/examples/places/fds.yaml
@@ -1,0 +1,10 @@
+# Highway jam at Porte de Bagnolet
+verticalScale: 1.0
+horizontalScale: 1.0
+area:
+  center:
+    latitude: 48.8659
+    longitude: 2.35531
+  extentX: 1000
+  extentY: 1000
+  angle: -21

--- a/examples/processes/fds.yaml
+++ b/examples/processes/fds.yaml
@@ -1,0 +1,407 @@
+heightmaps:
+  ground:
+    default: 0
+  water:
+    default: 0
+
+forEachTile:
+
+  fetchAltitude:
+    type: fetchData
+    modelType: altitude
+    provider:
+      type: wmsFloat
+      url: https://data.geopf.fr/wms-r/wms
+      layer: RGEALTI-MNT_PYR-ZIP_FXX_LAMB93_WMS
+    processor:
+      type: floatMatrix
+
+  fetchBuildings:
+    type: fetchData
+    modelType: buildings
+    provider:
+      type: wfs
+      url: https://data.geopf.fr/wfs/wfs
+      features: BDTOPO_V3:batiment
+      maxFeaturesPerQuery: 500
+    processor:
+      type: geoToolsVector
+    postProcessing:
+      - type: copy
+        metadata: hauteur
+        to: height
+      - type: parse
+        metadata: height
+        as: decimal
+        ifMissing: ignore
+        ifNotParsable: removeMetadata
+      - type: truncate
+        metadata: height
+        method: round
+        ifMissing: ignore
+      - type: default
+        metadata: height
+        value: 5
+        as: integer
+
+  fetchVegetation:
+    type: fetchData
+    modelType: vegetation
+    provider:
+      type: wfs
+      url: https://data.geopf.fr/wfs/wfs
+      features: BDTOPO_V3:zone_de_vegetation
+    processor:
+      type: geoToolsVector
+
+  fetchWater:
+    type: fetchData
+    modelType: water
+    provider:
+      type: wfs
+      url: https://data.geopf.fr/wfs/wfs
+      features: BDTOPO_V3:surface_hydrographique
+    processor:
+      type: geoToolsVector
+
+  fetchRoads:
+    type: fetchData
+    modelType: road
+    provider:
+      type: wfs
+      url: https://data.geopf.fr/wfs/wfs
+      features: BDTOPO_V3:troncon_de_route
+    processor:
+      type: geoToolsVector
+
+  setAltitude:
+    after: fetchAltitude
+    type: populateHeightmap
+    models:
+      type: altitude
+    heightmap: ground
+
+  setSpawn:
+    after: setAltitude
+    type: setSpawn
+    heightmap:
+      sum: [ground, 1]
+    x: 0
+    y: 0
+
+  flattenWater:
+    after:
+      - fetchWater
+      - setAltitude
+    type: copyHeightmap
+    models:
+      type: water
+    from:
+      localMin: ground
+      range: 9
+    to: ground
+
+  renderGround:
+    after:
+      - setAltitude
+      - flattenWater
+    type: renderHeightmap
+    at: ground
+    place:
+      structure:
+        - put: *voxel-grass
+          at: [0, 0, 0]
+        - put: *voxel-dirt
+          at: [0, 0, -3..-1]
+        - put: *voxel-stone
+          at: [0, 0, -20..-4]
+
+  computeBuildingsAltitude:
+    after:
+      - fetchBuildings
+      - renderGround
+    type: computeHeightmapStats
+    models:
+      type: buildings
+    heightmap: ground
+    compute:
+      minimum: minimum-ground-altitude
+      maximum: ground-floor-altitude
+
+  flattenGroundBuildings:
+    after:
+      - computeBuildingsAltitude
+    type: fillBetweenHeightmapAndValue
+    models:
+      type: buildings
+    heightmap: ground
+    altitudeValue: ground-floor-altitude
+    placeAbove: *voxel-empty
+    placeBelow: *voxel-building-ground
+
+  renderBuildings:
+    after: flattenGroundBuildings
+    type: renderBuildings
+    models:
+      type: buildings-disabled
+      filter:
+        metadata: height
+        greaterThan: 0
+    roof: *voxel-cobble
+    wall: *voxel-stone
+    window: *voxel-glass
+
+  renderForest:
+    after:
+      - renderGround
+      - fetchVegetation
+    type: renderSurfaces
+    models:
+      type: vegetation-disabled
+      filter:
+        metadata: nature
+        in:
+          - "Bois"
+          - "Forêt fermée de conifères"
+          - "Forêt fermée de feuillus"
+          - "Forêt fermée mixte"
+          - "Forêt ouverte"
+          - "Zone arborée"
+    heightmap: ground
+    place:
+      - pattern:
+          seed: forest-grass
+          chance: 0.1
+          place:
+            structure:
+              - at: [0, 0, 1]
+                put: *forest-grass
+      - *voxel-forest-ground
+      - pattern:
+          seed: forest-tree1
+          chance: 0.01
+          place: *forest-tree1
+      - pattern:
+          seed: tree2
+          chance: 0.003
+          place: *forest-tree2
+
+  populateWaterPresence:
+    after: fetchWater
+    type: copyHeightmap
+    models:
+      type: water
+    from: 1
+    to: water
+
+  computeWaterDepth:
+    after: populateWaterPresence
+    type: copyHeightmap
+    models:
+      type: water
+    from:
+      remap:
+        manhattan: water
+        maximumDistance: 12
+        targetValue: 0
+      mapping:
+        0: 0
+        1: 1
+        2: 8
+        3..3: 10
+        4..6: 11
+        7..12: 12
+    to: water
+
+  renderWater:
+    after:
+      - renderGround
+      - computeWaterDepth
+      # Vegetation and water vector data overlap in certain areas. (Because of vegetation representing canopy)
+      # The dependency and air voxel below should be removed when cropping is implemented on vector data.
+      - renderForest
+    type: renderHeightmap
+    minimum:
+      sum:
+        - ground
+        - 1
+        - product: [ -1, water ]
+    maximum: ground
+    place:
+      structure:
+        - put: *voxel-water
+          at: [ 0, 0, 0 ]
+        # This a dirt fix to remove vegetation on water
+        - put: *voxel-air
+          at: [ 0, 0, 1..12 ]
+
+  path:
+    after:
+      - fetchRoads
+      - renderGround
+      - renderForest
+    type: renderLines
+    models:
+      type: road
+      filter:
+        metadata: nature
+        in: [ "Chemin", "Sentier", "Roue empierrée" ]
+    structure:
+      - put: *path
+        at: [ 0, -1..1, 0]
+      - put: *voxel-air
+        at: [ 0, -1..1, 1..2 ]
+
+  renderBridges:
+    after: path
+    type: renderLines
+    models:
+      type: road
+      filter:
+        metadata: nature
+        in: [ "Bretelle", "Rond-point", "Route à 1 chaussée", "Route à 2 chaussées", "Type autoroutier"]
+    renderOnlyWhenAbove:
+      sum:
+        - ground
+        - 1
+    structure:
+      # Half bridge structure (sectional view)
+      axes: [ z, y ]
+      blueprint:
+        - "     ▒▒"
+        - "▒▒▒▒▒▒▒"
+      with:
+        "▒": *voxel-stone
+      zOffset: -1
+
+  renderRoadsPass1:
+    after: renderBridges
+    type: renderLines
+    models:
+      type: road
+      filter:
+        metadata: nature
+        in: [ "Bretelle", "Rond-point", "Route à 1 chaussée", "Route à 2 chaussées", "Type autoroutier"]
+    structure:
+      # Road border lines and air to clean eventual voxels (sectional view)
+      axes: [ z, y ]
+      blueprint:
+        - "·····"
+        - "·····"
+        - "····█"
+      with:
+        "█": *road-paint
+        "·": *voxel-air
+
+  renderRoadsPass2:
+    after: renderRoadsPass1
+    type: renderLines
+    models:
+      type: road
+      filter:
+        metadata: nature
+        in: [ "Bretelle", "Rond-point", "Route à 1 chaussée", "Route à 2 chaussées", "Type autoroutier"]
+    structure:
+      # Road central line and tar (view from above)
+      axes: [ x, y ]
+      blueprint:
+        - "█░░░"
+        - "█░░░"
+        - "█░░░"
+        - "░░░░"
+        - "░░░░"
+      with:
+        "█": *road-paint
+        "░": *road-tar
+
+  fetchBatiCity:
+    type: fetchData
+    modelType: building-city
+    provider:
+      type: cityjson
+      filePath: data/bati.city.json
+    processor:
+      type: cityjsonBuilding
+
+  renderBati3dGround:
+    after:
+      - fetchBatiCity
+      - renderGround
+    type: renderBuildings3d
+    models:
+      type: building-city
+    surfaceType: ground
+    place: *voxel-cobble
+
+  renderBati3dWalls:
+    after:
+      - renderBati3dGround
+    type: renderBuildings3d
+    models:
+      type: building-city
+    surfaceType: wall
+    place: *default-wall
+
+  renderBati3dRoofs:
+    after:
+      - renderBati3dWalls
+    type: renderBuildings3d
+    models:
+      type: building-city
+    surfaceType: roof
+    place: *default-roof
+
+  fetchTrees:
+    type: fetchData
+    modelType: trees
+    provider:
+      type: gpkg
+      filePath: data/osm_extract.gpkg
+      typeName: trees
+    processor:
+      type: geoToolsVector
+
+  fetchLidar:
+    type: fetchData
+    modelType: lidarhd
+    provider:
+      type: lasTiled
+      tilesPath: data/lidar
+      tilesFilenameTemplate: LHD_FXX_%04d_%04d_PTS_O_LAMB93_IGN69.copc.laz
+      tileSize: 1000
+      tileOffsetY: 1000
+    processor:
+      type: lasMerged
+
+  renderVegetation:
+    after: fetchLidar
+    type: renderVoxels
+    models:
+      type: lidarhd
+      filter:
+        metadata: classification
+        in: [ 3, 4, 5 ]
+        as: integer
+    place: default:leaves
+
+  findHighestLeaves:
+    after:
+      - fetchTrees
+      - renderVegetation
+    type: findVoxels
+    models:
+      type: trees
+    only: default:leaves
+    find:
+      highest: highest-leaves
+
+  renderTrunks:
+    after: findHighestLeaves
+    type: fillBetweenHeightmapAndValue
+    models:
+      type: trees
+    heightmap: ground
+    altitudeValue:
+      sum: [highest-leaves, -1]
+    placeBelow: default:tree
+

--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,12 @@
             <artifactId>laszip4j</artifactId>
             <version>0.21</version>
         </dependency>
+        <!-- CityGML data manipulation (with CityJSON format support) -->
+        <dependency>
+            <groupId>org.citygml4j</groupId>
+            <artifactId>citygml4j-cityjson</artifactId>
+            <version>3.2.5</version>
+        </dependency>
 
         <!--
         TEST DEPENDENCIES

--- a/src/main/java/com/ignfab/minalac/generator/MinalacGenerator.java
+++ b/src/main/java/com/ignfab/minalac/generator/MinalacGenerator.java
@@ -20,6 +20,7 @@ import com.ignfab.minalac.generator.parameters.ParamsParser;
 import com.ignfab.minalac.generator.parameters.ParseException;
 import com.ignfab.minalac.generator.parameters.placeables.voxels.MCVoxelParams;
 import com.ignfab.minalac.generator.parameters.placeables.voxels.MTVoxelParams;
+import com.ignfab.minalac.generator.parameters.processors.CityJSONBuildingProcessorParams;
 import com.ignfab.minalac.generator.parameters.processors.FloatMatrixProcessorParams;
 import com.ignfab.minalac.generator.parameters.processors.GeoToolsVectorProcessorParams;
 import com.ignfab.minalac.generator.parameters.processors.LASPointMergedModelProcessorParams;
@@ -34,6 +35,7 @@ import com.ignfab.minalac.generator.parameters.processors.post.MetadataExplodePo
 import com.ignfab.minalac.generator.parameters.processors.post.MetadataParsePostProcessorParams;
 import com.ignfab.minalac.generator.parameters.processors.post.MetadataTruncatePostProcessorParams;
 import com.ignfab.minalac.generator.parameters.processors.post.MetadataValueMappingPostProcessorParams;
+import com.ignfab.minalac.generator.parameters.providers.CityJSONProviderParams;
 import com.ignfab.minalac.generator.parameters.providers.GeoPackageProviderParams;
 import com.ignfab.minalac.generator.parameters.providers.GeoTiffProviderParams;
 import com.ignfab.minalac.generator.parameters.providers.LASProviderParams;
@@ -47,6 +49,7 @@ import com.ignfab.minalac.generator.parameters.tasks.FillBetweenHeightmapAndValu
 import com.ignfab.minalac.generator.parameters.tasks.FindVoxelsTaskParams;
 import com.ignfab.minalac.generator.parameters.tasks.HeightmapStatsTaskParams;
 import com.ignfab.minalac.generator.parameters.tasks.PopulateHeightmapTaskParams;
+import com.ignfab.minalac.generator.parameters.tasks.RenderBuildings3dTaskParams;
 import com.ignfab.minalac.generator.parameters.tasks.RenderBuildingsTaskParams;
 import com.ignfab.minalac.generator.parameters.tasks.RenderHeightmapTaskParams;
 import com.ignfab.minalac.generator.parameters.tasks.RenderLinesTaskParams;
@@ -113,6 +116,7 @@ public final class MinalacGenerator {
         parser.registerParams("setSpawn", SetSpawnTaskParams.class);
         parser.registerParams("renderVoxels", RenderVoxelsTaskParams.class);
         parser.registerParams("findVoxels", FindVoxelsTaskParams.class);
+        parser.registerParams("renderBuildings3d", RenderBuildings3dTaskParams.class);
 
         parser.registerParams("wfs", WFSProviderParams.class);
         parser.registerParams("gpkg", GeoPackageProviderParams.class);
@@ -121,11 +125,13 @@ public final class MinalacGenerator {
         parser.registerParams("geotiff", GeoTiffProviderParams.class);
         parser.registerParams("las", LASProviderParams.class);
         parser.registerParams("lasTiled", LASTiledProviderParams.class);
+        parser.registerParams("cityjson", CityJSONProviderParams.class);
 
         parser.registerParams("floatMatrix", FloatMatrixProcessorParams.class);
         parser.registerParams("geoToolsVector", GeoToolsVectorProcessorParams.class);
         parser.registerParams("lasPoints", LASPointProcessorParams.class);
         parser.registerParams("lasMerged", LASPointMergedModelProcessorParams.class);
+        parser.registerParams("cityjsonBuilding", CityJSONBuildingProcessorParams.class);
 
         parser.registerParams("identity", IdentityPostProcessorParams.class);
         parser.registerParams("discard", DiscardPostProcessorParams.class);

--- a/src/main/java/com/ignfab/minalac/generator/inputs/CityJSONDataProvider.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/CityJSONDataProvider.java
@@ -1,0 +1,95 @@
+package com.ignfab.minalac.generator.inputs;
+
+import java.io.File;
+import java.util.List;
+
+import org.citygml4j.cityjson.CityJSONContext;
+import org.citygml4j.cityjson.CityJSONContextException;
+import org.citygml4j.cityjson.reader.CityJSONInputFactory;
+import org.citygml4j.cityjson.reader.CityJSONReadException;
+import org.citygml4j.cityjson.reader.CityJSONReader;
+import org.citygml4j.core.model.core.AbstractCityObject;
+import org.citygml4j.core.model.core.AbstractCityObjectProperty;
+import org.citygml4j.core.model.core.CityModel;
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.CRS;
+import org.xmlobjects.gml.model.geometry.DirectPosition;
+import org.xmlobjects.gml.model.geometry.Envelope;
+
+import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
+import com.ignfab.minalac.generator.exceptions.RetryableException;
+import com.ignfab.minalac.generator.exceptions.TransformException;
+import com.ignfab.minalac.generator.utils.coordinates.EnvelopeProvider;
+import com.ignfab.minalac.generator.utils.iterator.Iterators;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+
+public class CityJSONDataProvider implements Provider<AbstractCityObject> {
+    private final File file;
+    private final CoordinateReferenceSystem crsOverride;
+    private final EnvelopeProvider envelopeProvider;
+
+    public CityJSONDataProvider(File file, CoordinateReferenceSystem crsOverride, EnvelopeProvider envelopeProvider) {
+        this.file = file;
+        this.crsOverride = crsOverride;
+        this.envelopeProvider = envelopeProvider;
+    }
+
+    @Override
+    public Class<AbstractCityObject> providedType() {
+        return AbstractCityObject.class;
+    }
+
+    @Override
+    public Result<AbstractCityObject> provide(WorldBBox3d bbox) throws GenerationFailedException, RetryableException {
+
+        CityJSONContext context;
+        try {
+            context = CityJSONContext.newInstance();
+        } catch (CityJSONContextException e) {
+            throw new GenerationFailedException(e);
+        }
+
+        CityJSONInputFactory in = context.createCityJSONInputFactory();
+
+        CityModel cityModel;
+        try (CityJSONReader reader = in.createCityJSONReader(file)) {
+            cityModel = (CityModel) reader.next();
+        } catch (CityJSONReadException e) {
+            throw new RetryableException(e);
+        }
+
+        CoordinateReferenceSystem crs = crsOverride;
+        if (crs == null)
+            try {
+                crs = CRS.decode(cityModel.getBoundedBy().getEnvelope().getSrsName());
+            } catch (FactoryException e) {
+                throw new GenerationFailedException(e);
+            }
+
+        ReferencedEnvelope envelope;
+        try {
+            envelope = envelopeProvider.computeForCRS(crs, bbox);
+        } catch (FactoryException | TransformException e) {
+            throw new GenerationFailedException(e);
+        }
+
+        final Envelope cityEnvelope = new Envelope(
+                    new DirectPosition(envelope.getMinX(), envelope.getMinY()),
+                    new DirectPosition(envelope.getMaxX(), envelope.getMaxY())
+        );
+
+        return new SimpleResult<AbstractCityObject>(
+            crs,
+            Iterators.filter(
+                Iterators.remap(
+                    cityModel.getCityObjectMembers().iterator(),
+                    AbstractCityObjectProperty::getObject
+                ),
+                object -> object.getBoundedBy().getEnvelope().intersects(cityEnvelope)
+            ),
+            List.of()
+        );
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/models/BuildingSurfaceType.java
+++ b/src/main/java/com/ignfab/minalac/generator/models/BuildingSurfaceType.java
@@ -1,0 +1,5 @@
+package com.ignfab.minalac.generator.models;
+
+public enum BuildingSurfaceType {
+    GROUND, WALL, ROOF
+}

--- a/src/main/java/com/ignfab/minalac/generator/models/BuildingVoxelizable.java
+++ b/src/main/java/com/ignfab/minalac/generator/models/BuildingVoxelizable.java
@@ -1,0 +1,12 @@
+package com.ignfab.minalac.generator.models;
+
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+import com.ignfab.minalac.generator.voxelization.BuildingVoxelizer;
+
+/**
+ * An object (likely a model) voxelizable by {@link BuildingVoxelizer}.
+ */
+public interface BuildingVoxelizable extends Voxelizable3d {
+    @Override
+    BuildingVoxelizer voxelize3d(WorldBBox3d bbox);
+}

--- a/src/main/java/com/ignfab/minalac/generator/models/CityBuildingModel.java
+++ b/src/main/java/com/ignfab/minalac/generator/models/CityBuildingModel.java
@@ -1,0 +1,37 @@
+package com.ignfab.minalac.generator.models;
+
+import java.util.List;
+
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
+import com.ignfab.minalac.generator.voxelization.BuildingVoxelizer;
+import com.ignfab.minalac.generator.voxelization.PlanarPolygon;
+
+public class CityBuildingModel extends ModelImpl implements BuildingVoxelizable {
+    private final List<PlanarPolygon> ground;
+    private final List<PlanarPolygon> walls;
+    private final List<PlanarPolygon> roof;
+    private final WorldCoords3d center;
+
+
+    public CityBuildingModel(List<PlanarPolygon> ground, List<PlanarPolygon> walls, List<PlanarPolygon> roof, WorldCoords3d center) {
+        this.ground = ground;
+        this.walls = walls;
+        this.roof = roof;
+        this.center = center;
+    }
+
+    @Override
+    public String salt() {
+        return "%d/%d/%d".formatted(center.x(), center.y(), center.z());
+    }
+
+    @Override
+    public BuildingVoxelizer voxelize3d(WorldBBox3d bbox) {
+        BuildingVoxelizer voxelizer = new BuildingVoxelizer(bbox);
+        voxelizer.addAll(BuildingSurfaceType.GROUND, ground);
+        voxelizer.addAll(BuildingSurfaceType.WALL, walls);
+        voxelizer.addAll(BuildingSurfaceType.ROOF, roof);
+        return voxelizer;
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/parameters/processors/CityJSONBuildingProcessorParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/processors/CityJSONBuildingProcessorParams.java
@@ -1,0 +1,18 @@
+package com.ignfab.minalac.generator.parameters.processors;
+
+import org.citygml4j.core.model.core.AbstractCityObject;
+
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.models.CityBuildingModel;
+import com.ignfab.minalac.generator.processors.CityJSONBuildingProcessor;
+import com.ignfab.minalac.generator.processors.Processor;
+
+/**
+ * Parameters for CityJSON building processors.
+ */
+public class CityJSONBuildingProcessorParams extends ProcessorParams {
+    @Override
+    public Processor<AbstractCityObject, CityBuildingModel> create(Generation generation) {
+        return new CityJSONBuildingProcessor(generation::makeCoordsConverter);
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/parameters/providers/CityJSONProviderParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/providers/CityJSONProviderParams.java
@@ -1,0 +1,57 @@
+package com.ignfab.minalac.generator.parameters.providers;
+
+import java.beans.ConstructorProperties;
+import java.io.File;
+
+import org.citygml4j.core.model.core.AbstractCityObject;
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.referencing.CRS;
+
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.inputs.CityJSONDataProvider;
+import com.ignfab.minalac.generator.inputs.Provider;
+import com.ignfab.minalac.generator.utils.FileHelpers;
+
+/**
+ * Parameters for CityJSON providers.
+ */
+@SuppressWarnings("checkstyle:VisibilityModifier")
+public class CityJSONProviderParams extends ProviderParams {
+    /**
+     * Path to CityJSON file (required).
+     */
+    public String filePath;
+
+    /**
+     * Overriding coordinate reference system (optional, default: none).
+     */
+    public String overrideCrs;
+
+    /**
+     * Creates a new CityJSONProviderParams with mandatory fields.
+     *
+     * @param filePath Path to CityJSON file (absolute, or relative to current execution context)
+     */
+    @ConstructorProperties({"filePath"})
+    public CityJSONProviderParams(String filePath) {
+        this.filePath = filePath;
+    }
+
+    @Override
+    public Provider<AbstractCityObject> create(Generation generation) {
+        CoordinateReferenceSystem crs = null;
+        if (overrideCrs != null)
+            try {
+                crs = CRS.decode(overrideCrs);
+            } catch (FactoryException e) {
+                throw new IllegalArgumentException("CRS code \"%s\" is invalid".formatted(crs), e);
+            }
+
+        File file = new File(filePath);
+        if (!FileHelpers.isReadableRegularFile(file))
+            throw new IllegalArgumentException("File \"%s\" does not exist or is not readable".formatted(file.getAbsolutePath()));
+
+        return new CityJSONDataProvider(file, crs, generation::getEnvelopeForCRS);
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/parameters/tasks/RenderBuildings3dTaskParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/tasks/RenderBuildings3dTaskParams.java
@@ -1,0 +1,70 @@
+package com.ignfab.minalac.generator.parameters.tasks;
+
+import java.beans.ConstructorProperties;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.models.BuildingSurfaceType;
+import com.ignfab.minalac.generator.parameters.models.ModelSelectionParams;
+import com.ignfab.minalac.generator.parameters.placeables.PlaceableParams;
+import com.ignfab.minalac.generator.tasks.RenderBuildings3dTask;
+import com.ignfab.minalac.generator.tasks.TileTask;
+
+public class RenderBuildings3dTaskParams extends TileTaskParams {
+    /**
+     * Models to render (required).
+     */
+    @JsonSetter(nulls = Nulls.FAIL)
+    public ModelSelectionParams models;
+
+    @JsonSetter(nulls = Nulls.FAIL)
+    public PlaceableParams place;
+
+    @JsonSetter(nulls = Nulls.FAIL)
+    public Type surfaceType;
+
+    @ConstructorProperties({"models", "place", "surfaceType"})
+    public RenderBuildings3dTaskParams(ModelSelectionParams models, PlaceableParams place, Type surfaceType) {
+        this.models = models;
+        this.place = place;
+        this.surfaceType = surfaceType;
+    }
+
+    @Override
+    public void validate() throws IllegalArgumentException {
+        models.validate();
+        place.validate();
+    }
+
+    @Override
+    public TileTask create(Generation generation) {
+        return new RenderBuildings3dTask(
+            models.create(),
+            place.create(generation.seed()),
+            surfaceType.create()
+        );
+    }
+
+    public enum Type {
+        @JsonProperty("ground")
+        GROUND(BuildingSurfaceType.GROUND),
+
+        @JsonProperty("wall")
+        WALL(BuildingSurfaceType.WALL),
+
+        @JsonProperty("roof")
+        ROOF(BuildingSurfaceType.ROOF);
+
+        private final BuildingSurfaceType type;
+
+        Type(BuildingSurfaceType type) {
+            this.type = type;
+        }
+        public BuildingSurfaceType create() {
+            return type;
+        }
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/processors/CityJSONBuildingProcessor.java
+++ b/src/main/java/com/ignfab/minalac/generator/processors/CityJSONBuildingProcessor.java
@@ -1,0 +1,128 @@
+package com.ignfab.minalac.generator.processors;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.citygml4j.core.model.building.Building;
+import org.citygml4j.core.model.construction.GroundSurface;
+import org.citygml4j.core.model.construction.RoofSurface;
+import org.citygml4j.core.model.construction.WallSurface;
+import org.citygml4j.core.model.core.AbstractCityObject;
+import org.citygml4j.core.model.core.AbstractGenericAttribute;
+import org.citygml4j.core.model.core.AbstractGenericAttributeProperty;
+import org.xmlobjects.gml.model.geometry.DirectPosition;
+import org.xmlobjects.gml.model.geometry.GeometryProperty;
+import org.xmlobjects.gml.model.geometry.aggregates.MultiSurface;
+import org.xmlobjects.gml.model.geometry.primitives.AbstractRingProperty;
+import org.xmlobjects.gml.model.geometry.primitives.LinearRing;
+import org.xmlobjects.gml.model.geometry.primitives.Polygon;
+import org.xmlobjects.gml.model.geometry.primitives.SurfaceProperty;
+import org.xmlobjects.model.Child;
+
+import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
+import com.ignfab.minalac.generator.exceptions.IgnorableException;
+import com.ignfab.minalac.generator.exceptions.TransformException;
+import com.ignfab.minalac.generator.models.CityBuildingModel;
+import com.ignfab.minalac.generator.utils.coordinates.CoordsConverterProvider;
+import com.ignfab.minalac.generator.utils.coordinates.MapCoordinates;
+import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
+import com.ignfab.minalac.generator.utils.world3d.Vector3d;
+import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
+import com.ignfab.minalac.generator.voxelization.PlanarPolygon;
+
+
+public class CityJSONBuildingProcessor extends ConvertingProcessor<AbstractCityObject, CityBuildingModel> {
+
+    public CityJSONBuildingProcessor(CoordsConverterProvider converterProvider) {
+        super(converterProvider);
+    }
+
+    @Override
+    public Class<AbstractCityObject> acceptedType() {
+        return AbstractCityObject.class;
+    }
+
+    @Override
+    public Class<CityBuildingModel> modelType() {
+        return CityBuildingModel.class;
+    }
+
+    @Override
+    public CityBuildingModel process(AbstractCityObject object) throws GenerationFailedException, IgnorableException {
+        if (!(object instanceof Building building))
+            return null;
+
+        // Faces of the building (lists of planar polygons)
+        List<PlanarPolygon> ground = new ArrayList<>();
+        List<PlanarPolygon> walls = new ArrayList<>();
+        List<PlanarPolygon> roof = new ArrayList<>();
+        for (GeometryProperty<?> geometry : building.getGeometryInfo(true).getGeometries()) {
+            if (geometry.getObject() instanceof MultiSurface surfaces) {
+                Child parent = geometry.getParent();
+                List<PlanarPolygon> polygons;
+                if (parent instanceof GroundSurface)
+                    polygons = ground;
+                else if (parent instanceof WallSurface)
+                    polygons = walls;
+                else if (parent instanceof RoofSurface)
+                    polygons = roof;
+                else
+                    continue;
+                for (SurfaceProperty surfaceMember : surfaces.getSurfaceMember()) {
+                    if (surfaceMember.getObject() instanceof Polygon polygon) {
+                        List<Vector3d> shell;
+                        if (polygon.getExterior().getObject() instanceof LinearRing linearRing)
+                            shell = linearRingToCoords(linearRing);
+                        else
+                            continue;
+                        List<List<Vector3d>> holes = new ArrayList<>();
+                        for (AbstractRingProperty interior : polygon.getInterior())
+                            if (interior.getObject() instanceof LinearRing hole)
+                                holes.add(linearRingToCoords(hole));
+                        try {
+                            polygons.add(new PlanarPolygon(shell, holes));
+                        } catch (PlanarPolygon.IllegalPolygonException e) {
+                            //throw new IgnorableException(e); // Bad idea to ignore whole model because of 1 invalid polygon (often being way too small)
+                        }
+                    }
+                }
+            }
+        }
+        if (ground.isEmpty() && walls.isEmpty() && roof.isEmpty())
+            return null;
+
+        // Center of the building (approximated to the center of the bbox)
+        DirectPosition mapCenter = building.getBoundedBy().getEnvelope().getCenter();
+        WorldCoords2d center2d;
+        try {
+            center2d = converter.convert(new MapCoordinates(mapCenter.getValue().get(0), mapCenter.getValue().get(1)));
+        } catch (TransformException e) {
+            throw new IgnorableException(e);
+        }
+        WorldCoords3d center = center2d.to3d((int) Math.round(mapCenter.getValue().get(2)));
+
+        CityBuildingModel model = new CityBuildingModel(ground, walls, roof, center);
+
+        // Attributes
+        for (AbstractGenericAttributeProperty attributeProperty : building.getGenericAttributes()) {
+            AbstractGenericAttribute<?> attribute = attributeProperty.getObject();
+            model.setMetadata(attribute.getName(), attribute.getValue());
+        }
+        return model;
+    }
+
+    private List<Vector3d> linearRingToCoords(LinearRing linearRing) throws IgnorableException {
+        List<Double> ring = linearRing.toCoordinateList3D();
+        List<Vector3d> coords = new ArrayList<>(ring.size() / 3);
+        for (int i = 0; i < ring.size(); i += 3) {
+            MapCoordinates convert;
+            try {
+                convert = converter.convertRaw(new MapCoordinates(ring.get(i), ring.get(i + 1)));
+            } catch (TransformException e) {
+                throw new IgnorableException(e);
+            }
+            coords.add(new Vector3d(convert.x(), convert.y(), ring.get(i + 2)));
+        }
+        return coords;
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/tasks/RenderBuildings3dTask.java
+++ b/src/main/java/com/ignfab/minalac/generator/tasks/RenderBuildings3dTask.java
@@ -1,0 +1,29 @@
+package com.ignfab.minalac.generator.tasks;
+
+import com.ignfab.minalac.generator.generation.GenerationTile;
+import com.ignfab.minalac.generator.models.BuildingSurfaceType;
+import com.ignfab.minalac.generator.models.BuildingVoxelizable;
+import com.ignfab.minalac.generator.models.ModelSelection;
+import com.ignfab.minalac.generator.placeables.Placeable;
+import com.ignfab.minalac.generator.utils.world3d.Positioned3d;
+import com.ignfab.minalac.generator.voxelization.BuildingVoxelizer;
+
+public class RenderBuildings3dTask extends ModelTask<BuildingVoxelizable> {
+
+    private final Placeable placeable;
+    private final BuildingSurfaceType type;
+
+    public RenderBuildings3dTask(ModelSelection selection, Placeable placeable, BuildingSurfaceType type) {
+        super(BuildingVoxelizable.class, selection);
+        this.placeable = placeable;
+        this.type = type;
+    }
+
+    @Override
+    protected void run(BuildingVoxelizable model, GenerationTile tile) {
+        BuildingVoxelizer voxelizer = model.voxelize3d(tile.limits());
+
+        for (Positioned3d p : voxelizer.surfaces(type))
+            placeable.place(tile.voxels(), p.coords());
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/utils/coordinates/MapToWorldConverter.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/coordinates/MapToWorldConverter.java
@@ -92,4 +92,8 @@ public class MapToWorldConverter {
     public Geometry convert(Geometry geom) throws TransformException {
         return converter.convert(geom);
     }
+
+    public MapCoordinates convertRaw(MapCoordinates coords) throws TransformException {
+        return converter.convert(coords);
+    }
 }

--- a/src/main/java/com/ignfab/minalac/generator/utils/world2d/Vector2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world2d/Vector2d.java
@@ -48,6 +48,19 @@ public record Vector2d(double x, double y) {
     }
 
     /**
+     * Returns normalized vector. If vector is zero, zero vector is returned.
+     *
+     * @return normalized vector
+     */
+    // TODO: TESTS
+    public Vector2d normalized() {
+        if (isZero())
+            return ZERO;
+        double length = length();
+        return new Vector2d(x / length, y / length);
+    }
+
+    /**
      * Returns a new vector resulting from addition of a vector to this vector.
      *
      * @param vector vector to add
@@ -99,6 +112,43 @@ public record Vector2d(double x, double y) {
     }
 
     /**
+     * Computes scalar product of this vector with another vector as 2 coordinates.
+     * @param x x-coordinate of vector to compute product with
+     * @param y y-coordinate of vector to compute product with
+     *
+     * @return scalar product
+     */
+    // TODO: TESTS
+    public double dot(double x, double y) {
+        return this.x * x + this.y * y;
+    }
+
+    /**
+     * Computes scalar product of this vector with another vector.
+     * @param vector vector to compute product with
+     *
+     * @return scalar product
+     */
+    // TODO: TESTS
+    public double dot(Vector2d vector) {
+        return dot(vector.x, vector.y);
+    }
+
+    /**
+     * Computes product of this vector with another vector.
+     * @param vector vector to compute product with
+     *
+     * @return vector product
+     */
+    // TODO: TESTS
+    public Vector2d cross(Vector2d vector) {
+        return new Vector2d(
+            y * vector.x - x * vector.y,
+            x * vector.y - y * vector.x
+        );
+    }
+
+    /**
      * Creates a {@link Vector3d} from this vector by adding given z-axis component.
      *
      * @param z z-axis component to add
@@ -126,16 +176,6 @@ public record Vector2d(double x, double y) {
      */
     public double determinant(Vector2d vector) {
         return x * vector.y - y * vector.x;
-    }
-
-    /**
-     * Computes scalar product of this vector with another vector.
-     * @param vector vector to compute determinant with
-     *
-     * @return scalar product
-     */
-    public double scalarProduct(Vector2d vector) {
-        return x * vector.x + y * vector.y;
     }
 
     @Override

--- a/src/main/java/com/ignfab/minalac/generator/utils/world3d/Vector3d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world3d/Vector3d.java
@@ -50,6 +50,19 @@ public record Vector3d(double x, double y, double z) {
     }
 
     /**
+     * Returns normalized vector. If vector is zero, zero vector is returned.
+     *
+     * @return normalized vector
+     */
+    // TODO: TESTS
+    public Vector3d normalized() {
+        if (isZero())
+            return ZERO;
+        double length = length();
+        return new Vector3d(x / length, y / length, z / length);
+    }
+
+    /**
      * Returns a new vector resulting from addition of a vector to this vector.
      *
      * @param vector vector to add
@@ -98,6 +111,45 @@ public record Vector3d(double x, double y, double z) {
      */
     public WorldCoords3d round() {
         return WorldCoords3d.round(x, y, z);
+    }
+
+    /**
+     * Computes scalar product of this vector with another vector as 3 coordinates.
+     * @param x x-coordinate of vector to compute product with
+     * @param y y-coordinate of vector to compute product with
+     * @param z z-coordinate of vector to compute product with
+     *
+     * @return scalar product
+     */
+    // TODO: TESTS
+    public double dot(double x, double y, double z) {
+        return this.x * x + this.y * y + this.z * z;
+    }
+
+    /**
+     * Computes scalar product of this vector with another vector.
+     * @param vector vector to compute product with
+     *
+     * @return scalar product
+     */
+    // TODO: TESTS
+    public double dot(Vector3d vector) {
+        return dot(vector.x, vector.y, vector.z);
+    }
+
+    /**
+     * Computes product of this vector with another vector.
+     * @param vector vector to compute product with
+     *
+     * @return vector product
+     */
+    // TODO: TESTS
+    public Vector3d cross(Vector3d vector) {
+        return new Vector3d(
+            y * vector.z - z * vector.y,
+            z * vector.x - x * vector.z,
+            x * vector.y - y * vector.x
+        );
     }
 
     /**

--- a/src/main/java/com/ignfab/minalac/generator/voxelization/BuildingVoxelizer.java
+++ b/src/main/java/com/ignfab/minalac/generator/voxelization/BuildingVoxelizer.java
@@ -1,0 +1,60 @@
+package com.ignfab.minalac.generator.voxelization;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import com.ignfab.minalac.generator.models.BuildingSurfaceType;
+import com.ignfab.minalac.generator.utils.iterator.Iterables;
+import com.ignfab.minalac.generator.utils.iterator.Iterators;
+import com.ignfab.minalac.generator.utils.world3d.Positioned3d;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+
+public class BuildingVoxelizer implements Voxelizer3d {
+    private final Map<BuildingSurfaceType, List<PlanarPolygon>> shapes = new HashMap<>();
+    private final WorldBBox3d bbox;
+
+
+    public BuildingVoxelizer(WorldBBox3d bbox) {
+        this.bbox = bbox;
+    }
+
+    private List<PlanarPolygon> shapes(BuildingSurfaceType type) {
+        return shapes.computeIfAbsent(type, k -> new ArrayList<>());
+    }
+
+    public void add(BuildingSurfaceType type, PlanarPolygon shape) {
+        shapes(type).add(shape);
+    }
+
+    public void addAll(BuildingSurfaceType type, List<? extends PlanarPolygon> shapes) {
+        shapes(type).addAll(shapes);
+    }
+
+    @Override
+    public Iterator<Positioned3d> iterator() {
+        return bbox.crop(
+            Iterators.unwrapIterables(
+                Iterators.remap(
+                    Iterators.unwrapIterables(
+                        shapes.values().iterator()
+                    ),
+                    PlanarPolygon::iterable
+                )
+            )
+        );
+    }
+
+    public Iterable<Positioned3d> surfaces(BuildingSurfaceType type) {
+        return () -> bbox.crop(
+            Iterables.unwrap(
+                Iterables.remap(
+                    shapes(type),
+                    PlanarPolygon::iterable
+                )
+            )
+        );
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/voxelization/PlanarPolygon.java
+++ b/src/main/java/com/ignfab/minalac/generator/voxelization/PlanarPolygon.java
@@ -1,0 +1,120 @@
+package com.ignfab.minalac.generator.voxelization;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import com.ignfab.minalac.generator.utils.iterator.Iterators;
+import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
+import com.ignfab.minalac.generator.utils.world3d.Positioned3d;
+import com.ignfab.minalac.generator.utils.world3d.Vector3d;
+import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
+import com.ignfab.minalac.generator.voxelization.shape2d.LinearRing2d;
+import com.ignfab.minalac.generator.voxelization.shape2d.Polygon2d;
+import com.ignfab.minalac.generator.voxelization.shape2d.iterator.Polygon2dIterator;
+import com.ignfab.minalac.generator.voxelization.shape3d.LinearRing3d;
+import com.ignfab.minalac.generator.voxelization.shape3d.Polygon3d;
+
+public class PlanarPolygon {
+    private final Polygon3d polygon;
+    private final Polygon2d projected;
+    private final ProjectedRef ref;
+    private final boolean discard;
+
+    public PlanarPolygon(List<Vector3d> shell, List<List<Vector3d>> holes) throws IllegalPolygonException {
+        List<Vector3d> points = new ArrayList<>(shell);
+        holes.forEach(points::addAll);
+        Vector3d[] abc = threeMostDistantPoints(points);
+        Vector3d a = abc[0];
+        Vector3d b = abc[1];
+        Vector3d c = abc[2];
+        Vector3d ab = b.subtract(a);
+        Vector3d ac = c.subtract(a);
+        Vector3d cross = ab.cross(ac);
+        ref = new ProjectedRef(a, ab.normalized(), cross.cross(ab).normalized(), 2);
+        LinearRing2d shell2d = projectPoints(shell);
+        List<LinearRing2d> holes2d = new ArrayList<>(holes.size());
+        for (List<Vector3d> hole : holes)
+            holes2d.add(projectPoints(hole));
+        projected = new Polygon2d(shell2d, holes2d);
+        LinearRing3d shell3d = roundPoints(shell);
+        List<LinearRing3d> holes3d = new ArrayList<>(holes.size());
+        for (List<Vector3d> hole : holes)
+            holes3d.add(roundPoints(hole));
+        polygon = new Polygon3d(shell3d, holes3d);
+
+        // HACK : try to discard small surfaces to avoid unwanted artefacts
+        discard = cross.length() < 10.0;
+    }
+
+    private Vector3d[] threeMostDistantPoints(List<Vector3d> points) throws IllegalPolygonException {
+        double maxArea = 0;
+        Vector3d[] result = new Vector3d[3];
+        for (int i = 0; i < points.size(); i++) {
+            Vector3d a = points.get(i);
+            for (int j = i + 1; j < points.size(); j++) {
+                Vector3d b = points.get(j);
+                Vector3d ab = b.subtract(a);
+                for (int k = j + 1; k < points.size(); k++) {
+                    Vector3d c = points.get(k);
+                    double area = ab.cross(c.subtract(a)).length();
+                    if (area > maxArea) {
+                        maxArea = area;
+                        result[0] = points.get(i);
+                        result[1] = points.get(j);
+                        result[2] = points.get(k);
+                    }
+                }
+            }
+        }
+        if (maxArea == 0)
+            throw new IllegalPolygonException("Polygon must have a least 3 distinct points");
+        return result;
+    }
+
+    private LinearRing2d projectPoints(List<Vector3d> points) {
+        List<WorldCoords2d> points2d = new ArrayList<>();
+        for (int i = 0; i < points.size(); i++)
+            points2d.add(ref.project(points.get(i)));
+        return LinearRing2d.fromPoints(points2d);
+    }
+
+    private LinearRing3d roundPoints(List<Vector3d> points) {
+        List<WorldCoords3d> points3d = new ArrayList<>();
+        for (int i = 0; i < points.size(); i++)
+            points3d.add(points.get(i).round());
+        return LinearRing3d.fromPoints(points3d);
+    }
+
+    public Iterable<Positioned3d> iterable() {
+        if (discard)
+            return Collections.emptyList();
+        else
+            return () -> Iterators.remap(new Polygon2dIterator(projected, true), c -> ref.revert((WorldCoords2d) c));
+    }
+
+    public record ProjectedRef(Vector3d origin, Vector3d i, Vector3d j, double scale) {
+        public WorldCoords2d project(Vector3d pos) {
+            double x = pos.x() - origin.x();
+            double y = pos.y() - origin.y();
+            double z = pos.z() - origin.z();
+            return WorldCoords2d.round(i.dot(x, y, z) * scale, j.dot(x, y, z) * scale);
+        }
+
+        public WorldCoords3d revert(WorldCoords2d pos) {
+            double x = pos.x() / scale;
+            double y = pos.y() / scale;
+            return WorldCoords3d.round(
+                origin.x() + i.x() * x + j.x() * y,
+                origin.y() + i.y() * x + j.y() * y,
+                origin.z() + i.z() * x + j.z() * y
+            );
+        }
+    }
+
+    public static class IllegalPolygonException extends Exception {
+        public IllegalPolygonException(String message) {
+            super(message);
+        }
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/utils/world2d/Vector2dTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/world2d/Vector2dTest.java
@@ -90,9 +90,9 @@ public class Vector2dTest {
     @Test
     public void testScalarProduct() {
         Vector2d v = new Vector2d(2.0, 3.0);
-        assertEquals(v.length() * v.length(), v.scalarProduct(v), EPSILON);
-        assertEquals(0.0, v.scalarProduct(v.normal()), EPSILON);
-        assertEquals(0.0, v.scalarProduct(Vector2d.ZERO), EPSILON);
+        assertEquals(v.length() * v.length(), v.dot(v), EPSILON);
+        assertEquals(0.0, v.dot(v.normal()), EPSILON);
+        assertEquals(0.0, v.dot(Vector2d.ZERO), EPSILON);
     }
 
     @Test


### PR DESCRIPTION
Rebasage sans remettre le code au goût du jour avec les nouvelles formes et les nouveaux voxeliseurs.

Ça vaudrait le coup dans le futur d'avoir un voxéliseur de polygone plans (a tester en coordonnées entières si ça marche, ce qui éviterai d'avoir à créer tout un pan de formes décimales).

Le fichier bati.city.json est à placer dans ./data (est-ce qu'on l'ajoute à la branche ?).

# TODO avant de merge dans main

- Tester la voxelisation des polygones à coordonnées entière (de Shape3d)
- Essayer de faire une "régression plane" (regression linéaire à 2 dimensions) pour déterminer le plan du polygone
- Adapter le tout au nouveau système de voxelizers