### PR TITLE
fix: Add a missing policy on `full.yaml`

### DIFF
--- a/examples/processes/full.yaml
+++ b/examples/processes/full.yaml
@@ -38,6 +38,7 @@ forEachTile:
       - type: truncate
         metadata: height
         method: round
+        ifMissing: ignore
       - type: default
         metadata: height
         value: 5


### PR DESCRIPTION
### Description
Quick fix on `full.yaml`: an ignore `ifMissing` policy is needed on fetchBuildings task as some buildings don't have `hauteur` metadata.

### Self-checks

- ~~The code has unit tests associated~~
- ~~The code has Javadoc Comments associated~~
- ~~Complex / Unexpected code is explained / justified with a small comment~~
- ~~Relevant documentation inside the `/docs` folder has been updated~~
- ~~All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)~~
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [x] The texts have been proofread (documentation, error messages, logs, comments...)