### PR TITLE
Refactor provider/processor

### DIFF
--- a/src/main/java/com/ignfab/minalac/generator/inputs/GeoTiffDataProvider.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/GeoTiffDataProvider.java
@@ -2,7 +2,6 @@ package com.ignfab.minalac.generator.inputs;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Iterator;
 import javax.media.jai.iterator.RandomIter;
 import javax.media.jai.iterator.RandomIterFactory;
 
@@ -81,25 +80,6 @@ public class GeoTiffDataProvider implements Provider<FloatGeographicDataMatrix2d
             envelope.getHeight() / gridEnvelope.height
         );
 
-        return new Result(crs, result);
-    }
-
-    private record Result(CoordinateReferenceSystem crs, Iterator<FloatGeographicDataMatrix2d> iterator) implements Provider.Result<FloatGeographicDataMatrix2d> {
-        Result(CoordinateReferenceSystem crs, FloatGeographicDataMatrix2d data) {
-            this(crs, Iterators.iterator(data));
-        }
-
-        @Override
-        public void close() {}
-
-        @Override
-        public boolean hasNext() {
-            return iterator.hasNext();
-        }
-
-        @Override
-        public FloatGeographicDataMatrix2d next() {
-            return iterator.next();
-        }
+        return new SimpleResult<>(crs, Iterators.iterator(result));
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/inputs/GeoToolsDataStoreProvider.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/GeoToolsDataStoreProvider.java
@@ -19,6 +19,7 @@ import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 
 import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
+import com.ignfab.minalac.generator.exceptions.IgnorableException;
 import com.ignfab.minalac.generator.exceptions.RetryableException;
 import com.ignfab.minalac.generator.exceptions.TransformException;
 import com.ignfab.minalac.generator.utils.coordinates.EnvelopeProvider;
@@ -97,9 +98,14 @@ public abstract class GeoToolsDataStoreProvider implements Provider<SimpleFeatur
 
     private record FeaturesResult(CoordinateReferenceSystem crs, FeatureReader<SimpleFeatureType, SimpleFeature> reader, DataStore store) implements Result<SimpleFeature> {
         @Override
-        public void close() throws IOException {
-            reader.close();
-            store.dispose();
+        public void close() throws IgnorableException {
+            try {
+                reader.close();
+            } catch (IOException e) {
+                throw new IgnorableException(e);
+            } finally {
+                store.dispose();
+            }
         }
 
         @Override

--- a/src/main/java/com/ignfab/minalac/generator/inputs/Provider.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/Provider.java
@@ -1,10 +1,13 @@
 package com.ignfab.minalac.generator.inputs;
 
-import java.io.Closeable;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
 
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 
 import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
+import com.ignfab.minalac.generator.exceptions.IgnorableException;
 import com.ignfab.minalac.generator.exceptions.RetryableException;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 
@@ -33,14 +36,16 @@ public interface Provider<T> {
      * and then closed at the end. A typical usage may be:
      * <pre>{@code
      *  Provider<Elem> provider = ...;
-     *  try (Provider.Result<Elem> result = provider.provide()) {
+     *  try (Provider.Result<Elem> result = provider.provide(limits)) {
      *      for (Elem element : result) {
      *          // Code using element here...
      *      }
+     *  } catch (...) {
+     *      // Handle exceptions here...
      *  }
      * }</pre>
      *
-     * @param bbox Bbox to get elements for
+     * @param bbox limits of the area to provide elements from
      * @return A result wrapping elements and close method
      * @throws GenerationFailedException If a fatal error occurs while fetching data
      * @throws RetryableException If an error occurs but retrying may solve the issue
@@ -54,7 +59,7 @@ public interface Provider<T> {
      *
      * @param <T> The type of wrapped elements
      */
-    interface Result<T> extends Closeable {
+    interface Result<T> extends AutoCloseable {
         /**
          * {@return the coordinate reference system of resulting data}
          */
@@ -80,5 +85,115 @@ public interface Provider<T> {
          * @throws java.util.NoSuchElementException if no more result available.
          */
         T next() throws GenerationFailedException, RetryableException;
+
+        @Override
+        void close() throws IgnorableException;
+    }
+
+    /**
+     * Result implementation based on an iterator, and elements to close (optional).
+     * @param <T> The type of wrapped elements
+     */
+    class SimpleResult<T> implements Result<T> {
+        private final CoordinateReferenceSystem crs;
+        private final Iterator<T> iterator;
+        private final List<? extends AutoCloseable> close;
+
+        /**
+         * Creates a new simple result.
+         * @param crs the CRS of resulting data
+         * @param iterator the iterator to get data from
+         * @param close optional elements to close at the end
+         */
+        public SimpleResult(CoordinateReferenceSystem crs, Iterator<T> iterator, AutoCloseable... close) {
+            this(crs, iterator, List.of(close));
+        }
+
+        /**
+         * Creates a new simple result.
+         * @param crs the CRS of resulting data
+         * @param iterator the iterator to get data from
+         * @param close list of elements to close at the end
+         */
+        public SimpleResult(CoordinateReferenceSystem crs, Iterator<T> iterator, List<? extends AutoCloseable> close) {
+            this.crs = crs;
+            this.iterator = iterator;
+            this.close = close;
+        }
+
+        @Override
+        public CoordinateReferenceSystem crs() {
+            return crs;
+        }
+
+        @Override
+        public boolean hasNext() throws GenerationFailedException, RetryableException {
+            return iterator.hasNext();
+        }
+
+        @Override
+        public T next() throws GenerationFailedException, RetryableException {
+            return iterator.next();
+        }
+
+        @Override
+        public void close() throws IgnorableException {
+            IgnorableException exception = null;
+            for (AutoCloseable closeable : close) {
+                try {
+                    closeable.close();
+                } catch (Exception e) {
+                    // Save first exception, suppress others
+                    if (exception == null)
+                        exception = e instanceof IgnorableException ie ? ie : new IgnorableException(e);
+                    else
+                        exception.addSuppressed(e);
+                }
+            }
+            if (exception != null)
+                throw exception;
+        }
+    }
+
+    /**
+     * Result implementation based on multiple results.
+     * Each result is getting iterated over in order, and they all get closed at the end.
+     * @param <T> The type of wrapped elements
+     */
+    class MultiResult<T> extends SimpleResult<T> {
+        private final Iterator<? extends Result<? extends T>> results;
+        private Result<? extends T> current;
+
+        /**
+         * Creates a new multi-result.
+         * @param crs the CRS of resulting data
+         * @param results the results to iterator over
+         * @throws GenerationFailedException propagated if thrown by an underlying result
+         * @throws RetryableException propagated if thrown by an underlying result
+         */
+        public MultiResult(CoordinateReferenceSystem crs, List<? extends Result<? extends T>> results) throws GenerationFailedException, RetryableException {
+            super(crs, null, results);
+            this.results = results.iterator();
+            moveOn();
+        }
+
+        private void moveOn() throws GenerationFailedException, RetryableException {
+            while ((current == null || !current.hasNext()) && results.hasNext())
+                current = results.next();
+        }
+
+        @Override
+        public boolean hasNext() throws GenerationFailedException, RetryableException {
+            return current != null && current.hasNext();
+        }
+
+        @Override
+        public T next() throws GenerationFailedException, RetryableException {
+            if (current == null || !current.hasNext())
+                throw new NoSuchElementException();
+            T element = current.next();
+            moveOn();
+            return element;
+        }
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/inputs/WFS1_1_GML3_1_DataProvider.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/WFS1_1_GML3_1_DataProvider.java
@@ -82,7 +82,7 @@ public class WFS1_1_GML3_1_DataProvider implements Provider<SimpleFeature> {
     }
 
     @Override
-    public Provider.Result<SimpleFeature> provide(WorldBBox3d bbox) throws GenerationFailedException, RetryableException {
+    public Result<SimpleFeature> provide(WorldBBox3d bbox) throws GenerationFailedException, RetryableException {
 
         ReferencedEnvelope envelope;
         try {
@@ -125,21 +125,21 @@ public class WFS1_1_GML3_1_DataProvider implements Provider<SimpleFeature> {
             throw new GenerationFailedException(e);
         }
 
-        // Then we give hand to `Result` class for the rest.
-        return new Result(url, count);
+        // Then we give hand to `WFSResult` class for the rest.
+        return new WFSResult(url, count);
     }
 
    /**
      * A Result class for WFS that will fetch more features when needed.
      */
-    private class Result implements Provider.Result<SimpleFeature> {
+    private class WFSResult implements Result<SimpleFeature> {
 
         private final ParameterizedURL url;
         private final int total;
         private int remaining;
         private SimpleFeatureIterator iterator;
 
-        Result(ParameterizedURL url, int total) {
+        WFSResult(ParameterizedURL url, int total) {
             this.url = url;
             this.total = total;
             remaining = total;
@@ -154,7 +154,7 @@ public class WFS1_1_GML3_1_DataProvider implements Provider<SimpleFeature> {
         /**
          * Fetches more results from URL.
          */
-        private void fetchmore() throws RetryableException, GenerationFailedException {
+        private void fetchMore() throws RetryableException, GenerationFailedException {
             InputStream stream;
 
             try {
@@ -197,7 +197,7 @@ public class WFS1_1_GML3_1_DataProvider implements Provider<SimpleFeature> {
         }
 
         @Override
-        public void close() throws IOException {
+        public void close() {
             if (iterator != null)
                 iterator.close();
         }
@@ -208,7 +208,7 @@ public class WFS1_1_GML3_1_DataProvider implements Provider<SimpleFeature> {
                 return;
 
             if (iterator == null || !iterator.hasNext())
-                fetchmore();
+                fetchMore();
         }
 
         @Override

--- a/src/main/java/com/ignfab/minalac/generator/inputs/WMSFloatBilDataProvider.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/WMSFloatBilDataProvider.java
@@ -5,7 +5,6 @@ import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.util.Iterator;
 
 import org.geotools.api.referencing.FactoryException;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
@@ -63,7 +62,7 @@ public class WMSFloatBilDataProvider implements Provider<FloatGeographicDataMatr
     }
 
     @Override
-    public Provider.Result<FloatGeographicDataMatrix2d> provide(WorldBBox3d bbox) throws GenerationFailedException, RetryableException {
+    public Result<FloatGeographicDataMatrix2d> provide(WorldBBox3d bbox) throws GenerationFailedException, RetryableException {
 
         ReferencedEnvelope envelope;
         try {
@@ -128,35 +127,6 @@ public class WMSFloatBilDataProvider implements Provider<FloatGeographicDataMatr
 
         ByteBuffer.wrap(data).order(ByteOrder.LITTLE_ENDIAN).asFloatBuffer().get(result.data());
 
-        return new Result(result);
-    }
-
-    /**
-     * Result returned by provide method. Here, only one result is provided.
-     */
-    private class Result implements Provider.Result<FloatGeographicDataMatrix2d> {
-        private final Iterator<FloatGeographicDataMatrix2d> iterator;
-
-        Result(FloatGeographicDataMatrix2d data) {
-            iterator = Iterators.iterator(data);
-        }
-
-        @Override
-        public CoordinateReferenceSystem crs() {
-            return crs;
-        }
-
-        @Override
-        public void close() {}
-
-        @Override
-        public boolean hasNext() {
-            return iterator.hasNext();
-        }
-
-        @Override
-        public FloatGeographicDataMatrix2d next() {
-            return iterator.next();
-        }
+        return new SimpleResult<>(crs, Iterators.iterator(result));
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/processors/ConvertingProcessor.java
+++ b/src/main/java/com/ignfab/minalac/generator/processors/ConvertingProcessor.java
@@ -1,0 +1,39 @@
+package com.ignfab.minalac.generator.processors;
+
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+
+import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
+import com.ignfab.minalac.generator.models.Model;
+import com.ignfab.minalac.generator.utils.coordinates.CoordsConverterProvider;
+import com.ignfab.minalac.generator.utils.coordinates.MapToWorldConverter;
+
+/**
+ * Base processor implementation to provide coordinates conversion logic.
+ * @param <T> The type of processable elements
+ * @param <M> The type of created models
+ */
+public abstract class ConvertingProcessor<T, M extends Model> implements Processor<T, M> {
+    private final CoordsConverterProvider converterProvider;
+    /**
+     * Converter from map to world, automatically initialized by {@link #initialize(CoordinateReferenceSystem)}.
+     */
+    protected MapToWorldConverter converter;
+
+    /**
+     * Creates a new {@code ConvertingProcessor}.
+     * @param converterProvider converter provider to transform coordinates from map to world
+     */
+    public ConvertingProcessor(CoordsConverterProvider converterProvider) {
+        this.converterProvider = converterProvider;
+    }
+
+    @Override
+    public void initialize(CoordinateReferenceSystem layerCrs) throws GenerationFailedException {
+        try {
+            converter = converterProvider.computeForCRS(layerCrs);
+        } catch (FactoryException e) {
+            throw new GenerationFailedException("Could not find a converter from layer to generation CRS", e);
+        }
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/processors/FloatMatrixProcessor.java
+++ b/src/main/java/com/ignfab/minalac/generator/processors/FloatMatrixProcessor.java
@@ -1,39 +1,22 @@
 package com.ignfab.minalac.generator.processors;
 
-import org.geotools.api.referencing.FactoryException;
-import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
-
-import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
 import com.ignfab.minalac.generator.exceptions.IgnorableException;
 import com.ignfab.minalac.generator.exceptions.TransformException;
 import com.ignfab.minalac.generator.inputs.FloatGeographicDataMatrix2d;
 import com.ignfab.minalac.generator.models.FloatMatrixModel;
 import com.ignfab.minalac.generator.utils.coordinates.CoordsConverterProvider;
-import com.ignfab.minalac.generator.utils.coordinates.MapToWorldConverter;
 
 /**
  * Processor transforming {@link FloatGeographicDataMatrix2d} into a
  * {@link FloatMatrixModel}.
  */
-public class FloatMatrixProcessor implements Processor<FloatGeographicDataMatrix2d, FloatMatrixModel> {
-    private final CoordsConverterProvider converterProvider;
-    private MapToWorldConverter converter;
-
+public class FloatMatrixProcessor extends ConvertingProcessor<FloatGeographicDataMatrix2d, FloatMatrixModel> {
     /**
      * Creates a new {@code FloatMatrixProcessor}.
      * @param converterProvider converter provider to transform coordinates from map to world
      */
     public FloatMatrixProcessor(CoordsConverterProvider converterProvider) {
-        this.converterProvider = converterProvider;
-    }
-
-    @Override
-    public void initialize(CoordinateReferenceSystem layerCrs) throws GenerationFailedException {
-        try {
-            converter = converterProvider.computeForCRS(layerCrs);
-        } catch (FactoryException e) {
-            throw new GenerationFailedException("Could not find a converter from layer to generation CRS", e);
-        }
+        super(converterProvider);
     }
 
     @Override

--- a/src/main/java/com/ignfab/minalac/generator/processors/GeoToolsVectorProcessor.java
+++ b/src/main/java/com/ignfab/minalac/generator/processors/GeoToolsVectorProcessor.java
@@ -2,16 +2,12 @@ package com.ignfab.minalac.generator.processors;
 
 import org.geotools.api.feature.Property;
 import org.geotools.api.feature.simple.SimpleFeature;
-import org.geotools.api.referencing.FactoryException;
-import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.locationtech.jts.geom.Geometry;
 
-import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
 import com.ignfab.minalac.generator.exceptions.IgnorableException;
 import com.ignfab.minalac.generator.exceptions.TransformException;
 import com.ignfab.minalac.generator.models.JTSGeometryModel;
 import com.ignfab.minalac.generator.utils.coordinates.CoordsConverterProvider;
-import com.ignfab.minalac.generator.utils.coordinates.MapToWorldConverter;
 
 /**
  * Processor transforming {@link SimpleFeature} GeoTools object
@@ -20,25 +16,13 @@ import com.ignfab.minalac.generator.utils.coordinates.MapToWorldConverter;
  * <p>
  * This processor pairs well with {@link com.ignfab.minalac.generator.inputs.WFS1_1_GML3_1_DataProvider}.
  */
-public class GeoToolsVectorProcessor implements Processor<SimpleFeature, JTSGeometryModel> {
-    private final CoordsConverterProvider converterProvider;
-    private MapToWorldConverter converter;
-
+public class GeoToolsVectorProcessor extends ConvertingProcessor<SimpleFeature, JTSGeometryModel> {
     /**
      * Creates a new processor using the given converter to for the {@link JTSGeometryModel}.
      * @param converterProvider the converter provider to transform coordinates from map to world
      */
     public GeoToolsVectorProcessor(CoordsConverterProvider converterProvider) {
-        this.converterProvider = converterProvider;
-    }
-
-    @Override
-    public void initialize(CoordinateReferenceSystem layerCrs) throws GenerationFailedException {
-        try {
-            converter = converterProvider.computeForCRS(layerCrs);
-        } catch (FactoryException e) {
-            throw new GenerationFailedException("Could not find a converter from layer to generation CRS", e);
-        }
+        super(converterProvider);
     }
 
     @Override

--- a/src/main/java/com/ignfab/minalac/generator/tasks/FetchDataTask.java
+++ b/src/main/java/com/ignfab/minalac/generator/tasks/FetchDataTask.java
@@ -1,7 +1,5 @@
 package com.ignfab.minalac.generator.tasks;
 
-import java.io.IOException;
-
 import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
 import com.ignfab.minalac.generator.exceptions.IgnorableException;
 import com.ignfab.minalac.generator.exceptions.RetryableException;
@@ -73,13 +71,17 @@ public class FetchDataTask implements TileTask {
                 } catch (IgnorableException e) {
                     // TODO Add an exception handling policy
                     // To fail even on ignorable exceptions:
-                    // throw e;
+                    // throw new GenerationFailedException(e);
                 }
             }
         } catch (RetryableException e) {
             // TODO Implement a retry mechanism
             throw new RuntimeException(e);
-        } catch (IOException | GenerationFailedException e) {
+        } catch (IgnorableException e) {
+            // TODO Handle this according to the policy
+            // This can be thrown if unable to close a Provider.Result
+            throw new RuntimeException(e);
+        } catch (GenerationFailedException e) {
             throw new RuntimeException(e);
         }
     }

--- a/src/main/java/com/ignfab/minalac/generator/utils/coordinates/MapToWorldConverter.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/coordinates/MapToWorldConverter.java
@@ -20,7 +20,7 @@ public class MapToWorldConverter {
      *
      * @param converter base converter to use
      */
-    protected MapToWorldConverter(Converter converter) {
+    private MapToWorldConverter(Converter converter) {
         this.converter = converter;
     }
 

--- a/src/test/java/com/ignfab/minalac/generator/models/filters/ModelFilterEmptyGeometryTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/models/filters/ModelFilterEmptyGeometryTest.java
@@ -2,22 +2,19 @@ package com.ignfab.minalac.generator.models.filters;
 
 import java.util.function.Predicate;
 
-import org.geotools.referencing.operation.transform.IdentityTransform;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
-import org.locationtech.jts.geom.util.AffineTransformation;
 
 import com.ignfab.minalac.generator.exceptions.TransformException;
 import com.ignfab.minalac.generator.models.JTSGeometryModel;
 import com.ignfab.minalac.generator.models.Model;
 import com.ignfab.minalac.generator.models.TestingModel;
-import com.ignfab.minalac.generator.utils.coordinates.MapToWorldConverter;
+import com.ignfab.minalac.generator.utils.coordinates.TestingConverter;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 public class ModelFilterEmptyGeometryTest {
-    private static final MapToWorldConverter IDENTITY_CONVERTER = new MapToWorldConverter(IdentityTransform.create(2), new AffineTransformation());
     private static final GeometryFactory FACTORY = new GeometryFactory();
 
     @Test
@@ -28,8 +25,8 @@ public class ModelFilterEmptyGeometryTest {
             new Coordinate(1, 1),
             new Coordinate(1, 0),
             new Coordinate(0, 0)
-        }), IDENTITY_CONVERTER);
-        Model emptyGeometryModel = new JTSGeometryModel(FACTORY.createEmpty(2), IDENTITY_CONVERTER);
+        }), TestingConverter.IDENTITY);
+        Model emptyGeometryModel = new JTSGeometryModel(FACTORY.createEmpty(2), TestingConverter.IDENTITY);
         Model other = new TestingModel();
 
         Predicate<Model> filter = ModelFilterEmptyGeometry.INSTANCE;

--- a/src/test/java/com/ignfab/minalac/generator/processors/FloatMatrixProcessorTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/processors/FloatMatrixProcessorTest.java
@@ -1,0 +1,37 @@
+package com.ignfab.minalac.generator.processors;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.referencing.CRS;
+import org.geotools.referencing.operation.transform.IdentityTransform;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.util.AffineTransformation;
+
+import com.ignfab.minalac.generator.exceptions.TransformException;
+import com.ignfab.minalac.generator.inputs.FloatGeographicDataMatrix2d;
+import com.ignfab.minalac.generator.models.FloatMatrixModel;
+import com.ignfab.minalac.generator.utils.coordinates.MapToWorldConverter;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class FloatMatrixProcessorTest {
+    private static final MapToWorldConverter IDENTITY_CONVERTER = new MapToWorldConverter(IdentityTransform.create(2), new AffineTransformation());
+
+    @Test
+    public void test() throws FactoryException, TransformException {
+        CoordinateReferenceSystem crs2154 = CRS.decode("EPSG:2154");
+        AtomicBoolean initialized = new AtomicBoolean(false);
+        FloatMatrixProcessor processor = new FloatMatrixProcessor(crs -> {
+            initialized.set(crs == crs2154);
+            return IDENTITY_CONVERTER;
+        });
+        assertDoesNotThrow(() -> processor.initialize(crs2154)); // layerCrs is only validated but not actually used by the converter provider we gave above
+        assertTrue(initialized.get(), "processor initialized with given CRS");
+
+        // Validate capabilities of processor
+        assertTrue(processor.acceptedType().isAssignableFrom(FloatGeographicDataMatrix2d.class), "It accepts FloatGeographicDataMatrix2d");
+        assertTrue(FloatMatrixModel.class.isAssignableFrom(processor.modelType()), "It produces a FloatMatrixModel");
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/processors/FloatMatrixProcessorTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/processors/FloatMatrixProcessorTest.java
@@ -5,27 +5,23 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.geotools.api.referencing.FactoryException;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.referencing.CRS;
-import org.geotools.referencing.operation.transform.IdentityTransform;
 import org.junit.jupiter.api.Test;
-import org.locationtech.jts.geom.util.AffineTransformation;
 
 import com.ignfab.minalac.generator.exceptions.TransformException;
 import com.ignfab.minalac.generator.inputs.FloatGeographicDataMatrix2d;
 import com.ignfab.minalac.generator.models.FloatMatrixModel;
-import com.ignfab.minalac.generator.utils.coordinates.MapToWorldConverter;
+import com.ignfab.minalac.generator.utils.coordinates.TestingConverter;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 public class FloatMatrixProcessorTest {
-    private static final MapToWorldConverter IDENTITY_CONVERTER = new MapToWorldConverter(IdentityTransform.create(2), new AffineTransformation());
-
     @Test
     public void test() throws FactoryException, TransformException {
         CoordinateReferenceSystem crs2154 = CRS.decode("EPSG:2154");
         AtomicBoolean initialized = new AtomicBoolean(false);
         FloatMatrixProcessor processor = new FloatMatrixProcessor(crs -> {
             initialized.set(crs == crs2154);
-            return IDENTITY_CONVERTER;
+            return TestingConverter.IDENTITY;
         });
         assertDoesNotThrow(() -> processor.initialize(crs2154)); // layerCrs is only validated but not actually used by the converter provider we gave above
         assertTrue(initialized.get(), "processor initialized with given CRS");

--- a/src/test/java/com/ignfab/minalac/generator/processors/GeoToolsVectorProcessorTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/processors/GeoToolsVectorProcessorTest.java
@@ -10,12 +10,10 @@ import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.data.DataUtilities;
 import org.geotools.feature.SchemaException;
 import org.geotools.referencing.CRS;
-import org.geotools.referencing.operation.transform.IdentityTransform;
 import org.junit.jupiter.api.Test;
-import org.locationtech.jts.geom.util.AffineTransformation;
 
 import com.ignfab.minalac.generator.models.JTSGeometryModel;
-import com.ignfab.minalac.generator.utils.coordinates.MapToWorldConverter;
+import com.ignfab.minalac.generator.utils.coordinates.TestingConverter;
 import com.ignfab.minalac.generator.utils.iterator.Iterables;
 import com.ignfab.minalac.generator.utils.world2d.Positioned2d;
 import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
@@ -25,7 +23,6 @@ import static com.ignfab.minalac.generator.utils.iterator.IteratorTester.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class GeoToolsVectorProcessorTest {
-    private static final MapToWorldConverter IDENTITY_CONVERTER = new MapToWorldConverter(IdentityTransform.create(2), new AffineTransformation());
 
     @Test
     public void test() throws SchemaException, FactoryException {
@@ -33,7 +30,7 @@ public class GeoToolsVectorProcessorTest {
         AtomicBoolean initialized = new AtomicBoolean(false);
         GeoToolsVectorProcessor processor = new GeoToolsVectorProcessor(crs -> {
             initialized.set(crs == crs2154);
-            return IDENTITY_CONVERTER;
+            return TestingConverter.IDENTITY;
         });
         assertDoesNotThrow(() -> processor.initialize(crs2154)); // layerCrs is only validated but not actually used by the converter provider we gave above
         assertTrue(initialized.get(), "processor initialized with given CRS");

--- a/src/test/java/com/ignfab/minalac/generator/processors/post/JTSGeometryBufferPostProcessorTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/processors/post/JTSGeometryBufferPostProcessorTest.java
@@ -1,29 +1,26 @@
 package com.ignfab.minalac.generator.processors.post;
 
-import org.geotools.referencing.operation.transform.IdentityTransform;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Envelope;
-import org.locationtech.jts.geom.util.AffineTransformation;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKTReader;
 
 import com.ignfab.minalac.generator.exceptions.TransformException;
 import com.ignfab.minalac.generator.models.JTSGeometryModel;
-import com.ignfab.minalac.generator.utils.coordinates.MapToWorldConverter;
+import com.ignfab.minalac.generator.utils.coordinates.TestingConverter;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 public class JTSGeometryBufferPostProcessorTest {
     private JTSGeometryModel model;
 
-    private static final MapToWorldConverter IDENTITY_CONVERTER = new MapToWorldConverter(IdentityTransform.create(2), new AffineTransformation());
     private static final WKTReader WKT_READER = new WKTReader();
 
     @BeforeEach
     public void setUp() throws ParseException, TransformException {
-        model = new JTSGeometryModel(WKT_READER.read("POLYGON ((0 0, 5 0, 5 5, 0 5, 0 0))"), IDENTITY_CONVERTER);
+        model = new JTSGeometryModel(WKT_READER.read("POLYGON ((0 0, 5 0, 5 5, 0 5, 0 0))"), TestingConverter.IDENTITY);
     }
 
     private JTSGeometryModel process(double buffer) {

--- a/src/test/java/com/ignfab/minalac/generator/utils/coordinates/TestingConverter.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/coordinates/TestingConverter.java
@@ -1,0 +1,19 @@
+package com.ignfab.minalac.generator.utils.coordinates;
+
+import org.geotools.api.referencing.operation.MathTransform;
+import org.geotools.referencing.operation.transform.IdentityTransform;
+import org.locationtech.jts.geom.util.AffineTransformation;
+
+/**
+ * A {@link MapToWorldConverter} for testing purposes.
+ */
+public final class TestingConverter extends MapToWorldConverter {
+    /**
+     * A testing {@code MapToWorldConverter} that does no transformation.
+     */
+    public static final TestingConverter IDENTITY = new TestingConverter(IdentityTransform.create(2), new AffineTransformation());
+
+    private TestingConverter(MathTransform crsTransform, AffineTransformation postTransform) {
+        super(crsTransform, postTransform);
+    }
+}


### PR DESCRIPTION
### Description
Integration of the following commits from `fds` of [PR#126](https://github.com/ignfab/minalac-generator/pull/126):
+  (0c13946b) refactor(processor): Simplify processor common operation
+  (b350a970) refactor(provider): Add common Provider.Result implementation

See [sheet](https://ignf.sharepoint.com/:x:/r/sites/IGNfab/Documents%20partages/minalac-generator%20-%20Integration%20FDS%20-%20main/2025-10-16_SuiviIntegrationFDSMain.xlsx?d=w31771745a4c34814b011ac1b37b3b2ea&csf=1&web=1&e=a0BXbC) of functionality to integrate.

### Notes
+ `Provider.MultiResult` is not used, on fds was only used by `LASTiledDataProvider`.
+ `Provider.SimpleResult` is used `WMSFloatBilDataProvider` and `GeoTiffDataProvider` (Was also used by `LASDataProvider` and `CityJSONDataProvider`)

### TODOs
- [x] Squash

### Self-checks

- [x] The code has unit tests associated
- [x] The code has Javadoc Comments associated
- ~~[ ] Complex / Unexpected code is explained / justified with a small comment~~
- ~~[ ] Relevant documentation inside the `/docs` folder has been updated~~
- [x] All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [x] The texts have been proofread (documentation, error messages, logs, comments...)
