### PR TITLE
Write the parameters file in the world root directory - MINALAC-141

### DIFF
--- a/src/main/java/com/ignfab/minalac/generator/MinalacGenerator.java
+++ b/src/main/java/com/ignfab/minalac/generator/MinalacGenerator.java
@@ -1,6 +1,8 @@
 package com.ignfab.minalac.generator;
 
 import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
@@ -120,7 +122,8 @@ public final class MinalacGenerator {
         parser.registerParams("geometryBuffer", JTSGeometryBufferPostProcessorParams.class);
         parser.registerParams("remap", MetadataValueMappingPostProcessorParams.class);
 
-        Generation generation = parser.parse(cli.readParameters()).create(maxTileSize);
+        String parameters = cli.readParameters();
+        Generation generation = parser.parse(parameters).create(maxTileSize);
 
         System.out.printf("Generation initialization took %ds.%n", Duration.between(initializationStart, Instant.now()).toSeconds());
         if (cli.generationDisabled()) {
@@ -174,6 +177,18 @@ public final class MinalacGenerator {
         Instant finalizationStart = Instant.now();
 
         generation.world().finalizeAndSave();
+        File parametersFile = new File(destination, "minalac.yaml");
+        try {
+            parametersFile.createNewFile();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        try (FileWriter writer = new FileWriter(parametersFile)) {
+            writer.write(parameters);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
         System.out.printf("Generation finalization took %ds.%n", Duration.between(finalizationStart, Instant.now()).toSeconds());
         System.out.printf("Total: %ds.%nDone.%n", Duration.between(start, Instant.now()).toSeconds());
     }


### PR DESCRIPTION
### Issue

MINALAC-141

### Changes

In the main file, add a small piece of code to write a file containing the world parameters.

#### Feature description

Use the `cli.readParameters()` function to get the parameters and write them to a file named `minalac.yaml` in the world root directory.

#### Showcase

<img width="524" height="177" alt="image" src="https://github.com/user-attachments/assets/f9e50920-4606-4dce-b8e5-96e957a86acf" />

### Self-checks

- ~~[ ] The code has unit tests associated~~
- ~~[ ] The code has Javadoc Comments associated~~
- ~~[ ] Complex / Unexpected code is explained / justified with a small comment~~
- [ ] Relevant documentation inside the `/docs` folder has been updated
- [x] All examples in `examples/` work the same (or have been adapted if subject to changes in this PR)
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [ ] The texts have been proofread (documentation, error messages, logs, comments...)
