### PR TITLE
Expose min/max heightmaps

### DIFF
--- a/src/main/java/com/ignfab/minalac/generator/world/VoxelTile.java
+++ b/src/main/java/com/ignfab/minalac/generator/world/VoxelTile.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.Iterator;
 
 import com.ignfab.minalac.generator.generation.heightmaps.Heightmap;
+import com.ignfab.minalac.generator.generation.heightmaps.ReadableHeightmap;
 import com.ignfab.minalac.generator.placeables.Placeable;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 
@@ -16,11 +17,14 @@ public abstract class VoxelTile {
      */
     private WorldBBox3d limits;
     /**
-     * Heightmap representing the altitude of the highest voxels.
+     * Heightmap below which no voxel has been placed.
+     * It keeps track of the lowest voxels ever placed, but does not necessarily represent the current lowest voxels.
      */
     protected Heightmap minimum;
+
     /**
-     * Heightmap representing the altitude of the lowest voxels.
+     * Heightmap above which no voxel has been placed.
+     * It keeps track of the highest voxels ever placed, but does not necessarily represent the current highest voxels.
      */
     protected Heightmap maximum;
 
@@ -98,5 +102,23 @@ public abstract class VoxelTile {
             maximum.set(x, y, z);
         if (z < minimum.get(x, y))
             minimum.set(x, y, z);
+    }
+
+    /**
+     * {@return a read-only heightmap below which no voxel has been placed}
+     * Can be used as a starting point to find the lowest voxels.
+     * Please note that its values might decrease as it is updated when voxels are placed.
+     */
+    public ReadableHeightmap minimum() {
+        return minimum;
+    }
+
+    /**
+     * {@return a read-only heightmap above which no voxel has been placed}
+     * Can be used as a starting point to find the highest voxels.
+     * Please note that its values might increase as it is updated when voxels are placed.
+     */
+    public ReadableHeightmap maximum() {
+        return maximum;
     }
 }


### PR DESCRIPTION
### Description
Integration of the following commit from `fds` of [PR#126](https://github.com/ignfab/minalac-generator/pull/126):
+  (e9931af7) feat(voxel): Expose min & max placed voxel in column from tile

See [sheet](https://ignf.sharepoint.com/:x:/r/sites/IGNfab/Documents%20partages/minalac-generator%20-%20Integration%20FDS%20-%20main/2025-10-16_SuiviIntegrationFDSMain.xlsx?d=w31771745a4c34814b011ac1b37b3b2ea&csf=1&web=1&e=a0BXbC) of functionality to integrate.

### Self-checks

- [x] The code has unit tests associated
- [x] The code has Javadoc Comments associated
- ~~[ ] Complex / Unexpected code is explained / justified with a small comment~~
- ~~[ ] Relevant documentation inside the `/docs` folder has been updated~~
- [x] All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [x] The texts have been proofread (documentation, error messages, logs, comments...)