### PR TITLE
feat(renderlines): Add ability to render line with dynamic width

### DIFF
--- a/src/main/java/com/ignfab/minalac/generator/MinalacGenerator.java
+++ b/src/main/java/com/ignfab/minalac/generator/MinalacGenerator.java
@@ -51,6 +51,7 @@ import com.ignfab.minalac.generator.parameters.tasks.HeightmapStatsTaskParams;
 import com.ignfab.minalac.generator.parameters.tasks.PopulateHeightmapTaskParams;
 import com.ignfab.minalac.generator.parameters.tasks.RenderBuildings3dTaskParams;
 import com.ignfab.minalac.generator.parameters.tasks.RenderBuildingsTaskParams;
+import com.ignfab.minalac.generator.parameters.tasks.RenderDynamicLinesTaskParams;
 import com.ignfab.minalac.generator.parameters.tasks.RenderHeightmapTaskParams;
 import com.ignfab.minalac.generator.parameters.tasks.RenderLinesTaskParams;
 import com.ignfab.minalac.generator.parameters.tasks.RenderSurfacesTaskParams;
@@ -113,6 +114,7 @@ public final class MinalacGenerator {
         parser.registerParams("renderHeightmap", RenderHeightmapTaskParams.class);
         parser.registerParams("renderSurfaces", RenderSurfacesTaskParams.class);
         parser.registerParams("renderLines", RenderLinesTaskParams.class);
+        parser.registerParams("renderDynamicLines", RenderDynamicLinesTaskParams.class);
         parser.registerParams("setSpawn", SetSpawnTaskParams.class);
         parser.registerParams("renderVoxels", RenderVoxelsTaskParams.class);
         parser.registerParams("findVoxels", FindVoxelsTaskParams.class);

--- a/src/main/java/com/ignfab/minalac/generator/parameters/tasks/RenderDynamicLinesTaskParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/tasks/RenderDynamicLinesTaskParams.java
@@ -1,0 +1,108 @@
+package com.ignfab.minalac.generator.parameters.tasks;
+
+import java.beans.ConstructorProperties;
+
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+
+import com.ignfab.minalac.generator.exceptions.IgnorableException;
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.generation.heightmaps.ReadableHeightmapSpec;
+import com.ignfab.minalac.generator.models.values.ModelValue;
+import com.ignfab.minalac.generator.parameters.heightmaps.ReadableHeightmapParams;
+import com.ignfab.minalac.generator.parameters.models.ModelSelectionParams;
+import com.ignfab.minalac.generator.parameters.models.values.ModelValueParams;
+import com.ignfab.minalac.generator.parameters.placeables.structures.PlaceableStructureParams;
+import com.ignfab.minalac.generator.placeables.PlaceableStructure;
+import com.ignfab.minalac.generator.tasks.RenderLinesTask;
+import com.ignfab.minalac.generator.tasks.TileTask;
+
+/**
+ * Parameters for a {@link RenderDynamicLinesTaskParams}.
+ */
+public class RenderDynamicLinesTaskParams extends TileTaskParams {
+    /**
+     * Models to render (required).
+     */
+    @JsonSetter(nulls = Nulls.FAIL)
+    public ModelSelectionParams models;
+
+    @JsonSetter(nulls = Nulls.FAIL)
+    public ModelValueParams width;
+
+    @JsonSetter(nulls = Nulls.FAIL)
+    public PlaceableStructureParams repeated;
+
+    @JsonSetter(nulls = Nulls.SKIP)
+    public PlaceableStructureParams extra;
+
+    /**
+     * If specified, resulting voxels will be placed on this heightmap (optional, default use voxelized altitude).
+     */
+    @JsonSetter(nulls = Nulls.SKIP)
+    public ReadableHeightmapParams stickToHeightmap;
+
+    /**
+     * Render only when above this heightmap (optional, default render always).
+     */
+    @JsonSetter(nulls = Nulls.SKIP)
+    public ReadableHeightmapParams renderOnlyWhenAbove;
+
+    @ConstructorProperties({"models", "width", "repeated"})
+    public RenderDynamicLinesTaskParams(ModelSelectionParams models, ModelValueParams width, PlaceableStructureParams repeated) {
+        this.models = models;
+        this.width = width;
+        this.repeated = repeated;
+    }
+
+    @Override
+    public void validate() throws IllegalArgumentException {
+        models.validate();
+        width.validate();
+        repeated.validate();
+        if (extra != null)
+            extra.validate();
+        if (renderOnlyWhenAbove != null)
+            renderOnlyWhenAbove.validate();
+        if (stickToHeightmap != null)
+            stickToHeightmap.validate();
+    }
+
+    @Override
+    public TileTask create(Generation generation) {
+        ReadableHeightmapSpec renderOnlyWhenAboveSpec = null;
+        ReadableHeightmapSpec stickToHeightmapsSpec = null;
+        if (renderOnlyWhenAbove != null)
+            renderOnlyWhenAboveSpec = renderOnlyWhenAbove.create(generation.heightmaps());
+        if (stickToHeightmap != null)
+            stickToHeightmapsSpec = stickToHeightmap.create(generation.heightmaps());
+
+        PlaceableStructure repeatedStructure = repeated.create(generation.seed());
+        if (repeatedStructure.limits().sizeY() != 1)
+            throw new IllegalArgumentException("repeated must have width == 1");
+        PlaceableStructure extraStructure = extra == null ? null : extra.create(generation.seed());
+        if (extraStructure != null && (repeatedStructure.limits().sizeX() != extraStructure.limits().sizeX() || repeatedStructure.limits().sizeZ() != extraStructure.limits().sizeZ()))
+            throw new IllegalArgumentException("repeated and extra must have same length & height");
+        ModelValue widthValue = width.create(generation);
+        return new RenderLinesTask(
+            models.create(),
+            model -> {
+                int width = widthValue.getAsInt(model).orElseThrow(() -> new IgnorableException("Missing line width"));
+                // Meh! structure.merge(otherStructure, offset)?
+                PlaceableStructure structure = new PlaceableStructure();
+                for (int w = 0; w < width; w++)
+                    for (int x = 0; x < repeatedStructure.limits().sizeX(); x++)
+                        for (int z = 0; z < repeatedStructure.limits().sizeZ(); z++)
+                            structure.set(x, w, z, repeatedStructure.get(x, 0, z));
+                if (extraStructure != null)
+                    for (int x = 0; x < extraStructure.limits().sizeX(); x++)
+                        for (int y = 0; y < extraStructure.limits().sizeY(); y++)
+                            for (int z = 0; z < extraStructure.limits().sizeZ(); z++)
+                                structure.set(x, width + y, z, extraStructure.get(x, y, z));
+                return structure;
+            },
+            stickToHeightmapsSpec,
+            renderOnlyWhenAboveSpec
+        );
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/parameters/tasks/RenderLinesTaskParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/tasks/RenderLinesTaskParams.java
@@ -10,6 +10,7 @@ import com.ignfab.minalac.generator.generation.heightmaps.ReadableHeightmapSpec;
 import com.ignfab.minalac.generator.parameters.heightmaps.ReadableHeightmapParams;
 import com.ignfab.minalac.generator.parameters.models.ModelSelectionParams;
 import com.ignfab.minalac.generator.parameters.placeables.structures.PlaceableStructureParams;
+import com.ignfab.minalac.generator.placeables.PlaceableStructure;
 import com.ignfab.minalac.generator.tasks.RenderLinesTask;
 import com.ignfab.minalac.generator.tasks.TileTask;
 
@@ -72,9 +73,10 @@ public class RenderLinesTaskParams extends TileTaskParams {
         if (stickToHeightmap != null)
             stickToHeightmapSpec = stickToHeightmap.create(generation.heightmaps());
 
+        PlaceableStructure structure = this.structure.create(generation.seed());
         return new RenderLinesTask(
             models.create(),
-            structure.create(generation.seed()),
+            ignored -> structure,
             stickToHeightmapSpec,
             renderOnlyWhenAboveSpec
         );

--- a/src/main/java/com/ignfab/minalac/generator/tasks/RenderLinesTask.java
+++ b/src/main/java/com/ignfab/minalac/generator/tasks/RenderLinesTask.java
@@ -1,8 +1,10 @@
 package com.ignfab.minalac.generator.tasks;
 
+import com.ignfab.minalac.generator.exceptions.IgnorableException;
 import com.ignfab.minalac.generator.generation.GenerationTile;
 import com.ignfab.minalac.generator.generation.heightmaps.ReadableHeightmap;
 import com.ignfab.minalac.generator.generation.heightmaps.ReadableHeightmapSpec;
+import com.ignfab.minalac.generator.models.Model;
 import com.ignfab.minalac.generator.models.ModelSelection;
 import com.ignfab.minalac.generator.models.Shape3dConvertibleModel;
 import com.ignfab.minalac.generator.placeables.Placeable;
@@ -17,10 +19,9 @@ import com.ignfab.minalac.generator.voxelization.shape3d.voxelizer.ThickLinearIn
  */
 public class RenderLinesTask extends ModelTask<Shape3dConvertibleModel> {
     // In structure, X is for linear direction (starting at 0, looping over bbox max x), Y for both orthogonal directions (0 is central axis).
-    private final PlaceableStructure structure;
+    private final StructureGenerator structureGenerator;
     private final ReadableHeightmapSpec stickToHeightmapSpec;
     private final ReadableHeightmapSpec renderOnlyWhenAboveSpec;
-    private final ThickLinearIndexedVoxelizer3d voxelizer;
 
     /**
      * Creates a new {@code RenderLinesTask}.
@@ -30,28 +31,30 @@ public class RenderLinesTask extends ModelTask<Shape3dConvertibleModel> {
      * In structure x-axis will be along lines. Y-axis will be on sides, and z-axis will be used for height.
      *
      * @param selection Selection of models to render
-     * @param structure Structure to use as template
+     * @param structureGenerator Structure to use as template
      * @param stickToHeightmapSpec If not null, lines will be rendered at that heightmap
      * @param renderOnlyWhenAboveSpec If not null, lines will be rendered only if they have a part over that heightmap
      */
     public RenderLinesTask(
-            ModelSelection selection,
-            PlaceableStructure structure,
-            ReadableHeightmapSpec stickToHeightmapSpec,
-            ReadableHeightmapSpec renderOnlyWhenAboveSpec) {
-
+        ModelSelection selection,
+        StructureGenerator structureGenerator,
+        ReadableHeightmapSpec stickToHeightmapSpec,
+        ReadableHeightmapSpec renderOnlyWhenAboveSpec
+    ) {
         super(Shape3dConvertibleModel.class, selection);
 
-        this.structure = structure;
+        this.structureGenerator = structureGenerator;
         this.renderOnlyWhenAboveSpec = renderOnlyWhenAboveSpec;
         this.stickToHeightmapSpec = stickToHeightmapSpec;
-        voxelizer = new ThickLinearIndexedVoxelizer3d(structure.limits().maxY() * 2 + 1); // 1 for central position and * 2 for each side
     }
 
     @Override
-    protected void run(Shape3dConvertibleModel model, GenerationTile tile) {
+    protected void run(Shape3dConvertibleModel model, GenerationTile tile) throws IgnorableException {
         ReadableHeightmap renderOnlyWhenAbove = renderOnlyWhenAboveSpec == null ? null : tile.heightmaps().get(renderOnlyWhenAboveSpec);
         ReadableHeightmap stickToHeightmap = stickToHeightmapSpec == null ? null : tile.heightmaps().get(stickToHeightmapSpec);
+
+        PlaceableStructure structure = structureGenerator.generate(model);
+        ThickLinearIndexedVoxelizer3d voxelizer = new ThickLinearIndexedVoxelizer3d(structure.limits().maxY() * 2 + 1); // 1 for central position and * 2 for each side
 
         WorldBBox3d limits = structure.limits();
 
@@ -71,5 +74,10 @@ public class RenderLinesTask extends ModelTask<Shape3dConvertibleModel> {
                     placeable.place(tile.voxels(), pos.coords().x(), pos.coords().y(), zOffset + z);
             }
         }
+    }
+
+    @FunctionalInterface
+    public interface StructureGenerator {
+        PlaceableStructure generate(Model model) throws IgnorableException;
     }
 }


### PR DESCRIPTION
Ajoute un paramétrage alternatif pour la tâche `renderLines` (`renderDynamicLines`) qui génère dynamiquement une structure selon la largeur définie par une model value.

La façon d'exprimer le paramétrage sera à revoir, mais l'idée du "structure generator" semble intéressante pour façonner des structures extensibles.

Paramétrage non inclus dans cette PR, exemple trouvable ici : https://github.com/ignfab/minalac-generator/commit/7181cc50e23f4b2d7a4ce27246cda9a4b9d36b3a (attention à la mise à l'échelle)

# TODO (avant merge dans main)

La structure est générée devra être revue avec l'élasticité des structures développées par Zen (on devrait facilement pouvoir avoir une interface qui permet de demander là la structure de se générer avec telle ou telle largeur/hauteur/profondeur).