### PR TITLE
Generate a generation.md file containing generation information

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -329,6 +329,38 @@
                     <doclint>all,-missing</doclint>
                 </configuration>
             </plugin>
+            <!-- Get information from git -->
+            <plugin>
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
+                <version>9.0.2</version>
+                <executions>
+                    <execution>
+                        <id>get-the-git-infos</id>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <failOnNoGitDirectory>false</failOnNoGitDirectory>
+                    <includeOnlyProperties>
+                        <includeOnlyProperty>git.commit.id</includeOnlyProperty>
+                        <includeOnlyProperty>git.branch</includeOnlyProperty>
+                        <includeOnlyProperty>git.remote.origin.url</includeOnlyProperty>
+                    </includeOnlyProperties>
+                    <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
+                    <prefix>git</prefix>
+                    <verbose>false</verbose>
+                    <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                    <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+                    <gitDescribe>
+                        <skip>false</skip>
+                        <always>false</always>
+                        <dirty>-dirty</dirty>
+                    </gitDescribe>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/src/main/java/com/ignfab/minalac/generator/MinalacGenerator.java
+++ b/src/main/java/com/ignfab/minalac/generator/MinalacGenerator.java
@@ -2,8 +2,10 @@ package com.ignfab.minalac.generator;
 
 import java.io.File;
 import java.io.IOException;
+import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Calendar;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -60,6 +62,32 @@ public final class MinalacGenerator {
         throw new UnsupportedOperationException();
     }
 
+    private static void writeGenerationInfoFile(MinalacGeneratorCLI cli) throws MapWriteException {
+        String generationInfo = """
+            # Minalac Voxel Generator
+
+            ## Version information
+
+            %s
+
+            ## Generation information
+
+            Date: %s
+            Max tile size: %s
+            """.formatted(
+                VersionInfo.asMarkdown(),
+                new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(Calendar.getInstance().getTime()),
+                cli.maxTileSize()
+        );
+
+        // Write the information and parameters files into world root directory
+        try {
+            FileHelpers.write(new File(cli.outputPath().toFile(), "generation.md"), generationInfo);
+        } catch (IOException e) {
+            throw new MapWriteException("Failed to write information file", e);
+        }
+    }
+
     /**
      * Serves as the entry point for the program.
      *
@@ -77,17 +105,33 @@ public final class MinalacGenerator {
         MinalacGeneratorCLI cli = new MinalacGeneratorCLI();
         cli.parse(args);
 
+        System.out.printf("""
+
+            =======================
+            Minalac Voxel Generator
+            =======================
+
+            %s
+            Max tile size: %s
+
+            """,
+            VersionInfo.asText(),
+            cli.maxTileSize()
+        );
+
         File destination;
         String parameters = cli.readParameters();
         if (cli.saveDisabled())
             destination = null;
         else {
+            writeGenerationInfoFile(cli);
             destination = cli.outputPath().toFile();
-            // Write the parameters file in the world root directory
+
+            // Write the parameters files into world root directory
             try {
                 FileHelpers.write(new File(destination, "parameters.yaml"), parameters);
             } catch (IOException e) {
-                throw new MapWriteException("Failed to write parameters.yaml", e);
+                throw new MapWriteException("Failed to write parameters file", e);
             }
         }
 

--- a/src/main/java/com/ignfab/minalac/generator/MinalacGeneratorCLI.java
+++ b/src/main/java/com/ignfab/minalac/generator/MinalacGeneratorCLI.java
@@ -45,6 +45,7 @@ public class MinalacGeneratorCLI {
         options.addOption(new Option(null, "generation-disabled", false, "Stop before starting generation, after parameters parsed"));
         options.addOption(new Option(null, "save-disabled", false, "Stop before saving output file, after generation done"));
         options.addOption(new Option(null, "max-tile-size", true, "Set maximum tile size (may be passed using %s environment variable)".formatted(MAX_TILE_SIZE_ENVVAR_NAME)));
+        options.addOption(new Option(null, "version", false, "Display version and build information then exit"));
     }
 
     /**
@@ -66,6 +67,11 @@ public class MinalacGeneratorCLI {
 
         if (cmd.hasOption("h")) {
             usage();
+            System.exit(0);
+        }
+
+        if (cmd.hasOption("version")) {
+            System.out.println(VersionInfo.asText());
             System.exit(0);
         }
 

--- a/src/main/java/com/ignfab/minalac/generator/VersionInfo.java
+++ b/src/main/java/com/ignfab/minalac/generator/VersionInfo.java
@@ -1,0 +1,74 @@
+package com.ignfab.minalac.generator;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+/**
+ * Class managing information string about map generation.
+ */
+public final class VersionInfo {
+
+    private static final String VERSION = "Development version";
+    private static final String GIT_COMMIT;
+    private static final String GIT_BRANCH;
+    private static final String GIT_REMOTE;
+
+    static {
+
+        // Git information
+        Properties prop = new Properties();
+        try {
+            InputStream resource = MinalacGenerator.class.getClassLoader().getResourceAsStream("git.properties");
+            if (resource != null)
+                prop.load(resource);
+        } catch (IOException ex) {
+        }
+        GIT_COMMIT = prop.getProperty("git.commit.id", "");
+        String branch = prop.getProperty("git.branch", "");
+        if (branch.equals(GIT_COMMIT))
+            branch = "";
+        GIT_BRANCH = branch;
+        GIT_REMOTE = prop.getProperty("git.remote.origin.url");
+    }
+
+    private VersionInfo() {}
+
+    /**
+     * @return a string containing version information in markdown format.
+     */
+    public static String asMarkdown() {
+        String result = VERSION;
+
+        if (GIT_COMMIT.isBlank())
+            result = "%n%nNo git information%n".formatted();
+        else {
+            result = "%n%nGit information%n".formatted();
+            if (!GIT_REMOTE.isBlank())
+                result += "* remote: %s%n".formatted(GIT_REMOTE);
+            if (!GIT_BRANCH.isBlank())
+                result += "* branch: %s%n".formatted(GIT_BRANCH);
+            result += "* commit: %s".formatted(GIT_COMMIT);
+        }
+        return result;
+    }
+
+    /**
+     * @return a string containing version information in text format.
+     */
+    public static String asText() {
+        String result = VERSION;
+
+        if (GIT_COMMIT.isBlank())
+            result += "%nNo git information%n".formatted();
+        else {
+            result += "%nGit information:%n".formatted();
+            if (!GIT_REMOTE.isBlank())
+                result += "  remote: %s%n".formatted(GIT_REMOTE);
+            if (!GIT_BRANCH.isBlank())
+                result += "  branch: %s%n".formatted(GIT_BRANCH);
+            result += "  commit: %s%n".formatted(GIT_COMMIT);
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
There is no rush to merge this feature, PR is widely open to discussions.

### Changes

For each generation, create a summary file with generation information.

#### Feature description

A `generation.md` file is created aside world files, containing generation information:
* Generation date
* Git information

Some more information could be added later like generator version, service website, ...

### Reason

Main reason is to keep track of commit hash. This will be very useful when users will send us bug reports.

### Self-checks

- ~~The code has unit tests associated~~
- [x] The code has Javadoc Comments associated
- ~~Complex / Unexpected code is explained / justified with a small comment~~
- ~~Relevant documentation inside the `/docs` folder has been updated~~
- [x] All examples in `examples/` work the same (or have been adapted if subject to changes in this PR)
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [ ] The texts have been proofread (documentation, error messages, logs, comments...)
