### PR TITLE
Several small fixes on outputs

### DIFF
--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelTile.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelTile.java
@@ -61,6 +61,8 @@ public class MCVoxelTile extends VoxelTile {
 
         if (isOutOfLimits(blockX, blockY, blockZ)) return;
         getOrCreateRegion(blockX, blockZ).file().setBlockStateAt(blockX, blockY, blockZ, block, false);
+        // (In-Game coords to world coords) X/Z/-Y => X/Y/Z
+        updateHeightmaps(blockX, -(blockZ + 1), blockY);
     }
 
     // In-Game coords

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelWorld.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelWorld.java
@@ -88,6 +88,7 @@ public class MTVoxelWorld extends VoxelWorld {
                 """);
             FileHelpers.write(new File(destination, "worldmods/ign_spawn/init.lua"), """
                 minetest.setting_set("static_spawnpoint", "%d, %d, %d")
+                core.register_on_joinplayer(function(player) player:set_sky{ clouds = false } end)
                 """.formatted(metadata.getSpawn().x(), metadata.getSpawn().z(), metadata.getSpawn().y())); // XYZ => XZY
         } catch (Exception e) {
             throw new MapWriteException(e);

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelWorld.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelWorld.java
@@ -83,6 +83,7 @@ public class MTVoxelWorld extends VoxelWorld {
             FileHelpers.write(new File(destination, "map_meta.txt"), """
                 mapgen_limit = 31000
                 mg_name = singlenode
+                seed = 0
                 [end_of_params]
                 """);
             FileHelpers.write(new File(destination, "worldmods/ign_spawn/init.lua"), """


### PR DESCRIPTION
This PR includes three small and obvious fixes:
* Update heightmaps when placing voxels in Minecraft format (have been forgotten);
* Adds a dummy map seed in Luanti format, avoiding some mod crash with recent Luanti versions (Darkage mod for example);
* Disable cloud display in Luanti format;
