### PR TITLE
Write the parameters file in the world root directory

### DIFF
--- a/.github/workflows/parameters-tests.yml
+++ b/.github/workflows/parameters-tests.yml
@@ -35,7 +35,7 @@ jobs:
           for FORMAT in $FORMATS; do
             for PLACE in $PLACES; do
               for PROCESS in $PROCESSES; do
-                output=$(./generate.sh -g $FORMAT $PROCESS $PLACE 2>&1)
+                output=$(./generate.sh -g -s $FORMAT $PROCESS $PLACE 2>&1)
                 if [ $? -ne 0 ]; then
                   echo "::group::Error parsing parameters: format=$FORMAT, place=$PLACE, process=$PROCESS"
                   echo "Parameters used:"

--- a/generate.sh
+++ b/generate.sh
@@ -40,7 +40,6 @@ while [[ "$1" == "-"* ]]; do
     case $opt in
         -g)
             generator_opt="$generator_opt --generation-disabled"
-            unset output_dir_needed
             ;;
         -s)
             generator_opt="$generator_opt --save-disabled"

--- a/src/main/java/com/ignfab/minalac/generator/MinalacGenerator.java
+++ b/src/main/java/com/ignfab/minalac/generator/MinalacGenerator.java
@@ -1,6 +1,7 @@
 package com.ignfab.minalac.generator;
 
 import java.io.File;
+import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
@@ -45,6 +46,7 @@ import com.ignfab.minalac.generator.parameters.tasks.RenderBuildingsTaskParams;
 import com.ignfab.minalac.generator.parameters.tasks.RenderHeightmapTaskParams;
 import com.ignfab.minalac.generator.parameters.tasks.RenderVectorsTaskParams;
 import com.ignfab.minalac.generator.parameters.tasks.SetSpawnTaskParams;
+import com.ignfab.minalac.generator.utils.FileHelpers;
 import com.ignfab.minalac.generator.utils.execution.TaskFailedException;
 import com.ignfab.minalac.generator.utils.network.HttpTrustAllSSL;
 import com.ignfab.minalac.generator.world.MapWriteException;
@@ -73,12 +75,20 @@ public final class MinalacGenerator {
         // Command line arguments parsing & basic processing
         MinalacGeneratorCLI cli = new MinalacGeneratorCLI();
         cli.parse(args);
-        File destination;
 
+        File destination;
+        String parameters = cli.readParameters();
         if (cli.saveDisabled())
             destination = null;
-        else
+        else {
             destination = cli.outputPath().toFile();
+            // Write the parameters file in the world root directory
+            try {
+                FileHelpers.write(new File(destination, "parameters.yaml"), parameters);
+            } catch (IOException e) {
+                throw new MapWriteException("Failed to write parameters.yaml", e);
+            }
+        }
 
         Integer maxTileSize = cli.maxTileSize();
 
@@ -120,7 +130,7 @@ public final class MinalacGenerator {
         parser.registerParams("geometryBuffer", JTSGeometryBufferPostProcessorParams.class);
         parser.registerParams("remap", MetadataValueMappingPostProcessorParams.class);
 
-        Generation generation = parser.parse(cli.readParameters()).create(maxTileSize);
+        Generation generation = parser.parse(parameters).create(maxTileSize);
 
         System.out.printf("Generation initialization took %ds.%n", Duration.between(initializationStart, Instant.now()).toSeconds());
         if (cli.generationDisabled()) {


### PR DESCRIPTION
### Issue

MINALAC-141

### Changes

In the main file, add a small piece of code to write a file containing the world parameters.

#### Feature description

Use the `cli.readParameters()` function to get the parameters and write them to a file named `minalac.yaml` in the world root directory.

#### Showcase

<img width="524" height="177" alt="image" src="https://github.com/user-attachments/assets/f9e50920-4606-4dce-b8e5-96e957a86acf" />

### Self-checks

- ~~[ ] The code has unit tests associated~~
- ~~[ ] The code has Javadoc Comments associated~~
- ~~[ ] Complex / Unexpected code is explained / justified with a small comment~~
- [ ] Relevant documentation inside the `/docs` folder has been updated
- [x] All examples in `examples/` work the same (or have been adapted if subject to changes in this PR)
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [ ] The texts have been proofread (documentation, error messages, logs, comments...)
