### PR TITLE
Fix concurrence bug on heightmaps

### DIFF
--- a/src/main/java/com/ignfab/minalac/generator/generation/heightmaps/HeightmapStore.java
+++ b/src/main/java/com/ignfab/minalac/generator/generation/heightmaps/HeightmapStore.java
@@ -36,10 +36,13 @@ public class HeightmapStore {
      * @return resulting {@link ReadableHeightmap}
      */
     public ReadableHeightmap get(ReadableHeightmapSpec spec) {
-        ReadableHeightmap heightmap = heightmaps.get(spec);
-        if (heightmap == null) {
-            heightmap = spec.create(this);
-            heightmaps.put(spec, heightmap);
+        ReadableHeightmap heightmap;
+        synchronized (heightmaps) {
+            heightmap = heightmaps.get(spec);
+            if (heightmap == null) {
+                heightmap = spec.create(this);
+                heightmaps.put(spec, heightmap);
+            }
         }
         return heightmap;
     }
@@ -51,7 +54,10 @@ public class HeightmapStore {
      * @return resulting {@link Heightmap}
      */
     public WritableHeightmap get(WritableHeightmapSpec spec) {
-        ReadableHeightmap heightmap = heightmaps.get(spec);
+        ReadableHeightmap heightmap;
+        synchronized (heightmaps) {
+            heightmap = heightmaps.get(spec);
+        }
         if (heightmap == null)
             throw new IndexOutOfBoundsException("Writable heightmap not found");
 


### PR DESCRIPTION
Generations involving multiple computed heightmap randomly experienced crashes.

These where due to a race condition on heightmap store making it saying a heightmap wasn't present despite it was:
```
java.lang.IndexOutOfBoundsException: Stored heightmap not found
```

Backtrace:
```
	at com.ignfab.minalac.generator.generation.heightmaps.WritableHeightmapSpec.create(WritableHeightmapSpec.java:18)
	at com.ignfab.minalac.generator.generation.heightmaps.WritableHeightmapSpec.create(WritableHeightmapSpec.java:13)
	at com.ignfab.minalac.generator.generation.heightmaps.HeightmapStore.get(HeightmapStore.java:41)
	at com.ignfab.minalac.generator.parameters.tasks.RenderSurfacesTaskParams.lambda$create$0(RenderSurfacesTaskParams.java:71)
	at com.ignfab.minalac.generator.tasks.RenderSurfacesTask.run(RenderSurfacesTask.java:42)
	at com.ignfab.minalac.generator.tasks.RenderSurfacesTask.run(RenderSurfacesTask.java:19)
	at com.ignfab.minalac.generator.tasks.ModelTask.run(ModelTask.java:27)
	at com.ignfab.minalac.generator.tasks.TileTask.accept(TileTask.java:21)
	at com.ignfab.minalac.generator.tasks.TileTask.accept(TileTask.java:10)
	at com.ignfab.minalac.generator.utils.execution.ScheduledTask.lambda$tryExecute$0(ScheduledTask.java:68)
```

### Changes

Access to store hash map is now synchronized. This avoids hash map to be modified while queried (returning not found on some existing heightmaps).

### Self-checks
- ~~[ ] The code has unit tests associated~~
- ~~[ ] The code has Javadoc Comments associated~~
- ~~[ ] Complex / Unexpected code is explained / justified with a small comment~~
- ~~[ ] Relevant documentation inside the `/docs` folder has been updated~~
- ~~[ ] All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)~~
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- ~~[ ] The texts have been proofread (documentation, error messages, logs, comments...)~~
