### PR TITLE
refactor(heightmaps): Add an helper method to retrieve readable heightmap from specs

### DIFF
--- a/docs/dev/Heightmaps.md
+++ b/docs/dev/Heightmaps.md
@@ -26,9 +26,9 @@ public class MyHeightmapTask extends TiledTask {
 
     @Override
     protected void run(GenerationTile tile) {
-        // Now we got a tile, we can acces heightmaps:
-        ReadableHeightmap readable = tile.heightmaps().get(readableSpec);
-        WritableHeightmap writable = tile.heightmaps().get(writableSpec);
+        // Now we got a tile, we can access heightmaps:
+        ReadableHeightmap readable = tile.heightmap(readableSpec);
+        WritableHeightmap writable = tile.heightmap(writableSpec);
 
         ...
         h1 = readable.get(x, y);

--- a/src/main/java/com/ignfab/minalac/generator/generation/GenerationTile.java
+++ b/src/main/java/com/ignfab/minalac/generator/generation/GenerationTile.java
@@ -1,6 +1,10 @@
 package com.ignfab.minalac.generator.generation;
 
 import com.ignfab.minalac.generator.generation.heightmaps.HeightmapStore;
+import com.ignfab.minalac.generator.generation.heightmaps.ReadableHeightmap;
+import com.ignfab.minalac.generator.generation.heightmaps.ReadableHeightmapSpec;
+import com.ignfab.minalac.generator.generation.heightmaps.WritableHeightmap;
+import com.ignfab.minalac.generator.generation.heightmaps.WritableHeightmapSpec;
 import com.ignfab.minalac.generator.models.ModelStore;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.world.MapWriteException;
@@ -57,6 +61,37 @@ public class GenerationTile {
      */
     public HeightmapStore heightmaps() {
         return heightmaps;
+    }
+
+    /**
+     * Retrieves or creates a {@link ReadableHeightmap} from {@link #heightmaps() the store}, using the given spec if not null.
+     * @param spec Specification of heightmap to get, can be null
+     * @return The resulting heightmap, or {@code null} if the spec was {@code null}
+     * @see HeightmapStore#get(ReadableHeightmapSpec)
+     */
+    public ReadableHeightmap heightmap(ReadableHeightmapSpec spec) {
+        return heightmap(spec, null);
+    }
+
+    /**
+     * Retrieves or creates a {@link ReadableHeightmap} from {@link #heightmaps() the store}, using the given spec if not null, with default otherwise.
+     * @param spec Specification of heightmap to get, can be null
+     * @param defaultHeightmap Default heightmap returned when specification is null
+     * @return The resulting heightmap, or {@code defaultHeightmap} if the spec was {@code null}
+     * @see HeightmapStore#get(ReadableHeightmapSpec)
+     */
+    public ReadableHeightmap heightmap(ReadableHeightmapSpec spec, ReadableHeightmap defaultHeightmap) {
+        return spec == null ? defaultHeightmap : heightmaps().get(spec);
+    }
+
+    /**
+     * Retrieves a {@link WritableHeightmap}  from {@link #heightmaps() the store}, using the given spec.
+     * @param spec Specification of stored heightmap to get
+     * @return The resulting heightmap
+     * @see HeightmapStore#get(WritableHeightmapSpec)
+     */
+    public WritableHeightmap heightmap(WritableHeightmapSpec spec) {
+        return heightmaps().get(spec);
     }
 
     /**

--- a/src/main/java/com/ignfab/minalac/generator/tasks/CopyHeightmapTask.java
+++ b/src/main/java/com/ignfab/minalac/generator/tasks/CopyHeightmapTask.java
@@ -34,8 +34,8 @@ public class CopyHeightmapTask extends ModelTask<Shape2dConvertibleModel> {
 
     @Override
     protected void run(Shape2dConvertibleModel model, GenerationTile tile) {
-        ReadableHeightmap from = tile.heightmaps().get(fromSpec);
-        WritableHeightmap to = tile.heightmaps().get(toSpec);
+        ReadableHeightmap from = tile.heightmap(fromSpec);
+        WritableHeightmap to = tile.heightmap(toSpec);
 
         WritableHeightmap buffered = to.copy();
         for (Positioned2d voxel : buffered.bbox().filterInside(voxelizer.voxelize(model)))

--- a/src/main/java/com/ignfab/minalac/generator/tasks/FillBetweenHeightmapAndMetadataTask.java
+++ b/src/main/java/com/ignfab/minalac/generator/tasks/FillBetweenHeightmapAndMetadataTask.java
@@ -48,7 +48,7 @@ public class FillBetweenHeightmapAndMetadataTask extends ModelTask<Shape2dConver
 
     @Override
     protected void run(Shape2dConvertibleModel model, GenerationTile tile) {
-        ReadableHeightmap heightmap = tile.heightmaps().get(heightmapSpec);
+        ReadableHeightmap heightmap = tile.heightmap(heightmapSpec);
         Integer altitude = model.getMetadata(altitudeMetadata);
         // TODO should we use a FailurePolicy ?
         if (altitude == null)

--- a/src/main/java/com/ignfab/minalac/generator/tasks/HeightmapStatsTask.java
+++ b/src/main/java/com/ignfab/minalac/generator/tasks/HeightmapStatsTask.java
@@ -40,7 +40,7 @@ public class HeightmapStatsTask extends ModelTask<Shape2dConvertibleModel> {
 
     @Override
     protected void run(Shape2dConvertibleModel model, GenerationTile tile) {
-        ReadableHeightmap heightmap = tile.heightmaps().get(heightmapSpec);
+        ReadableHeightmap heightmap = tile.heightmap(heightmapSpec);
 
         boolean empty = true;
         int min = Integer.MAX_VALUE;

--- a/src/main/java/com/ignfab/minalac/generator/tasks/PopulateHeightmapTask.java
+++ b/src/main/java/com/ignfab/minalac/generator/tasks/PopulateHeightmapTask.java
@@ -29,7 +29,7 @@ public class PopulateHeightmapTask extends ModelTask<FloatMatrixModel> {
 
     @Override
     protected void run(FloatMatrixModel model, GenerationTile tile) {
-        WritableHeightmap heightmap = tile.heightmaps().get(heightmapSpec);
+        WritableHeightmap heightmap = tile.heightmap(heightmapSpec);
         WorldBBox2d intersection = tile.limits().to2d().intersection(heightmap.bbox());
         // Iterate over matrix and fill heightmap altitude
         for (Matrix2d.Value<Float> value : model) {

--- a/src/main/java/com/ignfab/minalac/generator/tasks/RenderHeightmapTask.java
+++ b/src/main/java/com/ignfab/minalac/generator/tasks/RenderHeightmapTask.java
@@ -30,12 +30,12 @@ public class RenderHeightmapTask implements TileTask {
     @Override
     public void run(GenerationTile tile) {
         if (minimum == maximum) {
-            ReadableHeightmap heightmap = tile.heightmaps().get(maximum);
+            ReadableHeightmap heightmap = tile.heightmap(maximum);
             for (WorldCoords2d c : tile.limits().to2d().intersection(heightmap.bbox()))
                 placeable.place(tile.voxels(), c.x(), c.y(), heightmap.get(c));
         } else {
-            ReadableHeightmap minimum = tile.heightmaps().get(this.minimum);
-            ReadableHeightmap maximum = tile.heightmaps().get(this.maximum);
+            ReadableHeightmap minimum = tile.heightmap(this.minimum);
+            ReadableHeightmap maximum = tile.heightmap(this.maximum);
             for (WorldCoords2d c : tile.limits().to2d().intersection(minimum.bbox()).intersection(maximum.bbox()))
                 for (int z = minimum.get(c); z <= maximum.get(c); z++)
                     placeable.place(tile.voxels(), c.x(), c.y(), z);

--- a/src/main/java/com/ignfab/minalac/generator/tasks/RenderLinesTask.java
+++ b/src/main/java/com/ignfab/minalac/generator/tasks/RenderLinesTask.java
@@ -45,7 +45,7 @@ public class RenderLinesTask extends ModelTask<Shape3dConvertibleModel> {
 
     @Override
     protected void run(Shape3dConvertibleModel model, GenerationTile tile) {
-        ReadableHeightmap renderOnlyWhenAbove = renderOnlyWhenAboveSpec == null ? DEFAULT_HEIGHTMAP : tile.heightmaps().get(renderOnlyWhenAboveSpec);
+        ReadableHeightmap renderOnlyWhenAbove = tile.heightmap(renderOnlyWhenAboveSpec, DEFAULT_HEIGHTMAP);
         WorldBBox3d limits = structure.limits();
 
         // Always align structure center to the line axis.

--- a/src/main/java/com/ignfab/minalac/generator/tasks/RenderSurfacesTask.java
+++ b/src/main/java/com/ignfab/minalac/generator/tasks/RenderSurfacesTask.java
@@ -35,7 +35,7 @@ public class RenderSurfacesTask extends ModelTask<Shape2dConvertibleModel> {
 
     @Override
     protected void run(Shape2dConvertibleModel model, GenerationTile tile) {
-        ReadableHeightmap heightmap = tile.heightmaps().get(heightmapSpec);
+        ReadableHeightmap heightmap = tile.heightmap(heightmapSpec);
 
         for (Positioned2d voxel : tile.limits().to2d().filterInside(voxelizer.voxelize(model))) {
             WorldCoords2d c = voxel.coords();

--- a/src/main/java/com/ignfab/minalac/generator/tasks/SetSpawnTask.java
+++ b/src/main/java/com/ignfab/minalac/generator/tasks/SetSpawnTask.java
@@ -26,7 +26,7 @@ public class SetSpawnTask implements TileTask {
     @Override
     public void run(GenerationTile tile) {
         if (tile.limits().bbox().to2d().contains(spawn)) {
-            int spawnZ = tile.heightmaps().get(heightmapSpec).get(spawn);
+            int spawnZ = tile.heightmap(heightmapSpec).get(spawn);
             tile.generation().world().getMetadata().setSpawn(spawn.to3d(spawnZ));
         }
     }

--- a/src/test/java/com/ignfab/minalac/generator/parameters/heightmaps/MultiOperandsHeightmapParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/heightmaps/MultiOperandsHeightmapParamsTest.java
@@ -28,7 +28,7 @@ public class MultiOperandsHeightmapParamsTest {
         generation.heightmaps().add(heightmapSpec);
 
         GenerationTile tile = new GenerationTile(generation, new WorldBBox3d(0, 0, 0, 3, 1, 1));
-        WritableHeightmap ground = tile.heightmaps().get(heightmapSpec.spec());
+        WritableHeightmap ground = tile.heightmap(heightmapSpec.spec());
 
         ground.set(0, 0, 0);
         ground.set(1, 0, 2);
@@ -45,7 +45,7 @@ public class MultiOperandsHeightmapParamsTest {
 
         assertDoesNotThrow(params::validate);
         ReadableHeightmapSpec spec = assertDoesNotThrow(() -> params.create(generation.heightmaps()));
-        ReadableHeightmap result = tile.heightmaps().get(spec);
+        ReadableHeightmap result = tile.heightmap(spec);
 
         assertEquals(11, result.get(0, 0), "0 + 5 + 6");
         assertEquals(13, result.get(1, 0), "2 + 5 + 6");
@@ -59,7 +59,7 @@ public class MultiOperandsHeightmapParamsTest {
         generation.heightmaps().add(heightmapSpec);
 
         GenerationTile tile = new GenerationTile(generation, new WorldBBox3d(0, 0, 0, 3, 1, 1));
-        WritableHeightmap ground = tile.heightmaps().get(heightmapSpec.spec());
+        WritableHeightmap ground = tile.heightmap(heightmapSpec.spec());
 
         ground.set(0, 0, 0);
         ground.set(1, 0, 2);
@@ -76,7 +76,7 @@ public class MultiOperandsHeightmapParamsTest {
 
         assertDoesNotThrow(params::validate);
         ReadableHeightmapSpec spec = assertDoesNotThrow(() -> params.create(generation.heightmaps()));
-        ReadableHeightmap result = tile.heightmaps().get(spec);
+        ReadableHeightmap result = tile.heightmap(spec);
 
         assertEquals(0, result.get(0, 0), "0 * 5 * 7");
         assertEquals(70, result.get(1, 0), "2 * 5 * 7");

--- a/src/test/java/com/ignfab/minalac/generator/parameters/heightmaps/RemapHeightmapParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/heightmaps/RemapHeightmapParamsTest.java
@@ -30,7 +30,7 @@ public class RemapHeightmapParamsTest {
         generation.heightmaps().add(heightmapSpec);
 
         GenerationTile tile = new GenerationTile(generation, new WorldBBox3d(-3, 0, 0, 8, 1, 0));
-        WritableHeightmap base = tile.heightmaps().get(heightmapSpec.spec());
+        WritableHeightmap base = tile.heightmap(heightmapSpec.spec());
 
         for (int i = -3; i <= 4; i++)
             base.set(i, 0, i);
@@ -46,7 +46,7 @@ public class RemapHeightmapParamsTest {
         ));
 
         ReadableHeightmapSpec spec = assertDoesNotThrow(() -> params.create(generation.heightmaps()));
-        ReadableHeightmap result = tile.heightmaps().get(spec);
+        ReadableHeightmap result = tile.heightmap(spec);
         assertEquals(21, result.get(0, 0), "Should match first interval [0; 1] -> 21");
         assertEquals(34, result.get(2, 0), "Should match second interval [-3; 3] -> 34");
         assertEquals(34, result.get(-3, 0), "Should match second interval [-3; 3] -> 34");


### PR DESCRIPTION
### Type of modification

- Code
  - Tools

### Changes

This PR adds a shortcut method to optionally get a readable heightmap from the store of a tile.

#### Feature description

The generation tile hold multiple contextual objects such as the world tile, the model store... or the heightmap store. This last one is responsible for creating and caching readable heightmaps, from their specs. 99% of the time, when interacting with this store, the code looks like:
```java
ReadableHeightmap heightmap = tile.heightmaps().get(spec);
```
A simple shortcut is now available to write:
```java
ReadableHeightmap heightmap = tile.heightmap(spec);
```
Alone, it is not a big change. However, in upcoming works, some heightmap are "optional", which is denoted by a `null` spec. This helper method gracefully handles this case by early returning `null` without calling the store. This avoids the need to check for `null` ourselves.

Existing code has been updated to take advantage of this shortcut.

### Reason

This slightly simplifies the code, and increases readability of "optional" heightmap situations.

### TODOs

This PR is finished and ready for review, but won't be merged before #113, as it is not urgent and way easier to rebase in case any modification collides.

### Self-checks

- ~~The code has unit tests associated~~
- [x] The code has Javadoc Comments associated
- ~~Complex / Unexpected code is explained / justified with a small comment~~
- ~~Relevant documentation inside the `/docs` folder has been updated~~
- ~~All examples in `examples/` work the same (or have been adapted if subject to changes in this PR)~~
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [x] The texts have been proofread (documentation, error messages, logs, comments...)
