### PR TITLE
feat(tasks): Allow passing a model value instead of only a heightmap to the renderSurfaces task

### DIFF
--- a/examples/processes/fds.yaml
+++ b/examples/processes/fds.yaml
@@ -432,3 +432,45 @@ forEachTile:
       sum: [highest-leaves, -1]
     placeBelow: default:tree
 
+  renderFakeTreeCrown:
+    after: renderTrunks
+    type: renderSurfaces
+    models:
+      type: trees
+    altitude:
+      sum: [highest-leaves, -1]
+    place:
+      structure:
+        axes: [ z, x, y ]
+        with:
+          $: default:leaves
+        blueprint:
+          - - "     "
+            - "  $  "
+            - " $$$ "
+            - "  $  "
+            - "     "
+          - - " $$$ "
+            - "$$$$$"
+            - "$$$$$"
+            - "$$$$$"
+            - " $$$ "
+          - - " $$$ "
+            - "$$$$$"
+            - "$$ $$"
+            - "$$$$$"
+            - " $$$ "
+          - - " $$$ "
+            - "$$$$$"
+            - "$$ $$"
+            - "$$$$$"
+            - " $$$ "
+          - - "     "
+            - "  $  "
+            - " $ $ "
+            - "  $  "
+            - "     "
+        xOffset: -2
+        yOffset: -2
+        zOffset: -2
+

--- a/src/main/java/com/ignfab/minalac/generator/parameters/tasks/RenderSurfacesTaskParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/tasks/RenderSurfacesTaskParams.java
@@ -5,9 +5,13 @@ import java.beans.ConstructorProperties;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 
+import com.ignfab.minalac.generator.exceptions.IgnorableException;
 import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.generation.heightmaps.ReadableHeightmapSpec;
+import com.ignfab.minalac.generator.models.values.ModelValue;
 import com.ignfab.minalac.generator.parameters.heightmaps.ReadableHeightmapParams;
 import com.ignfab.minalac.generator.parameters.models.ModelSelectionParams;
+import com.ignfab.minalac.generator.parameters.models.values.ModelValueParams;
 import com.ignfab.minalac.generator.parameters.placeables.PlaceableParams;
 import com.ignfab.minalac.generator.tasks.RenderSurfacesTask;
 import com.ignfab.minalac.generator.tasks.TileTask;
@@ -24,8 +28,11 @@ public class RenderSurfacesTaskParams extends TileTaskParams {
     /**
      * The name of the heightmap to use (required).
      */
-    @JsonSetter(nulls = Nulls.FAIL)
+    @JsonSetter(nulls = Nulls.SKIP)
     public ReadableHeightmapParams heightmap;
+
+    @JsonSetter(nulls = Nulls.SKIP)
+    public ModelValueParams altitude;
     /**
      * What to place on surfaces (required).
      */
@@ -36,28 +43,39 @@ public class RenderSurfacesTaskParams extends TileTaskParams {
      * Constructor used to ensure that the required fields are present during deserialization.
      *
      * @param models models selection to render.
-     * @param heightmap heightmap to render on.
      * @param place what to place on surface.
      */
-    @ConstructorProperties({"models", "heightmap", "place"})
-    public RenderSurfacesTaskParams(ModelSelectionParams models, ReadableHeightmapParams heightmap, PlaceableParams place) {
+    @ConstructorProperties({"models", "place"})
+    public RenderSurfacesTaskParams(ModelSelectionParams models, PlaceableParams place) {
         this.models = models;
-        this.heightmap = heightmap;
         this.place = place;
     }
 
     @Override
     public void validate() throws IllegalArgumentException {
+        if ((heightmap == null) == (altitude == null))
+            throw new IllegalArgumentException("One (and only one) of 'heightmap' and 'altitude' must be specified");
         models.validate();
-        heightmap.validate();
+        if (heightmap != null)
+            heightmap.validate();
+        if (altitude != null)
+            altitude.validate();
         place.validate();
     }
 
     @Override
     public TileTask create(Generation generation) {
+        RenderSurfacesTask.GetZ atZ;
+        if (heightmap != null) {
+            ReadableHeightmapSpec heightmapSpec = heightmap.create(generation.heightmaps());
+            atZ = (tile, model, coords) -> tile.heightmaps().get(heightmapSpec).get(coords);
+        } else {
+            ModelValue altitudeValue = altitude.create(generation);
+            atZ = (tile, model, coords) -> altitudeValue.getAsInt(model).orElseThrow(() -> new IgnorableException("Missing altitude value"));
+        }
         return new RenderSurfacesTask(
             models.create(),
-            heightmap.create(generation.heightmaps()),
+            atZ,
             place.create(generation.seed())
         );
     }

--- a/src/main/java/com/ignfab/minalac/generator/tasks/RenderSurfacesTask.java
+++ b/src/main/java/com/ignfab/minalac/generator/tasks/RenderSurfacesTask.java
@@ -1,8 +1,8 @@
 package com.ignfab.minalac.generator.tasks;
 
+import com.ignfab.minalac.generator.exceptions.IgnorableException;
 import com.ignfab.minalac.generator.generation.GenerationTile;
-import com.ignfab.minalac.generator.generation.heightmaps.ReadableHeightmap;
-import com.ignfab.minalac.generator.generation.heightmaps.ReadableHeightmapSpec;
+import com.ignfab.minalac.generator.models.Model;
 import com.ignfab.minalac.generator.models.ModelSelection;
 import com.ignfab.minalac.generator.models.Shape2dConvertibleModel;
 import com.ignfab.minalac.generator.placeables.Placeable;
@@ -17,7 +17,7 @@ import com.ignfab.minalac.generator.voxelization.shape2d.voxelizer.SurfaceVoxeli
  * Placement can be done on borders (for all sorts of geometry) and/or inside (for polygon geometries) or everywhere.
  */
 public class RenderSurfacesTask extends ModelTask<Shape2dConvertibleModel> {
-    private final ReadableHeightmapSpec heightmapSpec;
+    private final GetZ atZ;
     private final Placeable placeable;
 
     private final SurfaceVoxelizer2d voxelizer = new SurfaceVoxelizer2d();
@@ -26,22 +26,25 @@ public class RenderSurfacesTask extends ModelTask<Shape2dConvertibleModel> {
      * Creates a new {@code RenderVectorsTask}.
      *
      * @param selection the model selection containing the wanted models to render (only ShapesVoxelizable2d ones will be)
-     * @param heightmapSpec Heightmap of the ground (on which features will be placed)
+     * @param atZ Getter for the altitude at which features will be placed
      * @param placeable What to place on surface
      */
-    public RenderSurfacesTask(ModelSelection selection, ReadableHeightmapSpec heightmapSpec, Placeable placeable) {
+    public RenderSurfacesTask(ModelSelection selection, GetZ atZ, Placeable placeable) {
         super(Shape2dConvertibleModel.class, selection);
-        this.heightmapSpec = heightmapSpec;
+        this.atZ = atZ;
         this.placeable = placeable;
     }
 
     @Override
-    protected void run(Shape2dConvertibleModel model, GenerationTile tile) {
-        ReadableHeightmap heightmap = tile.heightmaps().get(heightmapSpec);
-
+    protected void run(Shape2dConvertibleModel model, GenerationTile tile) throws IgnorableException {
         for (Positioned2d voxel : tile.clip2d(voxelizer.voxelize(model))) {
             WorldCoords2d c = voxel.coords();
-            placeable.place(tile.voxels(), c.x(), c.y(), heightmap.get(c));
+            placeable.place(tile.voxels(), c.x(), c.y(), atZ.get(tile, model, c));
         }
+    }
+
+    @FunctionalInterface
+    public interface GetZ {
+        int get(GenerationTile tile, Model model, WorldCoords2d coords) throws IgnorableException;
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/parameters/tasks/RenderSurfacesTaskParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/tasks/RenderSurfacesTaskParamsTest.java
@@ -15,16 +15,20 @@ public class RenderSurfacesTaskParamsTest {
         RenderSurfacesTaskParams params;
 
         // Test required arguments
-        params = new RenderSurfacesTaskParams(new ModelSelectionParams(""), TestingHeightmapParams.VALID, TestingPlaceableParams.VALID);
+        params = new RenderSurfacesTaskParams(new ModelSelectionParams(""), TestingPlaceableParams.VALID);
+        params.heightmap = TestingHeightmapParams.VALID;
         assertThrows(IllegalArgumentException.class, params::validate);
 
-        params = new RenderSurfacesTaskParams(selection, TestingHeightmapParams.INVALID, TestingPlaceableParams.VALID);
+        params = new RenderSurfacesTaskParams(selection, TestingPlaceableParams.VALID);
+        params.heightmap = TestingHeightmapParams.INVALID;
         assertThrows(IllegalArgumentException.class, params::validate);
 
-        params = new RenderSurfacesTaskParams(selection, TestingHeightmapParams.VALID,  TestingPlaceableParams.INVALID);
+        params = new RenderSurfacesTaskParams(selection, TestingPlaceableParams.INVALID);
+        params.heightmap = TestingHeightmapParams.VALID;
         assertThrows(IllegalArgumentException.class, params::validate);
 
-        params = new RenderSurfacesTaskParams(selection, TestingHeightmapParams.VALID, TestingPlaceableParams.VALID);
+        params = new RenderSurfacesTaskParams(selection, TestingPlaceableParams.VALID);
+        params.heightmap = TestingHeightmapParams.VALID;
         assertDoesNotThrow(params::validate);
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/tasks/RenderSurfacesTaskTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/tasks/RenderSurfacesTaskTest.java
@@ -21,6 +21,7 @@ class RenderSurfacesTaskTest {
     private TestingGenerationTile tile;
     private ModelSelection modelSelection;
     private TestingHeightmap heightmap;
+    private RenderSurfacesTask.GetZ getZ;
     private TestingVoxel voxel;
 
     @BeforeEach
@@ -28,6 +29,7 @@ class RenderSurfacesTaskTest {
         bbox = new WorldBBox3d(-1, -2, -3, 4, 5, 6);
         tile = new TestingGenerationTile(bbox);
         heightmap = tile.newStoredHeightmap("altitude", 0);
+        getZ = (t, model, coords) -> heightmap.get(coords);
         modelSelection = new ModelSelection("testing", null);
 
         voxel = new TestingVoxel("TEST");
@@ -35,7 +37,7 @@ class RenderSurfacesTaskTest {
 
     @Test
     public void testConstructor() {
-        assertDoesNotThrow(() -> new RenderSurfacesTask(modelSelection, heightmap.spec(), voxel));
+        assertDoesNotThrow(() -> new RenderSurfacesTask(modelSelection, getZ, voxel));
     }
 
     @Test
@@ -48,7 +50,7 @@ class RenderSurfacesTaskTest {
         // Add one model covering the whole map with INSIDE voxels
         tile.models().add("testing", new TestingRectangleShape2dModel(modelBbox));
 
-        new RenderSurfacesTask(modelSelection, heightmap.spec(), voxel).run(tile);
+        new RenderSurfacesTask(modelSelection, getZ, voxel).run(tile);
 
         for (WorldCoords3d pos : bbox) {
             if (pos.z() == 0 && modelBbox.contains(pos.to2d()))
@@ -69,7 +71,7 @@ class RenderSurfacesTaskTest {
         // Add one model covering the whole map
         tile.models().add("testing", new TestingRectangleShape2dModel(bbox.to2d()));
 
-        new RenderSurfacesTask(modelSelection, heightmap.spec(), voxel).run(tile);
+        new RenderSurfacesTask(modelSelection, getZ, voxel).run(tile);
 
         for (WorldCoords3d pos : bbox) {
             if (pos.z() == (pos.x() + pos.y()) / 2)
@@ -91,7 +93,7 @@ class RenderSurfacesTaskTest {
         // Add one model covering the whole map with BORDER voxels
         tile.models().add("testing", new TestingRectangleShape2dModel(bbox.to2d()));
 
-        new RenderSurfacesTask(modelSelection, heightmap.spec(), voxel).run(tile);
+        new RenderSurfacesTask(modelSelection, getZ, voxel).run(tile);
 
         for (WorldCoords3d pos : bbox) {
             if (pos.z() == pos.x() + pos.y() * 2)
@@ -108,7 +110,7 @@ class RenderSurfacesTaskTest {
         WorldBBox2d modelBbox = new WorldBBox2d(bbox.minX() - 1, bbox.minY() - 1, bbox.sizeX() + 2, bbox.sizeY() + 2);
         tile.models().add("testing", new TestingRectangleShape2dModel(modelBbox));
 
-        new RenderSurfacesTask(modelSelection, heightmap.spec(), voxel).run(tile);
+        new RenderSurfacesTask(modelSelection, getZ, voxel).run(tile);
 
         for (WorldCoords3d pos : bbox) {
             if (pos.z() == 0)


### PR DESCRIPTION
Ajout d'un paramètre pour spécifier l'altitude du rendu à partir d'une model value en plus d'une heightmap dans la tâche `renderSurfaces`. Le code de la tâche n'a presque pas changé (au lieu d'une heightmap en dur, il y a une fonction permettant de récupérer la hauteur).

Permet de générer une touffe de feuilles en haut des arbres pour palier à des données LiDAR trop éparses

# TODO:

* Peut être revoir comment cela peut être généralisé avec les model values
* Revoir aussi le paramétrage de la touffe selon les nouveautés