### PR TITLE
Set a world name with `mapName` field - MINALAC-106

### DIFF
--- a/docs/usage/parameters/Parameters.md
+++ b/docs/usage/parameters/Parameters.md
@@ -24,6 +24,7 @@ Only root Yaml parameters are described here. More specific aspects could be fou
 Here is a basic generation parameters set that generates a map of 1000x1000 voxels around IGN building at Saint-Mandé (FR), in Minetest format, with 1 meter voxels in every direction:
 
 ```yaml
+worldName: My World
 references:
   - &voxel-surface default:cobble
   - &voxel-border default:stone
@@ -96,6 +97,7 @@ forEachTile:
 
 ## Fields description
 
+- `worldName`: World name (text, default `Minalac`)
 - `references`: Ignored field where references (or other content) can be put in
 - `area`: Area to be rendered
   - `center`: Coordinates of the area's center point, expressed in the commonly used coordinate system (EPSG:4326)

--- a/examples/places/bagnolet.yaml
+++ b/examples/places/bagnolet.yaml
@@ -1,4 +1,5 @@
 # Highway jam at Porte de Bagnolet
+mapName: Porte de Bagnolet
 verticalScale: 1.0
 horizontalScale: 1.0
 area:

--- a/examples/places/boulouris.yaml
+++ b/examples/places/boulouris.yaml
@@ -1,4 +1,5 @@
 # Dead ends in Saint-Raphael/Boulouris
+mapName: Saint-Raphaël - Boulouris
 verticalScale: 1.0
 horizontalScale: 1.0
 area:

--- a/examples/places/ign.yaml
+++ b/examples/places/ign.yaml
@@ -1,4 +1,5 @@
 # I love Saint-Mandé
+mapName: Saint-Mandé - IGN
 verticalScale: 1.0
 horizontalScale: 1.0
 area:

--- a/examples/places/lakeSaintMande.yaml
+++ b/examples/places/lakeSaintMande.yaml
@@ -1,4 +1,5 @@
 # Lake of Saint-Mandé
+mapName: Saint-Mandé - Lake
 verticalScale: 1.0
 horizontalScale: 1.0
 area:

--- a/examples/places/martrou.yaml
+++ b/examples/places/martrou.yaml
@@ -1,4 +1,5 @@
 # Bridge over the Charente river at Martrou
+mapName: Martrou
 verticalScale: 1.0
 horizontalScale: 1.0
 area:

--- a/examples/places/millau.yaml
+++ b/examples/places/millau.yaml
@@ -1,4 +1,5 @@
 # Viaduct at Millau
+mapName: Millau
 verticalScale: 1.0
 horizontalScale: 1.0
 area:

--- a/examples/places/serreponcon.yaml
+++ b/examples/places/serreponcon.yaml
@@ -1,4 +1,5 @@
 # Lake of Serre-Ponçon
+mapName: Serre-Ponçon
 verticalScale: 1.0
 horizontalScale: 1.0
 area:

--- a/examples/places/stlazare.yaml
+++ b/examples/places/stlazare.yaml
@@ -1,4 +1,5 @@
 # Rails and bridges at Saint-Lazare station
+mapName: Saint-Lazare
 verticalScale: 1.0
 horizontalScale: 1.0
 area:

--- a/examples/places/villeneuve.yaml
+++ b/examples/places/villeneuve.yaml
@@ -1,4 +1,5 @@
 # Railroads entanglement at Villeneuve
+mapName: Villeneuve
 verticalScale: 1.0
 horizontalScale: 1.0
 area:

--- a/src/main/java/com/ignfab/minalac/generator/MinalacGenerator.java
+++ b/src/main/java/com/ignfab/minalac/generator/MinalacGenerator.java
@@ -48,7 +48,6 @@ import com.ignfab.minalac.generator.parameters.tasks.SetSpawnTaskParams;
 import com.ignfab.minalac.generator.utils.execution.TaskFailedException;
 import com.ignfab.minalac.generator.utils.network.HttpTrustAllSSL;
 import com.ignfab.minalac.generator.world.MapWriteException;
-import com.ignfab.minalac.generator.world.VoxelWorldMetadata;
 
 /**
  * Main class of Minalac project.
@@ -173,9 +172,6 @@ public final class MinalacGenerator {
         System.out.printf("%nAll %d tiles generated and saved.%nSpent %ds generating and %ds saving.%n", numberOfTiles, generatingDuration.toSeconds(), mapSavingDuration.toSeconds());
 
         Instant finalizationStart = Instant.now();
-
-        VoxelWorldMetadata metadata = generation.world().getMetadata();
-        metadata.setWorldName("Minalac");
 
         generation.world().finalizeAndSave();
         System.out.printf("Generation finalization took %ds.%n", Duration.between(finalizationStart, Instant.now()).toSeconds());

--- a/src/main/java/com/ignfab/minalac/generator/parameters/GenerationCreator.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/GenerationCreator.java
@@ -12,6 +12,7 @@ import org.geotools.referencing.crs.DefaultGeographicCRS;
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.tasks.TileTask;
 import com.ignfab.minalac.generator.utils.random.Seed;
+import com.ignfab.minalac.generator.world.VoxelWorld;
 
 /**
  * This class is used to create a new {@link Generation} from {@link GenerationParams} parameters.
@@ -43,8 +44,10 @@ public final class GenerationCreator {
             throw new RuntimeException("Wasn't able to convert the coordinates", e);
         }
 
+        VoxelWorld world = params.format.createWorld();
+        world.getMetadata().setWorldName(params.worldName);
         Generation generation = new Generation(
-            params.format.createWorld(),
+            world,
             new Seed(params.seed),
             targetCrs,
             center[0],

--- a/src/main/java/com/ignfab/minalac/generator/parameters/GenerationParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/GenerationParams.java
@@ -23,8 +23,11 @@ import com.ignfab.minalac.generator.parameters.tasks.TileTaskParams;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class GenerationParams {
-    // For now :
-    // - field mapName is not yet implemented (should probably be)
+    /**
+     * World name.
+     */
+    @JsonSetter(nulls = Nulls.SKIP)
+    public String worldName = "Minalac";
 
     /**
      * A placeholder for Yaml references than does not go anywhere else.
@@ -106,6 +109,8 @@ public class GenerationParams {
      * @throws IllegalArgumentException is any of the parameters is invalid.
      */
     public void validate() throws IllegalArgumentException {
+        if (worldName.isBlank())
+            throw new IllegalArgumentException("The field worldName cannot be empty or contain only whitespace.");
         if (verticalScale <= 0)
             throw new IllegalArgumentException("The field verticalScale must be greater than 0");
         if (horizontalScale <= 0)

--- a/src/test/java/com/ignfab/minalac/generator/parameters/GenerationParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/GenerationParamsTest.java
@@ -104,7 +104,14 @@ public class GenerationParamsTest {
     }
 
     @Test
+    public void testValidateWorldName() {
+        params.worldName = " ";
+        assertThrows(IllegalArgumentException.class, params::validate);
+    }
+
+    @Test
     public void testCreate() throws ParseException {
+        params.worldName = "test";
         params.verticalScale = 3.0;
         params.horizontalScale = 4.0;
         params.crs = "EPSG:5643";
@@ -125,6 +132,7 @@ public class GenerationParamsTest {
         Generation generation = params.create(100);
 
         assertNotNull(generation);
+        assertEquals("test", generation.world().getMetadata().getWorldName());
         assertEquals(50, generation.world().limits().sizeX());
         assertEquals(75, generation.world().limits().sizeY());
         assertEquals(3.0, generation.getVerticalScale(), 0.001);


### PR DESCRIPTION
### Issue

MINALAC-106

### Changes

Handle custom map name.

#### Feature description

Remove the default map name from the main class, add a `mapName` field, and when calling the `create` function in `GenerationCreator`, set the `mapName` in the `VoxelWorld` metadata.

#### Showcase

<img width="616" height="198" alt="image" src="https://github.com/user-attachments/assets/41a54248-8c5e-4707-8b3b-95086187e334" />

### Self-checks

- [x] The code has unit tests associated
- [x] The code has Javadoc Comments associated
- ~~[ ] Complex / Unexpected code is explained / justified with a small comment~~
- [x] Relevant documentation inside the `/docs` folder has been updated
- [x] All examples in `docs/usage/Examples.md` work the same (or have been adapted if subject to changes in this PR)
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [ ] The texts have been proofread (documentation, error messages, logs, comments...)
