### PR TITLE
Fix `ifNoMatchFound' field should not be specified when 'default' is set` error

### DIFF
--- a/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataValueMappingPostProcessorParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataValueMappingPostProcessorParams.java
@@ -3,6 +3,7 @@ package com.ignfab.minalac.generator.parameters.processors.post;
 import java.beans.ConstructorProperties;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -60,7 +61,7 @@ public class MetadataValueMappingPostProcessorParams extends PostProcessorParams
      * Policy to use when there is no match for the metadata value in the mappings (optional).
      */
     @JsonSetter(nulls = Nulls.SKIP)
-    public FailurePolicyParams ifNoMatchFound = FailurePolicyParams.ERROR;
+    public FailurePolicyParams ifNoMatchFound;
 
     /**
      * Constructor used to ensure that the required fields
@@ -100,8 +101,10 @@ public class MetadataValueMappingPostProcessorParams extends PostProcessorParams
             });
 
         Object defaultValue = this.defaultValue;
-        if (defaultValue != null)
+        if (defaultValue != null) {
             defaultValue = as.parse(defaultValue);
+            ifNoMatchFound = FailurePolicyParams.IGNORE;
+        }
 
         return new MetadataValueMappingPostProcessor<>(
             as.type(),
@@ -109,7 +112,7 @@ public class MetadataValueMappingPostProcessorParams extends PostProcessorParams
             valueMapping,
             defaultValue,
             ifMissing.create(),
-            ifNoMatchFound.create()
+            Objects.requireNonNullElse(ifNoMatchFound, FailurePolicyParams.ERROR).create()
         );
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataValueMappingPostProcessorParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataValueMappingPostProcessorParamsTest.java
@@ -71,6 +71,14 @@ public class MetadataValueMappingPostProcessorParamsTest {
         assertDoesNotThrow(params::validate);
 
         params = new MetadataValueMappingPostProcessorParams("metadata");
+        params.toFrom = Map.of("b", Set.of("a", "c", "d"), "e", Set.of("f", "g", "h"));
+        params.fromTo = new HashMap<>();
+        params.defaultValue = "a";
+        assertDoesNotThrow(params::validate);
+
+        params = new MetadataValueMappingPostProcessorParams("metadata");
+        params.toFrom = Map.of("b", Set.of("a", "c", "d"), "e", Set.of("f", "g", "h"));
+        params.fromTo = new HashMap<>();
         params.defaultValue = "a";
         params.ifNoMatchFound = FailurePolicyParams.ERROR;
         assertThrows(IllegalArgumentException.class, params::validate);
@@ -97,6 +105,11 @@ public class MetadataValueMappingPostProcessorParamsTest {
         MetadataValueMappingPostProcessorParams params;
         params = new MetadataValueMappingPostProcessorParams("metadata");
         params.fromTo = Map.of("a", "b", "c", "d");
+        assertDoesNotThrow(params::create);
+
+        params = new MetadataValueMappingPostProcessorParams("metadata");
+        params.fromTo = Map.of("a", "b", "c", "d");
+        params.defaultValue = "z";
         assertDoesNotThrow(params::create);
 
         params = new MetadataValueMappingPostProcessorParams("metadata");


### PR DESCRIPTION
### Changes

Supprimer la valeur par défaut de l’attribut `ifNoMatchFound` pour la définir dans le `create()`.

### Reason

La valeur par défaut de `ifNoMatchFound` causait une erreur lorsque le champ `default` était paramétré.

### Self-checks

- [x] The code has unit tests associated
- [x] The code has Javadoc Comments associated
- ~~[ ] Complex / Unexpected code is explained / justified with a small comment~~
- ~~[ ] Relevant documentation inside the `/docs` folder has been updated~~
- [x] All examples in `examples/` work the same (or have been adapted if subject to changes in this PR)
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [ ] The texts have been proofread (documentation, error messages, logs, comments...)
