### PR TITLE
refactor(iterators): Add flatMap method for iterators and iterables

### DIFF
--- a/src/main/java/com/ignfab/minalac/generator/utils/iterator/Iterables.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/iterator/Iterables.java
@@ -95,7 +95,7 @@ public final class Iterables {
      */
     @SafeVarargs
     public static <T> Iterable<T> union(Iterable<? extends T>... iterables) {
-        return () -> Iterators.unwrap(Iterators.remap(Iterators.array(iterables), Iterable::iterator));
+        return () -> Iterators.unwrapIterables(Iterators.array(iterables));
     }
 
      /**
@@ -108,7 +108,7 @@ public final class Iterables {
      * @param <T> common type returned by iterable iterables
      */
     public static <T> Iterable<T> unwrap(Iterable<? extends Iterable<? extends T>> iterable) {
-        return () -> Iterators.unwrap(Iterators.remap(iterable.iterator(), Iterable::iterator));
+        return () -> Iterators.unwrapIterables(iterable.iterator());
     }
 
     /**
@@ -122,6 +122,22 @@ public final class Iterables {
      */
     public static <T> Iterable<T> unwrapIterators(Iterable<? extends Iterator<? extends T>> iterable) {
         return () -> Iterators.unwrap(iterable.iterator());
+    }
+
+    /**
+     * Remaps then unwraps an iterable, transforming its result into other values using a
+     * provided function.
+     *
+     * @param iterable the iterable to remap
+     * @param mapper the mapping function
+     *
+     * @return an iterable returning transformed results
+     *
+     * @param <T> original type returned by iterable
+     * @param <U> new type returned by resulting iterable
+     */
+    public static <T, U> Iterable<U> flatMap(Iterable<T> iterable, Function<T, Iterable<? extends U>> mapper) {
+        return () -> Iterators.unwrapIterables(Iterators.remap(iterable.iterator(), mapper));
     }
 
 }

--- a/src/main/java/com/ignfab/minalac/generator/utils/iterator/Iterators.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/iterator/Iterators.java
@@ -116,7 +116,7 @@ public final class Iterators {
      */
     @SafeVarargs
     public static <T> Iterator<T> union(Iterator<? extends T>... iterators) {
-        return new UnwrapIterator<>(new ArrayIterator<>(iterators));
+        return unwrap(array(iterators));
     }
 
     /**
@@ -142,7 +142,23 @@ public final class Iterators {
      * @param <T> common type returned by iterator iterables
      */
     public static <T> Iterator<T> unwrapIterables(Iterator<? extends Iterable<? extends T>> iterator) {
-        return new UnwrapIterator<>(remap(iterator, Iterable::iterator));
+        return flatMap(iterator, Iterable::iterator);
+    }
+
+    /**
+     * Remaps then unwraps an iterator, transforming its result into other values using a
+     * provided function.
+     *
+     * @param iterator the iterator to remap
+     * @param mapper the mapping function
+     *
+     * @return an iterator returning transformed results
+     *
+     * @param <T> original type returned by iterator
+     * @param <U> new type returned by resulting iterator
+     */
+    public static <T, U> Iterator<U> flatMap(Iterator<T> iterator, Function<T, Iterator<? extends U>> mapper) {
+        return unwrap(remap(iterator, mapper));
     }
 
     /*

--- a/src/main/java/com/ignfab/minalac/generator/voxelization/shape2d/MultiShape2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/voxelization/shape2d/MultiShape2d.java
@@ -34,17 +34,17 @@ public class MultiShape2d implements Shape2d {
 
     @Override
     public Iterable<Point2d> points() {
-        return Iterables.unwrap(Iterables.remap(shapes, Shape2d::points));
+        return Iterables.flatMap(shapes, Shape2d::points);
     }
 
     @Override
     public Iterable<LineString2d> lineStrings() {
-        return Iterables.unwrap(Iterables.remap(shapes, Shape2d::lineStrings));
+        return Iterables.flatMap(shapes, Shape2d::lineStrings);
     }
 
     @Override
     public Iterable<Polygon2d> polygons() {
-        return Iterables.unwrap(Iterables.remap(shapes, Shape2d::polygons));
+        return Iterables.flatMap(shapes, Shape2d::polygons);
     }
 
     @Override

--- a/src/main/java/com/ignfab/minalac/generator/voxelization/shape2d/Polygon2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/voxelization/shape2d/Polygon2d.java
@@ -52,14 +52,14 @@ public class Polygon2d implements Shape2d {
 
     @Override
     public Iterable<Point2d> points() {
-        return Iterables.unwrap(Iterables.remap(lineStrings(), LineString2d::points));
+        return Iterables.flatMap(lineStrings(), LineString2d::points);
     }
 
     /**
      * {@return iterable over all segments in the shape}
      */
     public Iterable<Segment2d> segments() {
-        return Iterables.unwrap(Iterables.remap(lineStrings(), LineString2d::segments));
+        return Iterables.flatMap(lineStrings(), LineString2d::segments);
     }
 
     @Override

--- a/src/main/java/com/ignfab/minalac/generator/voxelization/shape2d/voxelizer/SurfaceVoxelizer2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/voxelization/shape2d/voxelizer/SurfaceVoxelizer2d.java
@@ -22,7 +22,7 @@ public class SurfaceVoxelizer2d implements Shape2dVoxelizer {
 
     @Override
     public Iterable<Positioned2d> voxelize(Shape2dConvertible convertible) {
-        return Iterables.unwrap(Iterables.remap(convertible.toShape2d().polygons(), this::voxelize));
+        return Iterables.flatMap(convertible.toShape2d().polygons(), this::voxelize);
     }
 
 }

--- a/src/main/java/com/ignfab/minalac/generator/voxelization/shape2d/voxelizer/ThickLinearIndexedVoxelizer2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/voxelization/shape2d/voxelizer/ThickLinearIndexedVoxelizer2d.java
@@ -39,7 +39,7 @@ public class ThickLinearIndexedVoxelizer2d implements Shape2dVoxelizer {
 
     @Override
     public Iterable<IndexedPosition2d> voxelize(Shape2dConvertible convertible) {
-        return Iterables.unwrap(Iterables.remap(convertible.toShape2d().lineStrings(), this::voxelize));
+        return Iterables.flatMap(convertible.toShape2d().lineStrings(), this::voxelize);
     }
 
 }

--- a/src/main/java/com/ignfab/minalac/generator/voxelization/shape2d/voxelizer/ThinLinearVoxelizer2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/voxelization/shape2d/voxelizer/ThinLinearVoxelizer2d.java
@@ -19,12 +19,12 @@ public class ThinLinearVoxelizer2d implements Shape2dVoxelizer {
      * @return an iterable over voxelized positions
      */
     public Iterable<Positioned2d> voxelize(LineString2d lineString) {
-        return Iterables.unwrap(Iterables.remap(lineString.segments(), (segment) -> () -> new ThinSegment2dIterator(segment)));
+        return Iterables.flatMap(lineString.segments(), (segment) -> () -> new ThinSegment2dIterator(segment));
     }
 
     @Override
     public Iterable<Positioned2d> voxelize(Shape2dConvertible convertible) {
-        return Iterables.unwrap(Iterables.remap(convertible.toShape2d().lineStrings(), this::voxelize));
+        return Iterables.flatMap(convertible.toShape2d().lineStrings(), this::voxelize);
     }
 
 }

--- a/src/main/java/com/ignfab/minalac/generator/voxelization/shape3d/MultiShape3d.java
+++ b/src/main/java/com/ignfab/minalac/generator/voxelization/shape3d/MultiShape3d.java
@@ -34,17 +34,17 @@ public class MultiShape3d implements Shape3d {
 
     @Override
     public Iterable<Point3d> points() {
-        return Iterables.unwrap(Iterables.remap(shapes, Shape3d::points));
+        return Iterables.flatMap(shapes, Shape3d::points);
     }
 
     @Override
     public Iterable<LineString3d> lineStrings() {
-        return Iterables.unwrap(Iterables.remap(shapes, Shape3d::lineStrings));
+        return Iterables.flatMap(shapes, Shape3d::lineStrings);
     }
 
     @Override
     public Iterable<Polygon3d> polygons() {
-        return Iterables.unwrap(Iterables.remap(shapes, Shape3d::polygons));
+        return Iterables.flatMap(shapes, Shape3d::polygons);
     }
 
     @Override

--- a/src/main/java/com/ignfab/minalac/generator/voxelization/shape3d/Polygon3d.java
+++ b/src/main/java/com/ignfab/minalac/generator/voxelization/shape3d/Polygon3d.java
@@ -52,14 +52,14 @@ public class Polygon3d implements Shape3d {
 
     @Override
     public Iterable<Point3d> points() {
-        return Iterables.unwrap(Iterables.remap(lineStrings(), LineString3d::points));
+        return Iterables.flatMap(lineStrings(), LineString3d::points);
     }
 
     /**
      * {@return iterable over all segments in the shape}
      */
     public Iterable<Segment3d> segments() {
-        return Iterables.unwrap(Iterables.remap(lineStrings(), LineString3d::segments));
+        return Iterables.flatMap(lineStrings(), LineString3d::segments);
     }
 
     @Override

--- a/src/main/java/com/ignfab/minalac/generator/voxelization/shape3d/voxelizer/ThickLinearIndexedVoxelizer2d5.java
+++ b/src/main/java/com/ignfab/minalac/generator/voxelization/shape3d/voxelizer/ThickLinearIndexedVoxelizer2d5.java
@@ -41,6 +41,6 @@ public class ThickLinearIndexedVoxelizer2d5 implements Shape3dVoxelizer {
 
     @Override
     public Iterable<IndexedPosition3d> voxelize(Shape3dConvertible convertible) {
-        return Iterables.unwrap(Iterables.remap(convertible.toShape3d().lineStrings(), this::voxelize));
+        return Iterables.flatMap(convertible.toShape3d().lineStrings(), this::voxelize);
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/utils/iterator/IterablesTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/iterator/IterablesTest.java
@@ -1,5 +1,6 @@
 package com.ignfab.minalac.generator.utils.iterator;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -147,6 +148,23 @@ public class IterablesTest {
         assertBrowsesAllOnce(
             Arrays.asList("Frodo", "Sam", "Gollum"),
             Iterables.unwrap(list)
+        );
+    }
+
+    @Test
+    void testFlatMap() {
+        assertBrowsesAllOnce(
+            Arrays.asList(
+                "11",
+                "21", "22",
+                "31", "32", "33"
+            ),
+            Iterables.flatMap(Arrays.asList(0, 1, 2, 3), n -> {
+                List<String> list = new ArrayList<>();
+                for (int i = 1; i <= n; i++)
+                    list.add(n + "" + i);
+                return list;
+            })
         );
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/utils/iterator/IteratorsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/iterator/IteratorsTest.java
@@ -1,5 +1,6 @@
 package com.ignfab.minalac.generator.utils.iterator;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
@@ -159,6 +160,23 @@ public class IteratorsTest {
         assertBrowsesAllOnce(
             Arrays.asList("Frodo", "Sam", "Gollum"),
             Iterators.unwrap(list.iterator())
+        );
+    }
+
+    @Test
+    void testFlatMap() {
+        assertBrowsesAllOnce(
+            Arrays.asList(
+                "11",
+                "21", "22",
+                "31", "32", "33"
+            ),
+            Iterators.flatMap(Arrays.asList(0, 1, 2, 3).iterator(), n -> {
+                List<String> list = new ArrayList<>();
+                for (int i = 1; i <= n; i++)
+                    list.add(n + "" + i);
+                return list.iterator();
+            })
         );
     }
 }


### PR DESCRIPTION
### Type of modification

- Code
  - Tools
- Documentation
  - Javadoc Comments
- Tests

### Changes

This PR adds a `flatMap` shortcut method to combine `remap` and `unwrap` operations on iterators/iterables, more readable and slightly more optimized.

#### Feature description

Our iterators/iterables toolbox includes a `remap` operation, allowing to replace values, and `unwrap`, transforming an iterator/iterable of iterators/iterables into a single layered, flattened, iterator/iterable with all end values.

Now, new methods are available to directly `remap` then `unwrap` in one call: `flatMap`. The name comes from the `Stream#flatMap` equivalent, fulfilling similar purpose on Java streams.

#### Showcase

Considering an object composed of parts (i.e. a line string composed of line segments). When having a collection of such objects, exposing an iterable of parts would have required:
```java
Iterables.unwrap(Iterables.remap(objects, MyObject::parts))
```

It now becomes possible to write:
```java
Iterables.flatMap(objects, MyObject::parts)
```

### Reason

Chaining the two operations was trivial, but introduced longer lines and was slightly more convoluted, requiring extra attention to properly understand what was going on. It also was possible to make a mistake when implementing an effective "flat-map" operation, where some developers wanted to use `union` instead of or even in addition to `unwrap`.

Implementing a direct `flatMap` operation is both clearer to read, and slightly more optimized. More methods in the `Iterables` utility construct an iterable extracting the iterator and delegating to `Iterators`. Chaining 2 successive operations was creating useless temporary iterables, which are not avoided.

### TODOs

This PR is finished and ready for review, but won't be merged before #113, as it is not urgent and way easier to rebase, and modifications will collide.

### Self-checks

- [x] The code has unit tests associated
- [x] The code has Javadoc Comments associated
- ~~Complex / Unexpected code is explained / justified with a small comment~~
- ~~Relevant documentation inside the `/docs` folder has been updated~~
- [x] All examples in `examples/` work the same (or have been adapted if subject to changes in this PR)
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [x] The texts have been proofread (documentation, error messages, logs, comments...)
