### PR TITLE
refactor(structures): Make placeable structures immutables

### DIFF
--- a/src/main/java/com/ignfab/minalac/generator/parameters/placeables/structures/BlueprintPlaceableStructureParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/placeables/structures/BlueprintPlaceableStructureParams.java
@@ -162,7 +162,7 @@ public class BlueprintPlaceableStructureParams extends PlaceableStructureParams.
     }
 
     @Override
-    public void apply(Seed seed, PlaceableStructure structure) {
+    public void apply(Seed seed, PlaceableStructure.Builder structureBuilder) {
         // Prepare translation form chars to placeables
         placeables = new HashMap<>();
         // Default space char for no voxel
@@ -174,15 +174,15 @@ public class BlueprintPlaceableStructureParams extends PlaceableStructureParams.
 
         switch (axes.size()) {
             // Process string along first axis
-            case 1 -> process1d(structure, position, axes.get(0), blueprint.data1d());
+            case 1 -> process1d(structureBuilder, position, axes.get(0), blueprint.data1d());
             // Process list of strings along first axis for list items and second axis for strings chars
-            case 2 -> process2d(structure, position, axes.get(0), axes.get(1), blueprint.data2d());
+            case 2 -> process2d(structureBuilder, position, axes.get(0), axes.get(1), blueprint.data2d());
             // Process list of lists of strings, along first axis first,
             // then second and third axes for child list items and final strings chars.
             // We process lines upside down for a more natural reading
             case 3 -> {
                 for (Iterator<LinkedList<String>> it = blueprint.data3d().descendingIterator(); it.hasNext();) {
-                    process2d(structure, position, axes.get(1), axes.get(2), it.next());
+                    process2d(structureBuilder, position, axes.get(1), axes.get(2), it.next());
                     position = position.add(axes.get(0).direction);
                 }
             }
@@ -196,20 +196,20 @@ public class BlueprintPlaceableStructureParams extends PlaceableStructureParams.
         return placeable;
     }
 
-    private void process1d(PlaceableStructure structure, WorldCoords3d position, Axis axis, String data1d) {
+    private void process1d(PlaceableStructure.Builder structureBuilder, WorldCoords3d position, Axis axis, String data1d) {
         WorldCoords3d direction = axis.direction;
 
         for (char c : data1d.toCharArray()) {
-            structure.set(position, getPlaceable(c));
+            structureBuilder.set(position, getPlaceable(c));
             position = position.add(direction);
         }
     }
 
-    private void process2d(PlaceableStructure structure, WorldCoords3d position, Axis listAxis, Axis stringAxis, LinkedList<String> data2d) {
+    private void process2d(PlaceableStructure.Builder structureBuilder, WorldCoords3d position, Axis listAxis, Axis stringAxis, LinkedList<String> data2d) {
         WorldCoords3d direction = listAxis.direction;
         // We process lines upside down for a more natural reading
         for (Iterator<String> it = data2d.descendingIterator(); it.hasNext();) {
-            process1d(structure, position, stringAxis, it.next());
+            process1d(structureBuilder, position, stringAxis, it.next());
             position = position.add(direction);
         }
     }

--- a/src/main/java/com/ignfab/minalac/generator/parameters/placeables/structures/BoxPlaceableStructureParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/placeables/structures/BoxPlaceableStructureParams.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.annotation.Nulls;
 
 import com.ignfab.minalac.generator.parameters.placeables.PlaceableParams;
 import com.ignfab.minalac.generator.parameters.utils.WorldBBox3dParams;
-import com.ignfab.minalac.generator.placeables.Placeable;
 import com.ignfab.minalac.generator.placeables.PlaceableStructure;
 import com.ignfab.minalac.generator.utils.random.Seed;
 
@@ -51,8 +50,7 @@ public class BoxPlaceableStructureParams extends PlaceableStructureParams.Varian
     }
 
     @Override
-    public void apply(Seed seed, PlaceableStructure structure) {
-        Placeable placeable = put.create(seed);
-        structure.set(at.create(), placeable);
+    public void apply(Seed seed, PlaceableStructure.Builder structureBuilder) {
+        structureBuilder.set(at.create(), put.create(seed));
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/parameters/placeables/structures/PlaceableStructureParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/placeables/structures/PlaceableStructureParams.java
@@ -42,11 +42,11 @@ public final class PlaceableStructureParams extends PlaceableParams {
 
     @Override
     public PlaceableStructure create(Seed seed) {
-        PlaceableStructure structure = new PlaceableStructure();
+        PlaceableStructure.Builder structureBuilder = PlaceableStructure.builder();
         for (Variant param : params)
-            param.apply(seed, structure);
+            param.apply(seed, structureBuilder);
 
-        return structure;
+        return structureBuilder.build();
     }
 
     /**
@@ -96,12 +96,12 @@ public final class PlaceableStructureParams extends PlaceableParams {
 
         /**
          * Applies this parameters content to the given structure.
-         *
+         * <p>
          * It is used rather than a {@code create} method to allow merging several parameters into one structure.
          *
          * @param seed Random seed to use for this {@code PlaceableStructure}.
-         * @param structure Structure which put created voxels into
+         * @param structureBuilder Structure builder to put created placeables into
          */
-        public abstract void apply(Seed seed, PlaceableStructure structure);
+        public abstract void apply(Seed seed, PlaceableStructure.Builder structureBuilder);
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/placeables/PlaceableStructure.java
+++ b/src/main/java/com/ignfab/minalac/generator/placeables/PlaceableStructure.java
@@ -9,11 +9,26 @@ import com.ignfab.minalac.generator.world.VoxelTile;
 
 /**
  * {@code PlaceableStructure} is a {@link Placeable} consisting of placeables at given coordinate offsets.
- * The structure can be defined notably by using the methods {@link #set(WorldCoords3d, Placeable)} and {@link #remove(WorldCoords3d)}.
+ * The structure itself is immutable, but can be defined by using the {@link #builder()}.
  */
-public class PlaceableStructure implements Placeable {
-    private final Map<WorldCoords3d, Placeable> placeables = new HashMap<>();
-    private WorldBBox3d limits = null;
+public final class PlaceableStructure implements Placeable {
+    private final Map<WorldCoords3d, Placeable> placeables;
+    private final WorldBBox3d limits;
+
+    /**
+     * Reusable empty structure instance.
+     */
+    public static final PlaceableStructure EMPTY = new PlaceableStructure();
+
+    private PlaceableStructure() {
+        placeables = Map.of();
+        limits = WorldBBox3d.EMPTY;
+    }
+
+    private PlaceableStructure(Map<WorldCoords3d, Placeable> placeables) {
+        this.placeables = Map.copyOf(placeables);
+        limits = new WorldBBox3d(this.placeables.keySet().toArray(WorldCoords3d[]::new));
+    }
 
     /**
      * {@inheritDoc}
@@ -27,88 +42,11 @@ public class PlaceableStructure implements Placeable {
     }
 
     /**
-     * Adds, replaces or removes a placeable at the specified coordinates.
-     * If the provided placeable value is {@code null}, any placeable at the specified coordinates will be removed.
-     * Coordinates are relative.
-     *
-     * @param coords the relative {@code WorldCoords3d}
-     * @param placeable the placeable to be added or {@code null} value
-     */
-    public void set(WorldCoords3d coords, Placeable placeable) {
-        if (placeable == null)
-            placeables.remove(coords);
-        else
-            placeables.put(coords, placeable);
-
-        // Force limits recompute
-        limits = null;
-    }
-
-    /**
-     * Adds, replaces or removes a placeable at the specified coordinates.
-     * If the provided placeable is {@code null}, any placeable at the specified coordinates will be removed.
-     * Coordinates are relative.
-     *
-     * @param x the x-coordinate value
-     * @param y the y-coordinate value
-     * @param z the z-coordinate value
-     * @param placeable the placeable to be added or {@code null} value
-     */
-    public void set(int x, int y, int z, Placeable placeable) {
-        set(new WorldCoords3d(x, y, z), placeable);
-    }
-
-    /**
-     * Adds, replaces or removes placeables at all the coordinates within the specified bounding box.
-     * If the provided placeable is {@code null}, any placeable within the bounding box will be removed.
-     *
-     * @param bbox  the bounding box
-     * @param placeable the placeable to be added or {@code null} value
-     */
-    public void set(WorldBBox3d bbox, Placeable placeable) {
-        if (placeable == null)
-            remove(bbox);
-        else
-            for (WorldCoords3d coords : bbox)
-                set(coords, placeable);
-    }
-
-    /**
-     * Removes the placeable, if it exists, at the specified coordinates.
-     *
-     * @param coords the relative {@code WorldCoords3d}
-     */
-    public void remove(WorldCoords3d coords) {
-        set(coords, null);
-    }
-
-    /**
-     * Removes the placeable, if it exists, at the specified coordinates.
-     *
-     * @param x the x-coordinate value
-     * @param y the y-coordinate value
-     * @param z the z-coordinate value
-     */
-    public void remove(int x, int y, int z) {
-        remove(new WorldCoords3d(x, y, z));
-    }
-
-    /**
-     * Removes all placeables within the provided BBOX.
-     *
-     * @param bbox the bounding box
-     */
-    public void remove(WorldBBox3d bbox) {
-        for (WorldCoords3d coords : bbox)
-            remove(coords);
-    }
-
-    /**
      * Returns the placeable at the specified coordinates.
      *
      * @param coords structure relative coordinates
      *
-     * @return placeable at relative structure coordinates or {@code NoVoxel.INSTANCE} if none
+     * @return placeable at relative structure coordinates or {@link Nothing#INSTANCE} if none
      */
     public Placeable get(WorldCoords3d coords) {
         return placeables.getOrDefault(coords, Nothing.INSTANCE);
@@ -121,28 +59,166 @@ public class PlaceableStructure implements Placeable {
      * @param y structure relative y-coordinate
      * @param z structure relative z-coordinate
      *
-     * @return placeable at relative structure coordinates or {@code NoVoxel.INSTANCE} if none
+     * @return placeable at relative structure coordinates or {@link Nothing#INSTANCE} if none
      */
     public Placeable get(int x, int y, int z) {
         return get(new WorldCoords3d(x, y, z));
     }
 
     /**
-     * Tells the limits of this structure in relative coordinates.
+     * {@return the limits of this structure in relative coordinates}
      * <p>
      * This is not the bounding box of all that would be placed.
      * Limits will only contain origin coordinates of contained placeables.
      * <p>
-     * In other words, limits contains every position for which {@link #get} returns something other than {@link Nothing#INSTANCE}.
+     * In other words, limits is the smallest bounding box containing every position
+     * for which {@link #get} returns something other than {@link Nothing#INSTANCE}.
      * This may be used to know how to repeat this structure.
-     *
-     * @return limits of the structure in relative coordinates.
      */
     public WorldBBox3d limits() {
-        if (limits == null)
-            limits = placeables.isEmpty() ? WorldBBox3d.EMPTY
-                : new WorldBBox3d(placeables.keySet().toArray(new WorldCoords3d[0]));
-
         return limits;
+    }
+
+    /**
+     * Creates a new builder from this structure.
+     * @return a pre-filled builder with this structure's content
+     */
+    public Builder toBuilder() {
+        return builder().merge(0, 0, 0, this);
+    }
+
+    /**
+     * Creates a new builder.
+     * @return an empty builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Simple builder to create structures from methods such as
+     * {@link #set(WorldCoords3d, Placeable)} and {@link #remove(WorldCoords3d)}.
+     */
+    public static final class Builder {
+        private final Map<WorldCoords3d, Placeable> placeables = new HashMap<>();
+
+        /**
+         * Adds, replaces or removes a placeable at the specified coordinates.
+         * If the provided placeable value is {@code null}, any placeable at the specified coordinates will be removed.
+         * Coordinates are relative.
+         *
+         * @param coords the relative {@code WorldCoords3d}
+         * @param placeable the placeable to be added or {@code null} value
+         * @return {@code this}
+         */
+        public Builder set(WorldCoords3d coords, Placeable placeable) {
+            if (placeable == null)
+                placeables.remove(coords);
+            else
+                placeables.put(coords, placeable);
+            return this;
+        }
+
+        /**
+         * Adds, replaces or removes a placeable at the specified coordinates.
+         * If the provided placeable is {@code null}, any placeable at the specified coordinates will be removed.
+         * Coordinates are relative.
+         *
+         * @param x the x-coordinate value
+         * @param y the y-coordinate value
+         * @param z the z-coordinate value
+         * @param placeable the placeable to be added or {@code null} value
+         * @return {@code this}
+         */
+        public Builder set(int x, int y, int z, Placeable placeable) {
+            return set(new WorldCoords3d(x, y, z), placeable);
+        }
+
+        /**
+         * Adds, replaces or removes placeables at all the coordinates within the specified bounding box.
+         * If the provided placeable is {@code null}, any placeable within the bounding box will be removed.
+         *
+         * @param bbox  the bounding box
+         * @param placeable the placeable to be added or {@code null} value
+         * @return {@code this}
+         */
+        public Builder set(WorldBBox3d bbox, Placeable placeable) {
+            for (WorldCoords3d coords : bbox)
+                set(coords, placeable);
+            return this;
+        }
+
+        /**
+         * Removes the placeable, if it exists, at the specified coordinates.
+         *
+         * @param coords the relative {@code WorldCoords3d}
+         * @return {@code this}
+         */
+        public Builder remove(WorldCoords3d coords) {
+            return set(coords, null);
+        }
+
+        /**
+         * Removes the placeable, if it exists, at the specified coordinates.
+         *
+         * @param x the x-coordinate value
+         * @param y the y-coordinate value
+         * @param z the z-coordinate value
+         * @return {@code this}
+         */
+        public Builder remove(int x, int y, int z) {
+            return set(x, y, z, null);
+        }
+
+        /**
+         * Removes all placeables within the provided BBOX.
+         *
+         * @param bbox the bounding box
+         * @return {@code this}
+         */
+        public Builder remove(WorldBBox3d bbox) {
+            return set(bbox, null);
+        }
+
+        /**
+         * Merges the given structure into this builder, with an offset.
+         * This will take all placeables of the structure and set them with
+         * the given offset added to their initial offset, potentially
+         * overwriting existing placeables of this builder.
+         * @param x the x-coordinate value
+         * @param y the y-coordinate value
+         * @param z the z-coordinate value
+         * @param structure the structure to merge
+         * @return {@code this}
+         */
+        public Builder merge(int x, int y, int z, PlaceableStructure structure) {
+            if (x == 0 && y == 0 && z == 0)
+                placeables.putAll(structure.placeables);
+            else
+                for (Map.Entry<WorldCoords3d, Placeable> entry : structure.placeables.entrySet())
+                    set(entry.getKey().add(x, y, z), entry.getValue());
+            return this;
+        }
+
+        /**
+         * Merges the given structure into this builder, with an offset.
+         * This will take all placeables of the structure and set them with
+         * the given offset added to their initial offset, potentially
+         * overwriting existing placeables of this builder.
+         * @param coords the relative {@code WorldCoords3d}
+         * @param structure the structure to merge
+         * @return {@code this}
+         */
+        public Builder merge(WorldCoords3d coords, PlaceableStructure structure) {
+            return merge(coords.x(), coords.y(), coords.z(), structure);
+        }
+
+        /**
+         * Creates an immutable structure from this builder.
+         * @return the created structure
+         */
+        public PlaceableStructure build() {
+            return placeables.isEmpty() ? EMPTY : new PlaceableStructure(placeables);
+        }
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/utils/world2d/WorldSize2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world2d/WorldSize2d.java
@@ -5,25 +5,25 @@ import com.ignfab.minalac.generator.utils.world3d.WorldSize3d;
 /**
  * The {@code WorldSize2d} subclass represents the size along the x-axis and the y-axis in the voxel world.
  * The x-component represents the size along the x-axis, while the y-component represents the size along the y-axis.
- * Size is always greater than zero.
+ * Size is always greater than or equals to zero.
  *
  * @param x The size along the x-axis
  * @param y The size along the y-axis
  *
- * @see com.ignfab.minalac.generator.utils.world2d.WorldCoords2d
+ * @see WorldCoords2d
  */
 public record WorldSize2d(int x, int y) {
     /**
      * Constructs a new {@code WorldSize2d}.
-     * Sizes must be greater than 0.
+     * Sizes must be greater than or equals to 0.
      *
-     * @param x the size along the x-axis.
-     * @param y the size along the y-axis.
-     * @throws IllegalArgumentException if either {@code x} or {@code y} is less than or equal to 0.
+     * @param x the size along the x-axis
+     * @param y the size along the y-axis
+     * @throws IllegalArgumentException if either {@code x} or {@code y} is less than 0
      */
     public WorldSize2d {
         if (x < 0 || y < 0)
-            throw new IllegalArgumentException("Invalid size: x and y must be positive numbers");
+            throw new IllegalArgumentException("Invalid size: x and y must be positive or zero");
     }
 
     /**

--- a/src/main/java/com/ignfab/minalac/generator/utils/world3d/WorldSize3d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world3d/WorldSize3d.java
@@ -4,8 +4,8 @@ import com.ignfab.minalac.generator.utils.world2d.WorldSize2d;
 
 /**
  * The {@code WorldSize3d} subclass represents the size along the three axes in the voxel world.
- * The each component represents the size along the corresponding axis.
- * Size is always greater than zero.
+ * Each component represents the size along the corresponding axis.
+ * Size is always greater than or equals to zero.
  *
  * @param x The size along the x-axis
  * @param y The size along the y-axis
@@ -16,16 +16,16 @@ import com.ignfab.minalac.generator.utils.world2d.WorldSize2d;
 public record WorldSize3d(int x, int y, int z) {
     /**
      * Constructs a new {@link WorldSize3d}.
-     * Sizes must be greater than 0.
+     * Sizes must be greater than or equals to 0.
      *
      * @param x the size along the x-axis
      * @param y the size along the y-axis
      * @param z the size along the z-axis
-     * @throws IllegalArgumentException if either {@code x}, {@code y} or {@code z} is less than or equal to 0
+     * @throws IllegalArgumentException if either {@code x}, {@code y} or {@code z} is less than 0
      */
     public WorldSize3d {
         if (x < 0 || y < 0 || z < 0)
-            throw new IllegalArgumentException("Invalid size: x, y and z must be positive numbers");
+            throw new IllegalArgumentException("Invalid size: x, y and z must be positive or zero");
     }
 
     /**

--- a/src/test/java/com/ignfab/minalac/generator/placeables/PlaceableStructureTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/placeables/PlaceableStructureTest.java
@@ -40,26 +40,28 @@ public class PlaceableStructureTest {
         ^       |B B| |CDE| |   |
         |       |  B| | C | |   |
         + - > x +---+ +---+ +---+ */
-        PlaceableStructure structure = new PlaceableStructure();
+        PlaceableStructure structure = PlaceableStructure.builder()
 
-        // z = -1 : fill with B
-        structure.set(new WorldBBox3d(-1, -1, -1, 3, 3, 1), vtB);
-        // z = -1 : remove the voxel at the middle -> |B B|
-        structure.set(0, 0, -1, null);
-        // z = -1 : remove the two voxels -> |  B|
-        structure.remove(new WorldBBox3d(-1, -1, -1, 2, 1, 1));
+            // z = -1 : fill with B
+            .set(new WorldBBox3d(-1, -1, -1, 3, 3, 1), vtB)
+            // z = -1 : remove the voxel at the middle -> |B B|
+            .set(0, 0, -1, null)
+            // z = -1 : remove the two voxels -> |  B|
+            .remove(new WorldBBox3d(-1, -1, -1, 2, 1, 1))
 
-        // z = 0 | E |
-        structure.set(0, 1, 0, vtE);
-        // z = 0 |CDE|
-        structure.set(-1, 0, 0, vtC);
-        structure.set(0, 0, 0, vtD);
-        structure.set(1, 0, 0, vtE);
-        // z = 0 | C |
-        structure.set(0, -1, 0, vtC);
+            // z = 0 | E |
+            .set(0, 1, 0, vtE)
+            // z = 0 |CDE|
+            .set(-1, 0, 0, vtC)
+            .set(0, 0, 0, vtD)
+            .set(1, 0, 0, vtE)
+            // z = 0 | C |
+            .set(0, -1, 0, vtC)
 
-        // z = 1 |B  |
-        structure.set(-1, 1, 1, vtB);
+            // z = 1 |B  |
+            .set(-1, 1, 1, vtB)
+
+            .build();
 
         // Structure is placed at the center of the world
         structure.place(tile, 0, -1, -2);
@@ -128,7 +130,7 @@ public class PlaceableStructureTest {
         TestingVoxel vt = new TestingVoxel("*");
         vt.place(tile, 4, 4, 5);
 
-        PlaceableStructure structure = new PlaceableStructure();
+        PlaceableStructure structure = PlaceableStructure.EMPTY;
         structure.place(tile, 3, 4, 5);
         structure.place(tile, 4, 4, 5);
 
@@ -141,9 +143,10 @@ public class PlaceableStructureTest {
         Placeable vtA = new TestingVoxel("A");
         Placeable vtB = new TestingVoxel("B");
 
-        PlaceableStructure structure = new PlaceableStructure();
-        structure.set(1, 2, 3, vtA);
-        structure.set(3, 2, 1, vtB);
+        PlaceableStructure structure = PlaceableStructure.builder()
+            .set(1, 2, 3, vtA)
+            .set(3, 2, 1, vtB)
+            .build();
 
         assertEquals(vtA, structure.get(1, 2, 3));
         assertEquals(vtB, structure.get(3, 2, 1));
@@ -153,26 +156,65 @@ public class PlaceableStructureTest {
     @Test
     public void testLimits() {
         Placeable vt = new TestingVoxel("X");
-        PlaceableStructure structure = new PlaceableStructure();
+        PlaceableStructure structure = PlaceableStructure.EMPTY;
 
         // Basic checks
-        structure.set(1, 2, 3, vt);
+        structure = structure.toBuilder().set(1, 2, 3, vt).build();
         assertEquals(new WorldBBox3d(1, 2, 3, 1, 1, 1), structure.limits());
 
-        structure.set(0, 0, 0, vt);
+        structure = structure.toBuilder().set(0, 0, 0, vt).build();
         assertEquals(new WorldBBox3d(0, 0, 0, 2, 3, 4), structure.limits());
 
         // Check adding novoxel extends limits
-        structure.set(6, 7, 8, Nothing.INSTANCE);
+        structure = structure.toBuilder().set(6, 7, 8, Nothing.INSTANCE).build();
         assertEquals(new WorldBBox3d(0, 0, 0, 7, 8, 9), structure.limits());
 
         // Check remove shrinks limits
-        structure.remove(0, 0, 0);
+        structure = structure.toBuilder().remove(0, 0, 0).build();
         assertEquals(new WorldBBox3d(1, 2, 3, 6, 6, 6), structure.limits());
 
         // Check underlying placeable does not extend limits
-        PlaceableStructure superStructure = new PlaceableStructure();
-        superStructure.set(3, 2, 1, structure);
+        PlaceableStructure superStructure = PlaceableStructure.builder()
+            .set(3, 2, 1, structure)
+            .build();
         assertEquals(new WorldBBox3d(3, 2, 1, 1, 1, 1), superStructure.limits());
+    }
+
+    @Test
+    public void testMerge() {
+        TestingVoxel vtA = new TestingVoxel("A");
+        TestingVoxel vtB = new TestingVoxel("B");
+        TestingVoxel vtC = new TestingVoxel("C");
+        TestingVoxel vtD = new TestingVoxel("D");
+        TestingVoxel vtE = new TestingVoxel("E");
+
+        PlaceableStructure subStruct = PlaceableStructure.builder().set(0, 0, 0, vtE).build();
+
+        PlaceableStructure structure = PlaceableStructure.builder()
+            .set(1, 2, 3, vtA)
+            .set(3, 2, 1, vtB)
+            .merge(1, 0, 0, PlaceableStructure.builder()
+                .set(0, 2, 3, vtC) // Overwrites vtA
+                .set(1, 1, 1, vtD)
+                .set(-1, -2, -3, subStruct)
+                .build())
+            .build();
+
+        // Original untouched structure content is preserved
+        assertEquals(vtB, structure.get(3, 2, 1));
+
+        // Other content from merged structure is present
+        assertEquals(vtD, structure.get(2, 1, 1));
+
+        // Merged structure has overwritten original content at same offset
+        assertEquals(vtC, structure.get(1, 2, 3));
+
+        // Sub-structures from merged are not flattened
+        assertEquals(subStruct, structure.get(0, -2, -3));
+    }
+
+    @Test
+    public void testEmptyBuilder() {
+        assertSame(PlaceableStructure.EMPTY, PlaceableStructure.builder().build());
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/placeables/patterns/RepeatPatternTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/placeables/patterns/RepeatPatternTest.java
@@ -15,7 +15,7 @@ public class RepeatPatternTest {
     @Test
     public void testConstructor() {
         assertDoesNotThrow(() -> new RepeatPattern(
-            new PlaceableStructure(),
+            PlaceableStructure.EMPTY,
             new WorldCoords3d(0, 0, 0),
             new WorldCoords3d(0, 0, 0),
             new WorldCoords3d(0, 0, 0)
@@ -29,10 +29,11 @@ public class RepeatPatternTest {
 
         TestingVoxel o = new TestingVoxel("O");
         TestingVoxel y = new TestingVoxel("Y");
-        struc = new PlaceableStructure();
-        struc.set(0, 0, 0, o);
-        struc.set(1, 0, 0, X);
-        struc.set(2, 0, 0, y);
+        struc = PlaceableStructure.builder()
+            .set(0, 0, 0, o)
+            .set(1, 0, 0, X)
+            .set(2, 0, 0, y)
+            .build();
 
         pattern = new RepeatPattern(
             struc,
@@ -50,10 +51,11 @@ public class RepeatPatternTest {
         assertEquals(X, pattern.get(7, 0, 0));
         assertEquals(y, pattern.get(8, 0, 0));
 
-        struc = new PlaceableStructure();
-        struc.set(0, 0, 0, o);
-        struc.set(0, 1, 0, X);
-        struc.set(0, 2, 0, y);
+        struc = PlaceableStructure.builder()
+            .set(0, 0, 0, o)
+            .set(0, 1, 0, X)
+            .set(0, 2, 0, y)
+            .build();
 
         pattern = new RepeatPattern(
             struc,
@@ -71,10 +73,11 @@ public class RepeatPatternTest {
         assertEquals(X, pattern.get(0, 7, 0));
         assertEquals(y, pattern.get(0, 8, 0));
 
-        struc = new PlaceableStructure();
-        struc.set(0, 0, 0, o);
-        struc.set(0, 0, 1, X);
-        struc.set(0, 0, 2, y);
+        struc = PlaceableStructure.builder()
+            .set(0, 0, 0, o)
+            .set(0, 0, 1, X)
+            .set(0, 0, 2, y)
+            .build();
 
         pattern = new RepeatPattern(
             struc,
@@ -99,9 +102,10 @@ public class RepeatPatternTest {
         PlaceableStructure struc;
 
         // Each Z -> Shift X and Y
-        struc = new PlaceableStructure();
-        struc.set(0, 0, 0, X);
-        struc.set(2, 2, 0, Nothing.INSTANCE);
+        struc = PlaceableStructure.builder()
+            .set(0, 0, 0, X)
+            .set(2, 2, 0, Nothing.INSTANCE)
+            .build();
         pattern = new RepeatPattern(
             struc,
             new WorldCoords3d(0, 0, 0),
@@ -118,9 +122,10 @@ public class RepeatPatternTest {
         assertEquals(X, pattern.get(5, 1, 2));
 
         // Each Y -> Shift X and Z
-        struc = new PlaceableStructure();
-        struc.set(0, 0, 0, X);
-        struc.set(2, 0, 2, Nothing.INSTANCE);
+        struc = PlaceableStructure.builder()
+            .set(0, 0, 0, X)
+            .set(2, 0, 2, Nothing.INSTANCE)
+            .build();
         pattern = new RepeatPattern(
             struc,
             new WorldCoords3d(0, 0, 0),
@@ -138,9 +143,10 @@ public class RepeatPatternTest {
 
 
         // Each X -> Shift Y and Z
-        struc = new PlaceableStructure();
-        struc.set(0, 0, 0, X);
-        struc.set(0, 2, 2, Nothing.INSTANCE);
+        struc = PlaceableStructure.builder()
+            .set(0, 0, 0, X)
+            .set(0, 2, 2, Nothing.INSTANCE)
+            .build();
         pattern = new RepeatPattern(
             struc,
             new WorldCoords3d(0, 2, 1),
@@ -158,8 +164,7 @@ public class RepeatPatternTest {
     }
 
     public void testSpacing() {
-        PlaceableStructure struc = new PlaceableStructure();
-        struc.set(0, 0, 0, X);
+        PlaceableStructure struc = PlaceableStructure.builder().set(0, 0, 0, X).build();
 
         RepeatPattern pattern = new RepeatPattern(
             struc,

--- a/src/test/java/com/ignfab/minalac/generator/tasks/RenderLinesTaskTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/tasks/RenderLinesTaskTest.java
@@ -23,7 +23,6 @@ class RenderLinesTaskTest {
     private WorldBBox3d bbox;
     private TestingGenerationTile tile;
     private ModelSelection modelSelection;
-    private PlaceableStructure structure;
 
     @BeforeEach
     public void setUp() {
@@ -31,20 +30,21 @@ class RenderLinesTaskTest {
         bbox = new WorldBBox3d(-1, -2, -3, 4, 5, 6);
         tile = new TestingGenerationTile(bbox);
         modelSelection = new ModelSelection("testing", null);
-        structure = new PlaceableStructure();
     }
 
     @Test
     public void testConstructor() {
-        assertDoesNotThrow(() -> new RenderLinesTask(modelSelection, structure, new ConstantHeightmap(0)));
-        assertDoesNotThrow(() -> new RenderLinesTask(modelSelection, structure, null));
+        assertDoesNotThrow(() -> new RenderLinesTask(modelSelection, PlaceableStructure.EMPTY, new ConstantHeightmap(0)));
+        assertDoesNotThrow(() -> new RenderLinesTask(modelSelection, PlaceableStructure.EMPTY, null));
     }
 
     @Test
     public void testRenderWithoutHeightmap() {
 
         tile.models().add("testing", new TestingShape3dModel(LineString3d.fromPoints(bbox.min(), bbox.max())));
-        structure.set(new WorldCoords3d(0, 0, 0), new TestingVoxel("TEST"));
+        PlaceableStructure structure = PlaceableStructure.builder()
+            .set(new WorldCoords3d(0, 0, 0), new TestingVoxel("TEST"))
+            .build();
 
         // Test rendering works
         assertDoesNotThrow(() -> new RenderLinesTask(modelSelection, structure, null).run(tile), "Render should not throw");
@@ -71,7 +71,9 @@ class RenderLinesTaskTest {
     public void testRenderWithHeightmap() {
 
         tile.models().add("testing", new TestingShape3dModel(LineString3d.fromPoints(bbox.min(), bbox.max())));
-        structure.set(new WorldCoords3d(0, 0, 0), new TestingVoxel("TEST"));
+        PlaceableStructure structure = PlaceableStructure.builder()
+            .set(new WorldCoords3d(0, 0, 0), new TestingVoxel("TEST"))
+            .build();
 
         // Test rendering works
         assertDoesNotThrow(() -> new RenderLinesTask(modelSelection, structure, new ConstantHeightmap(-1)).run(tile), "Render should not throw");
@@ -84,7 +86,7 @@ class RenderLinesTaskTest {
             throw new Exception("No voxel rendered");
         }, "Voxel expected to be rendered");
 
-        // Test all rendererd voxels are over or on heightmap ("render only above")
+        // Test all rendered voxels are over or on heightmap ("render only above")
         for (WorldCoords3d pos : bbox)
             if (tile.voxels().get(pos) != null)
                 assertTrue(pos.z() >= -1, "Voxel at %s expected to be over or on heightmap".formatted(pos));


### PR DESCRIPTION
### Type of modification

- Code
  - Placeables
- Documentation
  - Javadoc Comments
- Tests

### Changes

This PR refactors placeable structures into immutable objects, which can be constructed using builders.

#### Feature description

Prior to this PR, placeable structures were mutables, through their `set` and `remove` methods. This was initially useful to ease the creation of structures, however when we later gave them a dynamically computed bounding box, it forced us to take care of cache invalidation of the aforementioned bounding box.

The content of the structure is now immutable, which means it can no longer be modified after creation. This is ensured by using an immutable map implementation (through `Map.copyOf()`). A new builder has been added as an inner class, allowing to still use the old `set` and `remove` methods to assemble the structure. A new `merge` method has also been added, to shallow copy of the content of a structure into the builder. It allows turning an existing structure back into a mutable builder, if needed. It may also help with upcoming structure generators, as envisioned during the FDS code sprint ([ref](https://github.com/ignfab/minalac-generator/blob/fds/main/src/main/java/com/ignfab/minalac/generator/parameters/tasks/RenderDynamicLinesTaskParams.java#L110)).

The rest of the code base was updated to use the builder when creating structure (notably in the placeable structure params, and inside unit tests). No code was relying on modifying an existing structure (thankfully).

#### Showcase

Before:
```java
PlaceableStructure structure = new PlaceableStructure();
structure.set(new WorldBBox3d(-1, -1, -1, 3, 3, 1), vtB);
structure.set(0, 0, -1, null);
structure.remove(new WorldBBox3d(-1, -1, -1, 2, 1, 1));
structure.set(0, 1, 0, vtE);
```

After:
```java
PlaceableStructure structure = PlaceableStructure.builder()
    .set(new WorldBBox3d(-1, -1, -1, 3, 3, 1), vtB)
    .set(0, 0, -1, null)
    .remove(new WorldBBox3d(-1, -1, -1, 2, 1, 1))
    .set(0, 1, 0, vtE)
    .build();
```

### Reason

Immutability solves or prevents many problems, and is (almost) never a bad thing. It can be sometimes hard to achieve, while still maintaining usability (and ease of creation), but I think the builder does a great job here.

In some parts of our code, we were relying on the fact that a structure was not modified after being given to us (see the repeat pattern, for example, which would have break if the the structure was modified afterwards). This is no longer an "assumption" to make, as it is now strictly enforced by the code.

Cache invalidation is considered the #0 hardest task for programmers (source: [trust me](https://www.reddit.com/r/ProgrammerHumor/comments/rswbiv/there_are_actually_only_two_hard_problems/)).

### TODOs

This PR is finished and ready for review, but won't be merged before #113, as it is not urgent and way easier to rebase in case any modification collides.

### Self-checks

- [x] The code has unit tests associated
- [x] The code has Javadoc Comments associated
- [x] Complex / Unexpected code is explained / justified with a small comment
- ~~Relevant documentation inside the `/docs` folder has been updated~~
- [x] All examples in `examples/` work the same (or have been adapted if subject to changes in this PR)
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [x] The texts have been proofread (documentation, error messages, logs, comments...)
