### PR TITLE
Make  always return something, eventually the default voxel

### DIFF
--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxel.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxel.java
@@ -15,6 +15,12 @@ import com.ignfab.minalac.generator.world.VoxelTile;
  * A voxel in Minecraft, known as block, consists of two parameters: type and state properties.
  */
 public class MCVoxel implements Placeable {
+
+    /**
+     * Default voxel used on map initialization.
+     */
+    public static final MCVoxel DEFAULT_VOXEL = new MCVoxel("minecraft:air");
+
     /**
      * The block type string.
      * @see <a href="https://minecraft.wiki/w/Block">List of block types (Minecraft Wiki)</a>

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelTile.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelTile.java
@@ -91,13 +91,15 @@ public class MCVoxelTile extends VoxelTile {
     /**
      * {@inheritDoc}
      * The returned voxel is not necessarily one placed using {@link Placeable#place}.
-     * It may be an air block created when a {@link Region} is initialized.
+     * It may be an air block created when the world is initialized.
+     * <p>
+     * If you try to get a voxel outside the tile limits, it will return {@link MCVoxel#DEFAULT_VOXEL}.
      */
     @Override
     public Placeable getVoxel(int x, int y, int z) {
         Region region = regions.get(Region.computeKeyFromBlock(x, -y - 1));
 
-        if (region == null) return null;
+        if (region == null) return MCVoxel.DEFAULT_VOXEL;
 
         // (World coords to In-Game coords) X/Y/Z => X/Z/-Y-1
         return region.getBlock(x, z, -y - 1);

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/Region.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/Region.java
@@ -107,7 +107,7 @@ public record Region(int regionX, int regionZ, MCAFile file) {
      */
     public MCVoxel getBlock(int blockX, int blockY, int blockZ) {
         CompoundTag block = file().getBlockStateAt(blockX, blockY, blockZ);
-        return (block == null) ? null : MCVoxel.fromBlockState(block);
+        return (block == null) ? MCVoxel.DEFAULT_VOXEL : MCVoxel.fromBlockState(block);
     }
 
     /**

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxel.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxel.java
@@ -11,6 +11,12 @@ import com.ignfab.minalac.generator.world.VoxelTile;
  * @see <a href="https://github.com/minetest/minetest/blob/master/src/mapnode.h#L138">Minetest's MapNode class</a> for more information about the node's parameters
  */
 public class MTVoxel implements Placeable {
+
+    /**
+     * Default voxel used on map initialization.
+     */
+    public static final MTVoxel DEFAULT_VOXEL = new MTVoxel("air", (byte) 0, (byte) 0);
+
     /**
      * The node type string.
      * @see <a href="https://wiki.minetest.net/Games/Minetest_Game/Nodes">List of node types (Minetest Wiki)</a>

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelTile.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelTile.java
@@ -14,6 +14,7 @@ import com.ignfab.minalac.generator.world.VoxelTile;
  * Implementation of {@link VoxelTile} for Minetest.
  */
 public class MTVoxelTile extends VoxelTile {
+
     private final SQLiteMapWriter mapWriter;
 
     private final Long2ObjectMap<Block> blocks = Long2ObjectMaps.synchronize(new Long2ObjectOpenHashMap<>());
@@ -79,14 +80,16 @@ public class MTVoxelTile extends VoxelTile {
     /**
      * {@inheritDoc}
      * The returned voxel is not necessarily one placed using {@link Placeable#place}.
-     * It may be an air node created when a {@link Block} is initialized.
+     * It may be an air node created when the world is initialized.
+     * <p>
+     * If you try to get a voxel outside the tile limits, it will return {@link MTVoxel#DEFAULT_VOXEL}.
      */
     @Override
     public Placeable getVoxel(int x, int y, int z) {
         // X/Y/Z => X/Z/Y
         Block block = getBlock(x >> 4, z >> 4, y >> 4);
 
-        if (block == null) return null;
+        if (block == null) return MTVoxel.DEFAULT_VOXEL;
 
         // X/Y/Z => X/Z/Y
         return block.get(x & 0x0f, z & 0x0f, y & 0x0f);

--- a/src/main/java/com/ignfab/minalac/generator/world/VoxelTile.java
+++ b/src/main/java/com/ignfab/minalac/generator/world/VoxelTile.java
@@ -59,7 +59,7 @@ public abstract class VoxelTile {
      * @param x x-coordinate
      * @param y y-coordinate
      * @param z z-coordinate
-     * @return the corresponding voxel and {@code null} if the voxel doesn't exist.
+     * @return the corresponding voxel
      */
     public abstract Placeable getVoxel(int x, int y, int z);
 

--- a/src/test/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelTileTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelTileTest.java
@@ -11,13 +11,18 @@ import com.ignfab.minalac.generator.world.MapWriteException;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class MCVoxelTileTest {
+    private static final MCVoxel STONE = new MCVoxel("minecraft:stone");
+
+    private MCVoxelTile initTile(WorldBBox3d limits) {
+        MCVoxelWorld world = assertDoesNotThrow(() -> new MCVoxelWorld(null));
+        world.setLimits(limits);
+        assertDoesNotThrow(world::initialize);
+        return world.newTile(limits);
+    }
 
     @Test
     public void testIsOutOfLimits() throws MapWriteException {
-        WorldBBox3d limits = new WorldBBox3d(new WorldCoords3d(-10, -20, 0), new WorldCoords3d(20, 30, 40));
-        MCVoxelWorld world = new MCVoxelWorld(null);
-        world.setLimits(limits);
-        MCVoxelTile tile = world.newTile(limits);
+        MCVoxelTile tile = initTile(new WorldBBox3d(new WorldCoords3d(-10, -20, 0), new WorldCoords3d(20, 30, 40)));
 
         // X/Y/Z => X/Z/-Y
         assertFalse(tile.isOutOfLimits(-10, 0, 19));
@@ -35,24 +40,18 @@ public class MCVoxelTileTest {
 
     @Test
     public void testGetVoxel() throws MapWriteException {
-        WorldBBox3d limits = new WorldBBox3d(new WorldCoords3d(-20, -20, 0), new WorldCoords3d(50, 50, 255));
-        MCVoxelWorld world = new MCVoxelWorld(null);
-        world.setLimits(limits);
-        assertDoesNotThrow(world::initialize);
-
-        MCVoxelTile tile = world.newTile(limits);
-        MCVoxel stone = new MCVoxel("minecraft:stone");
+        MCVoxelTile tile = initTile(new WorldBBox3d(new WorldCoords3d(-20, -20, 0), new WorldCoords3d(50, 50, 255)));
         MCVoxel barrel = new MCVoxel("minecraft:barrel", Map.of(
             "facing", "south",
             "open", "true"
         ));
         MCVoxel dirt = new MCVoxel("minecraft:dirt");
         barrel.place(tile, -9, -8, 1);
-        stone.place(tile, 4, -3, 78);
+        STONE.place(tile, 4, -3, 78);
         dirt.place(tile, -7, 5, 55);
 
         assertEquals(barrel, tile.getVoxel(-9, -8, 1));
-        assertEquals(stone, tile.getVoxel(4, -3, 78));
+        assertEquals(STONE, tile.getVoxel(4, -3, 78));
         assertEquals(dirt, tile.getVoxel(-7, 5, 55));
 
         // Minecraft zMax
@@ -61,5 +60,18 @@ public class MCVoxelTileTest {
         // Minecraft zMin
         barrel.place(tile, -9, -8, 0);
         assertEquals(barrel, tile.getVoxel(-9, -8, 0));
+    }
+
+    @Test
+    public void testGetDefaultVoxel() {
+        MCVoxelTile tile = initTile(new WorldBBox3d(new WorldCoords3d(-32, -32, 0), new WorldCoords3d(32, 32, 255)));
+        STONE.place(tile, -12, 12, 5);
+
+        // Region created, chunk created with only one voxel
+        assertEquals(MCVoxel.DEFAULT_VOXEL, tile.getVoxel(-12, 13, 98));
+        // Region created, but no chunk
+        assertEquals(MCVoxel.DEFAULT_VOXEL, tile.getVoxel(-17, 17, 39));
+        // Returns something even if the region is not created
+        assertEquals(MCVoxel.DEFAULT_VOXEL, tile.getVoxel(16, 16, 24));
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelTileTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/outputs/minetest/MTVoxelTileTest.java
@@ -9,46 +9,54 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MTVoxelTileTest {
-    private static MTVoxelTile tile;
-    private static MTVoxel grass;
-    private static MTVoxel dirt;
-    private static MTVoxel stone;
+    private static final MTVoxel GRASS = new MTVoxel("default:dirt_with_grass", (byte) 0, (byte) 0);
+    private static final MTVoxel DIRT = new MTVoxel("default:dirt", (byte) 0, (byte) 0);
+    private static final MTVoxel STONE = new MTVoxel("default:stone", (byte) 0, (byte) 0);
 
-    private void initWorld(WorldBBox3d limits) {
+    private MTVoxelTile initTile(WorldBBox3d limits) {
         MTVoxelWorld world = assertDoesNotThrow(() -> new MTVoxelWorld(null));
         world.setLimits(limits);
         assertDoesNotThrow(world::initialize);
-
-        tile = world.newTile(limits);
-        grass = new MTVoxel("default:dirt_with_grass", (byte) 0, (byte) 0);
-        dirt = new MTVoxel("default:dirt", (byte) 0, (byte) 0);
-        stone = new MTVoxel("default:stone", (byte) 0, (byte) 0);
+        return world.newTile(limits);
     }
 
     @Test
     public void testGetVoxel() {
-        initWorld(new WorldBBox3d(new WorldCoords3d(-1, -2, -5), new WorldCoords3d(2, 3, 6)));
-        grass.place(tile, -1, -2, -3);
-        stone.place(tile, 0, -1, 1);
-        dirt.place(tile, -1, 0, 0);
+        MTVoxelTile tile;
 
-        assertEquals(grass, tile.getVoxel(-1, -2, -3));
-        assertEquals(stone, tile.getVoxel(0, -1, 1));
-        assertEquals(dirt, tile.getVoxel(-1, 0, 0));
+        tile = initTile(new WorldBBox3d(new WorldCoords3d(-1, -2, -5), new WorldCoords3d(2, 3, 6)));
+        GRASS.place(tile, -1, -2, -3);
+        STONE.place(tile, 0, -1, 1);
+        DIRT.place(tile, -1, 0, 0);
 
-        initWorld(new WorldBBox3d(new WorldCoords3d(-5, -5, -20), new WorldCoords3d(50, 50, 500)));
+        assertEquals(GRASS, tile.getVoxel(-1, -2, -3));
+        assertEquals(STONE, tile.getVoxel(0, -1, 1));
+        assertEquals(DIRT, tile.getVoxel(-1, 0, 0));
+
+        tile = initTile(new WorldBBox3d(new WorldCoords3d(-5, -5, -20), new WorldCoords3d(50, 50, 500)));
 
         // Extremum of a map block [-16, -1]
-        stone.place(tile, -2, -3, -1);
-        grass.place(tile, -2, -3, -16);
+        STONE.place(tile, -2, -3, -1);
+        GRASS.place(tile, -2, -3, -16);
         // Extremum of another map block [16, 31]
-        dirt.place(tile, 37, 16, 387);
-        stone.place(tile, 37, 31, 387);
+        DIRT.place(tile, 37, 16, 387);
+        STONE.place(tile, 37, 31, 387);
 
         // Testing on MT max limits
-        assertEquals(stone, tile.getVoxel(-2, -3, -1));
-        assertEquals(grass, tile.getVoxel(-2, -3, -16));
-        assertEquals(dirt, tile.getVoxel(37, 16, 387));
-        assertEquals(stone, tile.getVoxel(37, 31, 387));
+        assertEquals(STONE, tile.getVoxel(-2, -3, -1));
+        assertEquals(GRASS, tile.getVoxel(-2, -3, -16));
+        assertEquals(DIRT, tile.getVoxel(37, 16, 387));
+        assertEquals(STONE, tile.getVoxel(37, 31, 387));
+    }
+
+    @Test
+    public void testGetDefaultVoxel() {
+        MTVoxelTile tile = initTile(new WorldBBox3d(new WorldCoords3d(-5, -5, -20), new WorldCoords3d(50, 50, 500)));
+        GRASS.place(tile, 1, 0, 0);
+
+        // Block created with only one voxel
+        assertEquals(MTVoxel.DEFAULT_VOXEL, tile.getVoxel(3, 2, 7));
+        // Returns something even if the block is not created.
+        assertEquals(MTVoxel.DEFAULT_VOXEL, tile.getVoxel(49, 49, 71));
     }
 }


### PR DESCRIPTION
### Changes

Make `VoxelTile#getVoxel` always return something, eventually the default voxel

#### Feature description

Add a constant in `MCVoxel` and `MTVoxel` which correspond a voxel by default used in `VoxelTile#getVoxel` when we try to get a voxel which located in a the region or in a the block not defined.

### Self-checks

- [x] The code has unit tests associated
- [x] The code has Javadoc Comments associated
- ~~[ ] Complex / Unexpected code is explained / justified with a small comment~~
- ~~[ ] Relevant documentation inside the `/docs` folder has been updated~~
- [x] All examples in `examples/` work the same (or have been adapted if subject to changes in this PR)
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [ ] The texts have been proofread (documentation, error messages, logs, comments...)
