### PR TITLE
chore(fds): Disable some checks irrelevant for the FDS 2025 code-sprint

### DIFF
--- a/.github/workflows/parameters-tests.yml
+++ b/.github/workflows/parameters-tests.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   test-parameters:
+    if: false # FDS2025: Disable parameters validation via CI/CD
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -107,12 +107,13 @@
       <property name="allowInlineReturn" value="true"/>
     </module>
     <module name="JavadocType"/>
-    <module name="JavadocVariable">
-      <property name="accessModifiers" value="public,protected"/>
-    </module>
+    <!-- FDS2025: Disable Javadoc requirements from checkstyle -->
+<!--    <module name="JavadocVariable">-->
+<!--      <property name="accessModifiers" value="public,protected"/>-->
+<!--    </module>-->
     <module name="JavadocStyle"/>
-   <module name="MissingJavadocMethod"/>
-   <module name="MissingJavadocType"/>
+<!--   <module name="MissingJavadocMethod"/>-->
+<!--   <module name="MissingJavadocType"/>-->
 
     <!-- Checks for Naming Conventions.                  -->
     <!-- See https://checkstyle.org/config_naming.html -->


### PR DESCRIPTION
Un commit à drop plus tard, mais qui permet de ne pas s'embêter avec la Javadoc manquante sur les ajouts liés à la FDS 2025.

La validation des paramètres via CI/CD a été désactivée car le paramétrage FDS va reposer sur des données locales, qui n'existent pas en CI/CD.