### PR TITLE
chore(jackson): Migrate to Jackson 3

### DIFF
--- a/docs/usage/parameters/PostProcessing.md
+++ b/docs/usage/parameters/PostProcessing.md
@@ -104,8 +104,8 @@ A post-processor copying a metadata into another.
 **Extra parameters**:
 - `metadata` (required, `text`): Name of the metadata to copy.
 - `to` (required, `text`): Name of destination metadata.
-- `abortIfMetadataIsAbsent` (optional, default `no`): `yes` to stop the copy if the metadata is missing, `no` to allow the copy to proceed even if the metadata is missing (in this case, the metadata value will be empty).
-- `keepExisting` (optional, default `no`): `no` to overwrite existing data, `yes` to keep existing metadata.
+- `abortIfMetadataIsAbsent` (optional, default `false`): `true` to stop the copy if the metadata is missing, `false` to allow the copy to proceed even if the metadata is missing (in this case, the metadata value will be empty).
+- `keepExisting` (optional, default `false`): `false` to overwrite existing data, `true` to keep existing metadata.
 
 ### Metadata default
 

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,24 @@
         </repository>
     </repositories>
 
+    <dependencyManagement>
+        <dependencies>
+            <!--
+            BOM DEPENDENCIES
+            ================
+            These dependencies are BOMs (Bill of Materials).
+            They are used to provide the version of other dependencies included below.
+            -->
+            <dependency>
+                <groupId>tools.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>3.1.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <!--
         COMPILE DEPENDENCIES
@@ -113,25 +131,21 @@
         </dependency>
         <!-- Jackson (Yaml/Json deserialization) -->
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.20.0</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <groupId>tools.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>2.20.0</version>
         </dependency>
         <!-- Transitive dependencies for databind (If missing they might have a NoSuchMethodError)-->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.20</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.20.0</version>
         </dependency>
         <!-- Apache command line argument parsing -->
         <dependency>
@@ -253,8 +267,8 @@
                             <excludes>
                                 <exclude>**/module-info.class</exclude>
                                 <exclude>META-INF/MANIFEST.MF</exclude>
-                                <exclude>META-INF/LICENSE*</exclude>
-                                <exclude>META-INF/NOTICE*</exclude>
+                                <exclude>META-INF/*LICENSE*</exclude>
+                                <exclude>META-INF/*NOTICE*</exclude>
                                 <exclude>META-INF/*.SF</exclude>
                                 <exclude>META-INF/*.DSA</exclude>
                                 <exclude>META-INF/*.RSA</exclude>

--- a/src/main/java/com/ignfab/minalac/generator/MinalacGenerator.java
+++ b/src/main/java/com/ignfab/minalac/generator/MinalacGenerator.java
@@ -7,7 +7,6 @@ import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.geotools.api.referencing.FactoryException;
 
 import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
@@ -64,9 +63,8 @@ public final class MinalacGenerator {
      * Serves as the entry point for the program.
      *
      * @param args command line arguments
-     * @throws JsonProcessingException
      */
-    public static void main(String[] args) throws FactoryException, InterruptedException, MapWriteException, ParseException, TaskFailedException, TransformException, JsonProcessingException, TimeoutException, GenerationFailedException {
+    public static void main(String[] args) throws FactoryException, InterruptedException, MapWriteException, ParseException, TaskFailedException, TransformException, TimeoutException, GenerationFailedException {
         // Execution duration start
         Instant start = Instant.now();
         HttpTrustAllSSL.applyGlobally();

--- a/src/main/java/com/ignfab/minalac/generator/parameters/GenerationParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/GenerationParams.java
@@ -4,10 +4,11 @@ import java.beans.ConstructorProperties;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.parameters.tasks.TileTaskParams;
@@ -33,7 +34,7 @@ public class GenerationParams {
      * A placeholder for Yaml references than does not go anywhere else.
      * Content of this field will be ignored.
      */
-    @JsonSetter(nulls = Nulls.SKIP)
+    @JsonIgnore
     public JsonNode references;
 
     /**

--- a/src/main/java/com/ignfab/minalac/generator/parameters/JsonDelegateDeserialize.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/JsonDelegateDeserialize.java
@@ -5,14 +5,14 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.BeanDescription;
-import com.fasterxml.jackson.databind.DeserializationConfig;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier;
-import com.fasterxml.jackson.databind.deser.std.DelegatingDeserializer;
-import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.BeanDescription;
+import tools.jackson.databind.DeserializationConfig;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.deser.ValueDeserializerModifier;
+import tools.jackson.databind.deser.std.DelegatingDeserializer;
+import tools.jackson.databind.jsontype.TypeDeserializer;
 
 /**
  * Annotation to make Jackson use a custom delegating deserializer for a given class.
@@ -44,22 +44,22 @@ public @interface JsonDelegateDeserialize {
 
     /**
      * Jackson handler to wrap deserializer of annotated beans with the requested one.
-     * This should be registered in the {@link com.fasterxml.jackson.databind.ObjectMapper}:
+     * This should be registered in the {@link tools.jackson.databind.cfg.MapperBuilder}:
      * <pre>{@code
-     *  ObjectMapper mapper = ...;
+     *  MapperBuilder<?, ?> mapperBuilder = ...;
      *  SimpleModule module = new SimpleModule("MyModule");
      *  module.setDeserializerModifier(new JsonDelegateDeserialize.BeanModifier());
-     *  mapper.registerModule(module);
+     *  mapperBuilder.addModule(module);
      * }</pre>
      */
-    class BeanModifier extends BeanDeserializerModifier {
+    class BeanModifier extends ValueDeserializerModifier {
         @Override
-        public JsonDeserializer<?> modifyDeserializer(DeserializationConfig config, BeanDescription beanDesc, JsonDeserializer<?> deserializer) {
-            JsonDelegateDeserialize annotation = beanDesc.getClassAnnotations().get(JsonDelegateDeserialize.class);
+        public ValueDeserializer<?> modifyDeserializer(DeserializationConfig config, BeanDescription.Supplier beanDescRef, ValueDeserializer<?> deserializer) {
+            JsonDelegateDeserialize annotation = beanDescRef.getClassAnnotations().get(JsonDelegateDeserialize.class);
             if (annotation == null || annotation.using() == DelegatingDeserializer.class)
                 return deserializer;
             try {
-                return annotation.using().getConstructor(JsonDeserializer.class).newInstance(deserializer);
+                return annotation.using().getConstructor(ValueDeserializer.class).newInstance(deserializer);
             } catch (ReflectiveOperationException e) {
                 throw new IllegalStateException("Failed to construct delegating deserializer from " + annotation.using(), e);
             }

--- a/src/main/java/com/ignfab/minalac/generator/parameters/OutputFormat.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/OutputFormat.java
@@ -1,21 +1,19 @@
 package com.ignfab.minalac.generator.parameters;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.ObjectCodec;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.jsontype.NamedType;
-import com.fasterxml.jackson.databind.module.SimpleModule;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DatabindException;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.cfg.MapperBuilder;
+import tools.jackson.databind.jsontype.NamedType;
+import tools.jackson.databind.module.SimpleModule;
 
 import com.ignfab.minalac.generator.parameters.placeables.PlaceableParams;
 import com.ignfab.minalac.generator.world.VoxelWorld;
@@ -73,31 +71,31 @@ public class OutputFormat {
      * Creates a new {@code PlaceableParams} out of a {@code JsonNode} if a {@code voxelParams} class have been given to constructor.
      *
      * @param node {@code JsonNode} to interpret as {@code PlaceableParams}
-     * @param codec Codec to use for deserialization
+     * @param context Context to use for deserialization
      *
      * @return A new {@code PlaceableParams}
      */
-    public PlaceableParams createVoxelParams(JsonNode node, ObjectCodec codec) throws JsonProcessingException {
+    public PlaceableParams createVoxelParams(JsonNode node, DeserializationContext context) throws JacksonException {
         if (voxelParams == null)
             throw new IllegalArgumentException("Selected format does not have a default voxel type structure, add `type` attribute");
 
-        return codec.treeToValue(node, voxelParams);
-    };
+        return context.readTreeAsValue(node, voxelParams);
+    }
 
     /**
      * Register stuff needed for format deserialization.
      *
-     * @param mapper {@code ObjectMapper} into which register stuff
+     * @param mapperBuilder {@code MapperBuilder} into which register stuff
      */
-    public void registerPlaceableDeserializer(ObjectMapper mapper) {
+    public void registerPlaceableDeserializer(MapperBuilder<?, ?> mapperBuilder) {
         // Register format specific deserializer
         SimpleModule module = new SimpleModule("OutputFormatModule");
         module.addDeserializer(PlaceableParams.class, new PlaceableParams.Deserializer(this));
-        mapper.registerModule(module);
+        mapperBuilder.addModule(module);
 
         // Register base "voxel" type
         if (voxelParams != null)
-            mapper.registerSubtypes(new NamedType(voxelParams, "voxel"));
+            mapperBuilder.registerSubtypes(new NamedType(voxelParams, "voxel"));
     }
 
     /**
@@ -105,7 +103,7 @@ public class OutputFormat {
      *
      * It maps format name to a {@code OutputFormat} object.
      */
-    static class Deserializer extends JsonDeserializer<OutputFormat> {
+    static class Deserializer extends ValueDeserializer<OutputFormat> {
 
         private final Map<String, OutputFormat> formats = new HashMap<>();
 
@@ -114,12 +112,11 @@ public class OutputFormat {
         }
 
         @Override
-        public OutputFormat deserialize(JsonParser jp, DeserializationContext ctxt)
-            throws IOException, JsonMappingException {
+        public OutputFormat deserialize(JsonParser parser, DeserializationContext context) throws DatabindException {
 
-            String name = jp.readValueAs(String.class);
+            String name = parser.readValueAs(String.class);
             if (!formats.containsKey(name))
-                throw new JsonMappingException(jp, "Invalid value for the \"format\" property. Should be one of %s.".formatted(formats.keySet()));
+                throw DatabindException.from(parser, "Invalid value for the \"format\" property. Should be one of %s.".formatted(formats.keySet()));
 
             return formats.get(name);
         }

--- a/src/main/java/com/ignfab/minalac/generator/parameters/ParamsParser.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/ParamsParser.java
@@ -1,32 +1,32 @@
 package com.ignfab.minalac.generator.parameters;
 
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.exc.MismatchedInputException;
-import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
-import com.fasterxml.jackson.databind.jsontype.NamedType;
-import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.fasterxml.jackson.dataformat.yaml.YAMLAnchorReplayingFactory;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.StreamReadFeature;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.exc.MismatchedInputException;
+import tools.jackson.databind.exc.ValueInstantiationException;
+import tools.jackson.databind.jsontype.NamedType;
+import tools.jackson.databind.module.SimpleModule;
+import tools.jackson.dataformat.yaml.YAMLAnchorReplayingFactory;
+import tools.jackson.dataformat.yaml.YAMLMapper;
 
 /**
  * A Json/Yaml parser able to decode parameters into a {@code Generation} object.
  */
 public class ParamsParser {
-    private final ObjectMapper mapper;
+    private final YAMLMapper.Builder mapperBuilder;
     private final OutputFormat.Deserializer formatDeserializer = new OutputFormat.Deserializer();
 
     /**
      * Creates a new Parser.
      */
     public ParamsParser() {
-        mapper = new ObjectMapper(new YAMLAnchorReplayingFactory());
-        mapper.configure(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES, true);
-        // To prevent duplicates in map type parameters.
-        mapper.enable(JsonParser.Feature.STRICT_DUPLICATE_DETECTION);
+        mapperBuilder = YAMLMapper.builder(new YAMLAnchorReplayingFactory())
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true)
+            .configure(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES, true)
+            // To prevent duplicates in map type parameters.
+            .enable(StreamReadFeature.STRICT_DUPLICATE_DETECTION);
     }
 
     /**
@@ -35,9 +35,9 @@ public class ParamsParser {
      * @param serialized A string containing the generation parameters data in Json or Yaml format
      * @return the corresponding generation parameters object.
      * @throws ParseException if an error occurs during deserialization such as an invalid structure
-     * @throws JsonProcessingException
+     * @throws JacksonException
      */
-    public GenerationParams parse(String serialized) throws ParseException, JsonProcessingException {
+    public GenerationParams parse(String serialized) throws ParseException, JacksonException {
         GenerationParams params;
         SimpleModule module;
 
@@ -45,12 +45,14 @@ public class ParamsParser {
         module = new SimpleModule("MinalacParserModule");
         module.addDeserializer(OutputFormat.class, formatDeserializer);
         module.setDeserializerModifier(new JsonDelegateDeserialize.BeanModifier());
-        mapper.registerModule(module);
+        mapperBuilder.addModule(module);
+
+        YAMLMapper mapper = mapperBuilder.build();
 
         JsonNode document;
         try {
             document = mapper.readTree(serialized);
-        } catch (JsonParseException e) {
+        } catch (JacksonException e) {
             throw new ParseException(e);
         }
 
@@ -58,14 +60,16 @@ public class ParamsParser {
             throw new ParseException("Missing format field!");
 
         // Deserialize output format only
-        OutputFormat format = mapper.readValue(document.get("format").asText(), OutputFormat.class);
+        OutputFormat format = mapper.readValue(document.get("format").asString(), OutputFormat.class);
 
         // Register format specific deserializer
-        format.registerPlaceableDeserializer(mapper);
+        YAMLMapper.Builder rebuilder = mapper.rebuild();
+        format.registerPlaceableDeserializer(rebuilder);
 
         // Deserialize the whole parameter object
         try {
-            params = mapper.treeToValue(document, GenerationParams.class);
+            // Rebuild the mapper because format-specific configuration was added
+            params = rebuilder.build().treeToValue(document, GenerationParams.class);
         } catch (MismatchedInputException | ValueInstantiationException e) {
             throw new ParseException(e);
         }
@@ -86,7 +90,7 @@ public class ParamsParser {
      * @param <T> The type of the {@code PolymorphicParams} subclass
      */
     public <T extends PolymorphicParams> void registerParams(String name, Class<T> clazz) {
-        mapper.registerSubtypes(new NamedType(clazz, name));
+        mapperBuilder.registerSubtypes(new NamedType(clazz, name));
     }
 
     /**

--- a/src/main/java/com/ignfab/minalac/generator/parameters/ValueParser.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/ValueParser.java
@@ -1,15 +1,14 @@
 package com.ignfab.minalac.generator.parameters;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DatabindException;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 /**
  * Class parsing values into different types according to a given type name.
@@ -83,17 +82,15 @@ public record ValueParser<T>(Class<T> type, Function<Object, ? extends T> parser
     /**
      * A custom deserializer for {@code ValueParser}s.
      */
-    static class Deserializer extends JsonDeserializer<ValueParser<?>> {
+    static class Deserializer extends ValueDeserializer<ValueParser<?>> {
 
         @Override
-        public ValueParser<?> deserialize(JsonParser jp, DeserializationContext ctxt)
-            throws IOException {
-
-            String name = jp.readValueAs(String.class);
+        public ValueParser<?> deserialize(JsonParser parser, DeserializationContext context) {
+            String name = parser.readValueAs(String.class);
             try {
                 return ValueParser.get(name);
             } catch (IllegalArgumentException e) {
-                throw new JsonMappingException(jp, "Invalid parser name '%s'. Should be one of %s.".formatted(name, PARSERS.keySet()));
+                throw DatabindException.from(parser, "Invalid parser name '%s'. Should be one of %s.".formatted(name, PARSERS.keySet()));
             }
         }
     }

--- a/src/main/java/com/ignfab/minalac/generator/parameters/heightmaps/ReadableHeightmapParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/heightmaps/ReadableHeightmapParams.java
@@ -1,14 +1,12 @@
 package com.ignfab.minalac.generator.parameters.heightmaps;
 
-import java.io.IOException;
-
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.deser.std.DelegatingDeserializer;
-import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.deser.std.DelegatingDeserializer;
+import tools.jackson.databind.jsontype.TypeDeserializer;
 
 import com.ignfab.minalac.generator.generation.heightmaps.HeightmapDeclarationStore;
 import com.ignfab.minalac.generator.generation.heightmaps.ReadableHeightmapSpec;
@@ -56,21 +54,21 @@ public interface ReadableHeightmapParams {
          * Creates a new instance.
          * @param delegate The default deserializer.
          */
-        public Deserializer(JsonDeserializer<?> delegate) {
+        public Deserializer(ValueDeserializer<?> delegate) {
             super(delegate);
         }
 
         @Override
-        protected JsonDeserializer<?> newDelegatingInstance(JsonDeserializer<?> delegate) {
+        protected ValueDeserializer<?> newDelegatingInstance(ValueDeserializer<?> delegate) {
             return new Deserializer(delegate);
         }
 
         @Override
-        public Object deserializeWithType(JsonParser jsonParser, DeserializationContext deserializationContext, TypeDeserializer typeDeserializer) throws IOException {
-            return switch (jsonParser.currentToken()) {
-                case VALUE_NUMBER_INT -> new ConstantHeightmapParams(jsonParser.getIntValue());
-                case VALUE_STRING -> new WritableHeightmapParams(jsonParser.getText());
-                default -> super.deserializeWithType(jsonParser, deserializationContext, typeDeserializer);
+        public Object deserializeWithType(JsonParser parser, DeserializationContext context, TypeDeserializer typeDeserializer) {
+            return switch (parser.currentToken()) {
+                case VALUE_NUMBER_INT -> new ConstantHeightmapParams(parser.getIntValue());
+                case VALUE_STRING -> new WritableHeightmapParams(parser.getString());
+                default -> super.deserializeWithType(parser, context, typeDeserializer);
             };
         }
     }

--- a/src/main/java/com/ignfab/minalac/generator/parameters/heightmaps/RemapHeightmapParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/heightmaps/RemapHeightmapParams.java
@@ -1,16 +1,15 @@
 package com.ignfab.minalac.generator.parameters.heightmaps;
 
 import java.beans.ConstructorProperties;
-import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.IntUnaryOperator;
 
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.KeyDeserializer;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.KeyDeserializer;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 import com.ignfab.minalac.generator.generation.heightmaps.HeightmapDeclarationStore;
 import com.ignfab.minalac.generator.generation.heightmaps.ReadableHeightmapSpec;
@@ -74,7 +73,7 @@ public class RemapHeightmapParams implements ReadableHeightmapParams {
 
     static class ValuesKeyDeserializer extends KeyDeserializer {
         @Override
-        public Object deserializeKey(String s, DeserializationContext deserializationContext) throws IOException {
+        public Object deserializeKey(String s, DeserializationContext context) {
             return IntegerIntervalParams.FallbackParams.Deserializer.stringToFallbackParams(s);
         }
     }

--- a/src/main/java/com/ignfab/minalac/generator/parameters/heightmaps/WritableHeightmapParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/heightmaps/WritableHeightmapParams.java
@@ -1,15 +1,14 @@
 package com.ignfab.minalac.generator.parameters.heightmaps;
 
 import java.beans.ConstructorProperties;
-import java.io.IOException;
 
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.deser.std.DelegatingDeserializer;
-import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.deser.std.DelegatingDeserializer;
+import tools.jackson.databind.jsontype.TypeDeserializer;
 
 import com.ignfab.minalac.generator.generation.heightmaps.HeightmapDeclarationStore;
 import com.ignfab.minalac.generator.generation.heightmaps.WritableHeightmapSpec;
@@ -56,20 +55,20 @@ public class WritableHeightmapParams implements ReadableHeightmapParams {
          * Creates a new instance.
          * @param delegate The default deserializer.
          */
-        public Deserializer(JsonDeserializer<?> delegate) {
+        public Deserializer(ValueDeserializer<?> delegate) {
             super(delegate);
         }
 
         @Override
-        protected JsonDeserializer<?> newDelegatingInstance(JsonDeserializer<?> delegate) {
+        protected ValueDeserializer<?> newDelegatingInstance(ValueDeserializer<?> delegate) {
             return new Deserializer(delegate);
         }
 
         @Override
-        public Object deserializeWithType(JsonParser jsonParser, DeserializationContext deserializationContext, TypeDeserializer typeDeserializer) throws IOException {
-            return switch (jsonParser.currentToken()) {
-                case VALUE_STRING -> new WritableHeightmapParams(jsonParser.getText());
-                default -> super.deserializeWithType(jsonParser, deserializationContext, typeDeserializer);
+        public Object deserializeWithType(JsonParser parser, DeserializationContext context, TypeDeserializer typeDeserializer) {
+            return switch (parser.currentToken()) {
+                case VALUE_STRING -> new WritableHeightmapParams(parser.getString());
+                default -> super.deserializeWithType(parser, context, typeDeserializer);
             };
         }
     }

--- a/src/main/java/com/ignfab/minalac/generator/parameters/placeables/CombinedPlaceableParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/placeables/CombinedPlaceableParams.java
@@ -3,9 +3,9 @@ package com.ignfab.minalac.generator.parameters.placeables;
 import java.util.LinkedList;
 import java.util.List;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.ObjectCodec;
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
 
 import com.ignfab.minalac.generator.placeables.CombinedPlaceable;
 import com.ignfab.minalac.generator.placeables.Placeable;
@@ -27,11 +27,11 @@ public class CombinedPlaceableParams extends PlaceableParams {
      * This class is suposed to be instantiated only from {@link PlaceableParams} custom deserializer.
      *
      * @param array Array of {@code JsonNode} deserializable into {@code Placeable}
-     * @param codec Codec to use to deserialize placeables
+     * @param context Context to use to deserialize placeables
      */
-    public CombinedPlaceableParams(Iterable<JsonNode> array, ObjectCodec codec) throws JsonProcessingException {
+    public CombinedPlaceableParams(Iterable<JsonNode> array, DeserializationContext context) throws JacksonException {
         for (JsonNode node : array)
-            placeableParams.add(codec.treeToValue(node, PlaceableParams.class));
+            placeableParams.add(context.readTreeAsValue(node, PlaceableParams.class));
     }
 
     @Override

--- a/src/main/java/com/ignfab/minalac/generator/parameters/placeables/PlaceableParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/placeables/PlaceableParams.java
@@ -1,15 +1,13 @@
 package com.ignfab.minalac.generator.parameters.placeables;
 
-import java.io.IOException;
 import java.util.Map.Entry;
 
-import com.fasterxml.jackson.core.JacksonException;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.ObjectCodec;
-import com.fasterxml.jackson.core.exc.InputCoercionException;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.exc.InputCoercionException;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ValueDeserializer;
 
 import com.ignfab.minalac.generator.parameters.OutputFormat;
 import com.ignfab.minalac.generator.parameters.placeables.patterns.PatternParams;
@@ -28,7 +26,7 @@ public abstract class PlaceableParams {
      * This deserializer is able to deserialize various forms of {@link PlaceableParams}, depending on {@link OutputFormat}:
      * Nothing, Voxels (short and long description), Structures.
      */
-    public static class Deserializer extends JsonDeserializer<PlaceableParams> {
+    public static class Deserializer extends ValueDeserializer<PlaceableParams> {
         private OutputFormat format;
 
         /**
@@ -41,24 +39,21 @@ public abstract class PlaceableParams {
         }
 
         @Override
-        public PlaceableParams deserialize(JsonParser jp, DeserializationContext ctxt)
-            throws IOException, JacksonException {
+        public PlaceableParams deserialize(JsonParser parser, DeserializationContext context) throws JacksonException {
+            JsonNode node = parser.readValueAsTree();
 
-            ObjectCodec codec = jp.getCodec();
-            JsonNode node = codec.readTree(jp);
-
-            if (node.isTextual()) {
+            if (node.isString()) {
                 // "Nothing" string stands for NoVoxelParams (places nothing)
-                if (node.textValue().equals("nothing"))
+                if (node.asString().equals("nothing"))
                     return new NothingParams();
                 // If value is a string, try to serialize other string using "shortcut" format method.
-                return format.createVoxelParams(node.textValue());
+                return format.createVoxelParams(node.asString());
             }
             if (node.isArray())
-                return new CombinedPlaceableParams(node, codec);
+                return new CombinedPlaceableParams(node, context);
 
             if (!node.isObject())
-                throw new InputCoercionException(jp, "Placeable should be either a string, an object or a list of placeables", node.asToken(), PlaceableParams.class);
+                throw new InputCoercionException(parser, "Placeable should be either a string, an object or a list of placeables", node.asToken(), PlaceableParams.class);
 
             if (node.properties().size() == 1) {
                 // If value is an object with only one property, test if its one of hardcoded keys
@@ -69,18 +64,18 @@ public abstract class PlaceableParams {
                         return new NothingParams();
                     // Explicit way to deserialize voxels (could be handy for disambiguation)
                     case "voxel":
-                        return format.createVoxelParams(property.getValue(), codec);
+                        return format.createVoxelParams(property.getValue(), context);
                     // For structures, relies on PlaceableStructureParams type deduction
                     case "structure":
-                        return codec.treeToValue(property.getValue(), PlaceableStructureParams.class);
+                        return context.readTreeAsValue(property.getValue(), PlaceableStructureParams.class);
                     // For patterns, relies on PatternParams type deduction
                     case "pattern":
-                        return codec.treeToValue(property.getValue(), PatternParams.class);
+                        return context.readTreeAsValue(property.getValue(), PatternParams.class);
                 }
             }
 
             // If none of the above fits, fallback to voxel long description
-            return format.createVoxelParams(node, codec);
+            return format.createVoxelParams(node, context);
         }
     }
 

--- a/src/main/java/com/ignfab/minalac/generator/parameters/placeables/patterns/RepeatPatternParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/placeables/patterns/RepeatPatternParams.java
@@ -28,7 +28,7 @@ public class RepeatPatternParams extends PatternParams {
     /**
      * Represents shifts along the 3 axes.
      */
-    public class CoordShifts implements Positioned3d {
+    public static class CoordShifts implements Positioned3d {
         /**
          * Number of voxels to shift on the X-axis (optional).
          */

--- a/src/main/java/com/ignfab/minalac/generator/parameters/placeables/structures/BlueprintPlaceableStructureParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/placeables/structures/BlueprintPlaceableStructureParams.java
@@ -1,7 +1,6 @@
 package com.ignfab.minalac.generator.parameters.placeables.structures;
 
 import java.beans.ConstructorProperties;
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -12,14 +11,13 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
-import com.fasterxml.jackson.core.JacksonException;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.ObjectCodec;
-import com.fasterxml.jackson.core.exc.InputCoercionException;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.exc.InputCoercionException;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 import com.ignfab.minalac.generator.parameters.placeables.PlaceableParams;
 import com.ignfab.minalac.generator.placeables.Nothing;
@@ -231,35 +229,32 @@ public class BlueprintPlaceableStructureParams extends PlaceableStructureParams.
      * This deserializer ensures that we can have only : a string, a list of strings or a list of lists of strings.
      * A list mixing strings and lists of strings will be rejected.
      */
-    private static final class BlueprintDeserializer extends JsonDeserializer<Blueprint> {
+    private static final class BlueprintDeserializer extends ValueDeserializer<Blueprint> {
 
         @Override
-        public Blueprint deserialize(JsonParser jp, DeserializationContext ctxt)
-                throws IOException, JacksonException {
-
-            ObjectCodec codec = jp.getCodec();
-            JsonNode node = codec.readTree(jp);
+        public Blueprint deserialize(JsonParser parser, DeserializationContext context) throws JacksonException {
+            JsonNode node = parser.readValueAsTree();
 
             // Two possible exception thrown under various conditions:
-            final InputCoercionException typeError = new InputCoercionException(jp, "Blueprint should be either a string, a list of strings or a list of lists of strings", node.asToken(), PlaceableParams.class);
-            final InputCoercionException dimensionError = new InputCoercionException(jp, "Mixed list levels of strings in blueprint", node.asToken(), PlaceableParams.class);
+            final InputCoercionException typeError = new InputCoercionException(parser, "Blueprint should be either a string, a list of strings or a list of lists of strings", node.asToken(), PlaceableParams.class);
+            final InputCoercionException dimensionError = new InputCoercionException(parser, "Mixed list levels of strings in blueprint", node.asToken(), PlaceableParams.class);
 
              // One dimensional blueprint (single string)
-            if (node.isTextual())
-                return new Blueprint(node.asText(), null, null);
+            if (node.isString())
+                return new Blueprint(node.asString(), null, null);
 
             // Two or three dimensional: should be a non empty array
-            if (node.isArray() && node.elements().hasNext()) {
+            if (node.isArray() && !node.isEmpty()) {
                 // Inspect first element to tell how many dimensions we have
-                JsonNode first = node.elements().next();
+                JsonNode first = node.get(0);
 
                 // Two dimensional blueprint (list of strings)
-                if (first.isTextual()) {
+                if (first.isString()) {
                     LinkedList<String> list = new LinkedList<>();
                     for (JsonNode text : node) {
-                        if (!text.isTextual())
+                        if (!text.isString())
                             throw dimensionError;
-                        list.add(text.asText());
+                        list.add(text.asString());
                     }
                     return new Blueprint(null, list, null);
                 }
@@ -272,9 +267,9 @@ public class BlueprintPlaceableStructureParams extends PlaceableStructureParams.
                             throw dimensionError;
                         LinkedList<String> list = new LinkedList<>();
                         for (JsonNode text : array) {
-                            if (!text.isTextual())
+                            if (!text.isString())
                                 throw typeError;
-                            list.add(text.asText());
+                            list.add(text.asString());
                         }
                         result.add(list);
                     }

--- a/src/main/java/com/ignfab/minalac/generator/parameters/placeables/structures/PlaceableStructureParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/placeables/structures/PlaceableStructureParams.java
@@ -1,19 +1,17 @@
 package com.ignfab.minalac.generator.parameters.placeables.structures;
 
-import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.core.JacksonException;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.ObjectCodec;
-import com.fasterxml.jackson.core.exc.InputCoercionException;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.exc.InputCoercionException;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 import com.ignfab.minalac.generator.parameters.placeables.PlaceableParams;
 import com.ignfab.minalac.generator.placeables.PlaceableStructure;
@@ -52,31 +50,28 @@ public final class PlaceableStructureParams extends PlaceableParams {
     /**
      * Custom deserializer creating a PlaceableStructureParams out of a structure list or single structure.
      */
-    public static class Deserializer extends JsonDeserializer<PlaceableStructureParams> {
+    public static class Deserializer extends ValueDeserializer<PlaceableStructureParams> {
 
         @Override
-        public PlaceableStructureParams deserialize(JsonParser jp, DeserializationContext ctxt)
-                throws IOException, JacksonException {
-
-            ObjectCodec codec = jp.getCodec();
-            JsonNode node = codec.readTree(jp);
+        public PlaceableStructureParams deserialize(JsonParser parser, DeserializationContext context) throws JacksonException {
+            JsonNode node = parser.readValueAsTree();
 
             // Decode array into structure list
             if (node.isArray()) {
                 List<Variant> list = new LinkedList<>();
                 for (JsonNode item : node)
-                    list.add(codec.treeToValue(item, Variant.class));
+                    list.add(context.readTreeAsValue(item, Variant.class));
 
                 return new PlaceableStructureParams(list);
             }
 
             // Decode single structure into a single value list
             if (node.isObject()) {
-                Variant structure = codec.treeToValue(node, Variant.class);
+                Variant structure = context.readTreeAsValue(node, Variant.class);
                 return new PlaceableStructureParams(List.of(structure));
             }
 
-            throw new InputCoercionException(jp, "Structure should be either a list or an single structure", node.asToken(), PlaceableStructureParams.class);
+            throw new InputCoercionException(parser, "Structure should be either a list or an single structure", node.asToken(), PlaceableStructureParams.class);
         }
     }
 

--- a/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/PostProcessorParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/processors/post/PostProcessorParams.java
@@ -1,15 +1,14 @@
 package com.ignfab.minalac.generator.parameters.processors.post;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.deser.std.DelegatingDeserializer;
-import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonToken;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.deser.std.DelegatingDeserializer;
+import tools.jackson.databind.jsontype.TypeDeserializer;
 
 import com.ignfab.minalac.generator.parameters.JsonDelegateDeserialize;
 import com.ignfab.minalac.generator.parameters.PolymorphicParams;
@@ -35,24 +34,24 @@ public abstract class PostProcessorParams extends PolymorphicParams {
          * Creates a new instance.
          * @param delegate The default deserializer.
          */
-        public Deserializer(JsonDeserializer<?> delegate) {
+        public Deserializer(ValueDeserializer<?> delegate) {
             super(delegate);
         }
 
         @Override
-        protected JsonDeserializer<?> newDelegatingInstance(JsonDeserializer<?> delegate) {
+        protected ValueDeserializer<?> newDelegatingInstance(ValueDeserializer<?> delegate) {
             return new Deserializer(delegate);
         }
 
         @Override
-        public Object deserializeWithType(JsonParser jsonParser, DeserializationContext deserializationContext, TypeDeserializer typeDeserializer) throws IOException {
-            if (jsonParser.isExpectedStartArrayToken()) {
+        public Object deserializeWithType(JsonParser parser, DeserializationContext context, TypeDeserializer typeDeserializer) {
+            if (parser.isExpectedStartArrayToken()) {
                 List<PostProcessorParams> sequence = new ArrayList<>();
-                while (jsonParser.nextToken() != JsonToken.END_ARRAY)
-                    sequence.add(jsonParser.readValueAs(PostProcessorParams.class));
+                while (parser.nextToken() != JsonToken.END_ARRAY)
+                    sequence.add(parser.readValueAs(PostProcessorParams.class));
                 return new SequentialPostProcessorParams(sequence);
             }
-            return super.deserializeWithType(jsonParser, deserializationContext, typeDeserializer);
+            return super.deserializeWithType(parser, context, typeDeserializer);
         }
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/parameters/utils/IntegerIntervalParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/utils/IntegerIntervalParams.java
@@ -1,16 +1,15 @@
 package com.ignfab.minalac.generator.parameters.utils;
 
 import java.beans.ConstructorProperties;
-import java.io.IOException;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DatabindException;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 import com.ignfab.minalac.generator.utils.IntegerInterval;
 
@@ -125,12 +124,11 @@ public abstract class IntegerIntervalParams {
      *
      * It maps format name to a {@code CustomParams} object.
      */
-    public static class Deserializer extends JsonDeserializer<FallbackParams> {
+    public static class Deserializer extends ValueDeserializer<FallbackParams> {
 
         @Override
-        public FallbackParams deserialize(JsonParser jp, DeserializationContext ctxt)
-            throws IOException, JsonMappingException {
-            return stringToFallbackParams(jp.readValueAs(String.class));
+        public FallbackParams deserialize(JsonParser parser, DeserializationContext context) throws DatabindException {
+            return stringToFallbackParams(parser.readValueAs(String.class));
         }
 
          /**

--- a/src/test/java/com/ignfab/minalac/generator/parameters/JsonDelegateDeserializeTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/JsonDelegateDeserializeTest.java
@@ -1,19 +1,17 @@
 package com.ignfab.minalac.generator.parameters;
 
-import java.io.IOException;
-
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.deser.std.DelegatingDeserializer;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.deser.std.DelegatingDeserializer;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 public class JsonDelegateDeserializeTest {
     @Test
-    void testBeanDeserializerModifier() throws JsonProcessingException {
+    void testBeanDeserializerModifier() throws JacksonException {
         TestingDeserializer.flag = false;
         ParamsTester.deserialize(AnnotatedClass.class, "{}");
         assertTrue(TestingDeserializer.flag, "Deserializer should have been called");
@@ -26,19 +24,19 @@ public class JsonDelegateDeserializeTest {
     public static class TestingDeserializer extends DelegatingDeserializer {
         private static boolean flag;
 
-        public TestingDeserializer(JsonDeserializer<?> delegate) {
+        public TestingDeserializer(ValueDeserializer<?> delegate) {
             super(delegate);
         }
 
         @Override
-        protected JsonDeserializer<?> newDelegatingInstance(JsonDeserializer<?> delegate) {
+        protected ValueDeserializer<?> newDelegatingInstance(ValueDeserializer<?> delegate) {
             return new TestingDeserializer(delegate);
         }
 
         @Override
-        public Object deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
+        public Object deserialize(JsonParser parser, DeserializationContext context) {
             flag = true;
-            return super.deserialize(jsonParser, deserializationContext);
+            return super.deserialize(parser, context);
         }
     }
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/OutputFormatTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/OutputFormatTest.java
@@ -1,10 +1,12 @@
 package com.ignfab.minalac.generator.parameters;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.cfg.MapperBuilder;
+import tools.jackson.dataformat.yaml.YAMLMapper;
 
 import com.ignfab.minalac.generator.parameters.placeables.PlaceableParams;
 import com.ignfab.minalac.generator.parameters.placeables.voxels.TestingVoxelParams;
@@ -39,38 +41,40 @@ public class OutputFormatTest {
 
     @Test
     @DisplayName("Test createVoxelParams using default class")
-    public void testCreateVoxelParamsDefault() throws JsonProcessingException {
+    public void testCreateVoxelParamsDefault() throws JacksonException {
         OutputFormat format = new OutputFormat(
             () -> null,
             TestingVoxelParams.class,
             TestingVoxelParams::new
         );
 
-        ObjectMapper mapper = new ObjectMapper();
-        format.registerPlaceableDeserializer(mapper);
+        MapperBuilder<?, ?> builder = YAMLMapper.builder();
+        format.registerPlaceableDeserializer(builder);
+        ObjectMapper mapper = builder.build();
 
         JsonNode node = mapper.readValue("{ \"name\": \"test\" }", JsonNode.class);
 
-        PlaceableParams params = assertDoesNotThrow(() -> format.createVoxelParams(node, mapper));
+        PlaceableParams params = assertDoesNotThrow(() -> format.createVoxelParams(node, mapper._deserializationContext()));
         TestingVoxelParams testingParams = assertInstanceOf(TestingVoxelParams.class, params);
         assertEquals(testingParams.name, "test");
     }
 
     @Test
     @DisplayName("Test createVoxelParams with null default and shortcut")
-    public void testCreateVoxelParamsNull() throws JsonProcessingException {
+    public void testCreateVoxelParamsNull() throws JacksonException {
         OutputFormat format = assertDoesNotThrow(() -> new OutputFormat(
             () -> null,
             null,
             null
         ));
 
-        ObjectMapper mapper = new ObjectMapper();
-        format.registerPlaceableDeserializer(mapper);
+        MapperBuilder<?, ?> builder = YAMLMapper.builder();
+        format.registerPlaceableDeserializer(builder);
+        ObjectMapper mapper = builder.build();
 
         JsonNode node = mapper.readValue("{ \"toto\": \"tata\" }", JsonNode.class);
 
         assertThrows(IllegalArgumentException.class, () -> format.createVoxelParams("test"));
-        assertThrows(IllegalArgumentException.class, () -> format.createVoxelParams(node, mapper));
+        assertThrows(IllegalArgumentException.class, () -> format.createVoxelParams(node, mapper._deserializationContext()));
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/parameters/ParamsParserTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/ParamsParserTest.java
@@ -284,4 +284,31 @@ public class ParamsParserTest {
         assertEquals("juliet", tasksParams.requiredField);
         assertEquals("romeo", tasksParams.optionalField);
     }
+
+    @Test
+    public void testParseNestedReferences() {
+        ParamsParser parser = newParser();
+        parser.registerParams("deathStar", TestingTaskParams.class);
+
+        GenerationParams params = assertDoesNotThrow(() -> parser.parse("""
+            references:
+              - &sith vador
+              - &jedi luke
+            forEachTile:
+              death-star-1: &death-star
+                type: deathStar
+                requiredField: *sith
+                optionalField: *jedi
+              death-star-2: *death-star
+            """
+            + MINIMAL_YAML
+        ));
+
+        TestingTaskParams tasksParams1 = assertInstanceOf(TestingTaskParams.class, params.forEachTile.get("death-star-1"));
+        assertEquals("vador", tasksParams1.requiredField);
+        assertEquals("luke", tasksParams1.optionalField);
+        TestingTaskParams tasksParams2 = assertInstanceOf(TestingTaskParams.class, params.forEachTile.get("death-star-2"));
+        assertEquals("vador", tasksParams2.requiredField);
+        assertEquals("luke", tasksParams2.optionalField);
+    }
 }

--- a/src/test/java/com/ignfab/minalac/generator/parameters/ParamsTester.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/ParamsTester.java
@@ -1,12 +1,14 @@
 package com.ignfab.minalac.generator.parameters;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.StreamReadFeature;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.cfg.MapperBuilder;
+import tools.jackson.databind.jsontype.NamedType;
+import tools.jackson.databind.module.SimpleModule;
+import tools.jackson.dataformat.yaml.YAMLMapper;
 
 import com.ignfab.minalac.generator.parameters.placeables.voxels.TestingVoxelParams;
 
@@ -30,24 +32,25 @@ public final class ParamsTester {
      * @param cls class to deserialize to
      * @param serialized text to deserialize
      * @param format output format to use for deserialization
-     * @param mapper mapper to use for deserialization
+     * @param builder mapper builder to use for deserialization
      *
      * @param <T> type of deserialized object
      *
      * @return deserialized object
      */
-    public static <T> T deserialize(Class<T> cls, String serialized, OutputFormat format, ObjectMapper mapper) throws JsonProcessingException {
-        mapper.configure(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES, true);
-        mapper.enable(JsonParser.Feature.STRICT_DUPLICATE_DETECTION);
+    public static <T> T deserialize(Class<T> cls, String serialized, OutputFormat format, MapperBuilder<?, ?> builder) throws JacksonException {
+        builder.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
+        builder.configure(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES, true);
+        builder.enable(StreamReadFeature.STRICT_DUPLICATE_DETECTION);
 
         SimpleModule module = new SimpleModule("ParamsTesterModule");
         module.setDeserializerModifier(new JsonDelegateDeserialize.BeanModifier());
-        mapper.registerModule(module);
+        builder.addModule(module);
 
-        format.registerPlaceableDeserializer(mapper);
+        format.registerPlaceableDeserializer(builder);
 
+        ObjectMapper mapper = builder.build();
         JsonNode node = mapper.readValue(serialized, JsonNode.class);
-
         return mapper.treeToValue(node, cls);
     }
 
@@ -62,8 +65,8 @@ public final class ParamsTester {
      *
      * @return deserialized object
      */
-    public static <T> T deserialize(Class<T> cls, String serialized, OutputFormat format) throws JsonProcessingException {
-        return deserialize(cls, serialized, format, new ObjectMapper(new YAMLFactory()));
+    public static <T> T deserialize(Class<T> cls, String serialized, OutputFormat format) throws JacksonException {
+        return deserialize(cls, serialized, format, YAMLMapper.builder());
     }
 
 
@@ -72,14 +75,14 @@ public final class ParamsTester {
      *
      * @param cls class to deserialize to
      * @param serialized text to deserialize
-     * @param mapper mapper to use for deserialization
+     * @param builder mapper builder to use for deserialization
      *
      * @param <T> type of deserialized object
      *
      * @return deserialized object
      */
-    public static <T> T deserialize(Class<T> cls, String serialized, ObjectMapper mapper) throws JsonProcessingException {
-        return deserialize(cls, serialized, OUTPUT_FORMAT, mapper);
+    public static <T> T deserialize(Class<T> cls, String serialized, MapperBuilder<?, ?> builder) throws JacksonException {
+        return deserialize(cls, serialized, OUTPUT_FORMAT, builder);
     }
 
     /**
@@ -92,7 +95,29 @@ public final class ParamsTester {
      *
      * @return deserialized object
      */
-    public static <T> T deserialize(Class<T> cls, String serialized) throws JsonProcessingException {
-        return deserialize(cls, serialized, OUTPUT_FORMAT, new ObjectMapper(new YAMLFactory()));
+    public static <T> T deserialize(Class<T> cls, String serialized) throws JacksonException {
+        return deserialize(cls, serialized, OUTPUT_FORMAT, YAMLMapper.builder());
+    }
+
+    /**
+     * Creates a new {@link YAMLMapper.Builder} with a params class pre-registered.
+     * @param type Type of the params
+     * @param clazz Params class to use
+     * @return A new mapper builder
+     * @see ParamsParser#registerParams(String, Class)
+     */
+    public static YAMLMapper.Builder mapperBuilderWithParams(String type, Class<? extends PolymorphicParams> clazz) {
+        return YAMLMapper.builder().registerSubtypes(new NamedType(clazz, type));
+    }
+
+    /**
+     * Creates a new {@link YAMLMapper} with a params class pre-registered.
+     * @param type Type of the params
+     * @param clazz Params class to use
+     * @return A new mapper ready to use
+     * @see ParamsParser#registerParams(String, Class)
+     */
+    public static YAMLMapper mapperWithParams(String type, Class<? extends PolymorphicParams> clazz) {
+        return mapperBuilderWithParams(type, clazz).build();
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/parameters/ValueParserTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/ValueParserTest.java
@@ -1,7 +1,7 @@
 package com.ignfab.minalac.generator.parameters;
 
-import com.fasterxml.jackson.databind.JsonMappingException;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.DatabindException;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -84,6 +84,6 @@ public class ValueParserTest {
         ValueParser<?> params = assertDoesNotThrow(() -> ParamsTester.deserialize(ValueParser.class, "integer"));
         assertEquals(Integer.class, params.type());
 
-        assertThrows(JsonMappingException.class, () -> ParamsTester.deserialize(ValueParser.class, "yolo"));
+        assertThrows(DatabindException.class, () -> ParamsTester.deserialize(ValueParser.class, "yolo"));
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/parameters/heightmaps/CappedManhattanHeightmapParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/heightmaps/CappedManhattanHeightmapParamsTest.java
@@ -1,7 +1,7 @@
 package com.ignfab.minalac.generator.parameters.heightmaps;
 
-import com.fasterxml.jackson.core.JacksonException;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException;
 
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.generation.heightmaps.HeightmapDeclaration;

--- a/src/test/java/com/ignfab/minalac/generator/parameters/heightmaps/LocalMinimumHeightmapParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/heightmaps/LocalMinimumHeightmapParamsTest.java
@@ -1,7 +1,7 @@
 package com.ignfab.minalac.generator.parameters.heightmaps;
 
-import com.fasterxml.jackson.core.JacksonException;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException;
 
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.generation.heightmaps.HeightmapDeclaration;

--- a/src/test/java/com/ignfab/minalac/generator/parameters/heightmaps/RemapHeightmapParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/heightmaps/RemapHeightmapParamsTest.java
@@ -2,8 +2,8 @@ package com.ignfab.minalac.generator.parameters.heightmaps;
 
 import java.util.LinkedHashMap;
 
-import com.fasterxml.jackson.core.JacksonException;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException;
 
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.generation.GenerationTile;

--- a/src/test/java/com/ignfab/minalac/generator/parameters/placeables/CombinedPlaceableParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/placeables/CombinedPlaceableParamsTest.java
@@ -2,8 +2,8 @@ package com.ignfab.minalac.generator.parameters.placeables;
 
 import java.util.List;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException;
 
 import com.ignfab.minalac.generator.outputs.testing.TestingVoxelTile;
 import com.ignfab.minalac.generator.placeables.CombinedPlaceable;
@@ -16,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class CombinedPlaceableParamsTest {
     @Test
-    public void testValidate() throws JsonProcessingException {
+    public void testValidate() throws JacksonException {
         PlaceableParams invalid = new TestingPlaceableParams(null);
         PlaceableParams valid = new TestingPlaceableParams(new TestingPlaceable());
 
@@ -32,7 +32,7 @@ public class CombinedPlaceableParamsTest {
     }
 
     @Test
-    public void testCreate() throws JsonProcessingException {
+    public void testCreate() throws JacksonException {
         TestingPlaceable placeable = new TestingPlaceable();
         CombinedPlaceableParams params = new CombinedPlaceableParams(List.of(), null);
         params.placeableParams.add(new TestingPlaceableParams(placeable));

--- a/src/test/java/com/ignfab/minalac/generator/parameters/placeables/PlaceableParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/placeables/PlaceableParamsTest.java
@@ -1,9 +1,9 @@
 package com.ignfab.minalac.generator.parameters.placeables;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.DatabindException;
 
 import com.ignfab.minalac.generator.parameters.OutputFormat;
 import com.ignfab.minalac.generator.parameters.ParamsTester;
@@ -18,7 +18,7 @@ public class PlaceableParamsTest {
 
     @Test
     @DisplayName("Test voxel deserialization")
-    public void testPlaceableParamsDeserializerShortcut() throws JsonMappingException, JsonProcessingException {
+    public void testPlaceableParamsDeserializerShortcut() throws DatabindException, JacksonException {
         PlaceableParams params = assertDoesNotThrow(() -> ParamsTester.deserialize(PlaceableParams.class, "test"));
         TestingVoxelParams voxelParams = assertInstanceOf(TestingVoxelParams.class, params);
         assertEquals(voxelParams.name, "test");
@@ -26,7 +26,7 @@ public class PlaceableParamsTest {
 
     @Test
     @DisplayName("Test voxel deserialization using shortcut without existing shortcut")
-    public void testPlaceableParamsDeserializerNoShortcut() throws JsonMappingException, JsonProcessingException {
+    public void testPlaceableParamsDeserializerNoShortcut() throws DatabindException, JacksonException {
 
         OutputFormat format = new OutputFormat(null, TestingVoxelParams.class, null);
         assertThrows(IllegalArgumentException.class, () -> ParamsTester.deserialize(PlaceableParams.class, "test", format));
@@ -34,7 +34,7 @@ public class PlaceableParamsTest {
 
     @Test
     @DisplayName("Test voxel deserialization using default")
-    public void testPlaceableParamsDeserializerDefault() throws JsonMappingException, JsonProcessingException {
+    public void testPlaceableParamsDeserializerDefault() throws DatabindException, JacksonException {
 
         PlaceableParams params = assertDoesNotThrow(() -> ParamsTester.deserialize(PlaceableParams.class, "name: tata"));
         TestingVoxelParams voxelParams = assertInstanceOf(TestingVoxelParams.class, params);
@@ -43,7 +43,7 @@ public class PlaceableParamsTest {
 
     @Test
     @DisplayName("Test voxel deserialization using default without existing default")
-    public void testPlaceableParamsDeserializerNoDefault() throws JsonMappingException, JsonProcessingException {
+    public void testPlaceableParamsDeserializerNoDefault() throws DatabindException, JacksonException {
 
         OutputFormat format = new OutputFormat(null, null, TestingVoxelParams::new);
         assertThrows(IllegalArgumentException.class, () -> ParamsTester.deserialize(PlaceableParams.class, "name: tata", format));
@@ -64,7 +64,7 @@ public class PlaceableParamsTest {
 
     @Test
     @DisplayName("Test placeable deserialization using combined params")
-    public void testPlaceableParamsDeserializerCombined() throws JsonMappingException, JsonProcessingException {
+    public void testPlaceableParamsDeserializerCombined() throws DatabindException, JacksonException {
 
         PlaceableParams params = assertDoesNotThrow(() -> ParamsTester.deserialize(PlaceableParams.class, "[ titi, toto, tata ]"));
 
@@ -94,7 +94,7 @@ public class PlaceableParamsTest {
 
     @Test
     @DisplayName("Test structure deserialization")
-    public void testPlaceableParamsStructureDeserialization() throws JsonMappingException, JsonProcessingException {
+    public void testPlaceableParamsStructureDeserialization() throws DatabindException, JacksonException {
         PlaceableParams params;
         params = assertDoesNotThrow(() -> ParamsTester.deserialize(PlaceableParams.class, """
             structure:

--- a/src/test/java/com/ignfab/minalac/generator/parameters/placeables/structures/PlaceableStructureParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/placeables/structures/PlaceableStructureParamsTest.java
@@ -1,9 +1,9 @@
 package com.ignfab.minalac.generator.parameters.placeables.structures;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.exc.InvalidTypeIdException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.exc.InvalidTypeIdException;
 
 import com.ignfab.minalac.generator.parameters.ParamsTester;
 
@@ -78,7 +78,7 @@ public class PlaceableStructureParamsTest {
 
     @Test
     @DisplayName("Test PlaceableStructureParams propagates validation errors")
-    void testValidation() throws JsonProcessingException {
+    void testValidation() throws JacksonException {
         PlaceableStructureParams params;
 
         params = ParamsTester.deserialize(

--- a/src/test/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataCopyPostProcessorParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataCopyPostProcessorParamsTest.java
@@ -1,21 +1,14 @@
 package com.ignfab.minalac.generator.parameters.processors.post;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.jsontype.NamedType;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+import com.ignfab.minalac.generator.parameters.ParamsTester;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 public class MetadataCopyPostProcessorParamsTest {
-    private static ObjectMapper mapper;
-
-    @BeforeAll
-    public static void init() {
-        mapper = new ObjectMapper(new YAMLFactory());
-        mapper.registerSubtypes(new NamedType(MetadataCopyPostProcessorParams.class, "copy"));
-    }
+    private static final ObjectMapper MAPPER = ParamsTester.mapperWithParams("copy", MetadataCopyPostProcessorParams.class);
 
     @Test
     public void testCreate() {
@@ -38,7 +31,7 @@ public class MetadataCopyPostProcessorParamsTest {
             to: height
         """;
 
-        MetadataCopyPostProcessorParams requiredParams = assertDoesNotThrow(() -> mapper.readValue(requiredFields, MetadataCopyPostProcessorParams.class));
+        MetadataCopyPostProcessorParams requiredParams = assertDoesNotThrow(() -> MAPPER.readValue(requiredFields, MetadataCopyPostProcessorParams.class));
         assertEquals("hauteur", requiredParams.metadata);
         assertEquals("height", requiredParams.to);
         assertFalse(requiredParams.abortIfMetadataIsAbsent);
@@ -48,11 +41,11 @@ public class MetadataCopyPostProcessorParamsTest {
             type: copy
             metadata: toto
             to: tata
-            keepExisting: yes
-            abortIfMetadataIsAbsent: yes
+            keepExisting: true
+            abortIfMetadataIsAbsent: true
         """;
 
-        MetadataCopyPostProcessorParams requiredAndOptionalParams = assertDoesNotThrow(() -> mapper.readValue(requiredAndOptionalFields, MetadataCopyPostProcessorParams.class));
+        MetadataCopyPostProcessorParams requiredAndOptionalParams = assertDoesNotThrow(() -> MAPPER.readValue(requiredAndOptionalFields, MetadataCopyPostProcessorParams.class));
         assertEquals("toto", requiredAndOptionalParams.metadata);
         assertEquals("tata", requiredAndOptionalParams.to);
         assertTrue(requiredAndOptionalParams.abortIfMetadataIsAbsent);

--- a/src/test/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataParsePostProcessorParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataParsePostProcessorParamsTest.java
@@ -1,25 +1,15 @@
 package com.ignfab.minalac.generator.parameters.processors.post;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.jsontype.NamedType;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
+import com.ignfab.minalac.generator.parameters.ParamsTester;
 import com.ignfab.minalac.generator.parameters.ValueParser;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 public class MetadataParsePostProcessorParamsTest {
-    private static ObjectMapper mapper;
-
-    @BeforeAll
-    public static void init() {
-        mapper = new ObjectMapper(new YAMLFactory());
-        mapper.registerSubtypes(new NamedType(MetadataParsePostProcessorParams.class, "parse"));
-    }
-
     @Test
     public void testValidate() {
         assertThrows(IllegalArgumentException.class, new MetadataParsePostProcessorParams("", ValueParser.INTEGER)::validate);
@@ -27,7 +17,9 @@ public class MetadataParsePostProcessorParamsTest {
     }
 
     @Test
-    public void testCreate() throws JsonProcessingException {
+    public void testCreate() throws JacksonException {
+        ObjectMapper mapper = ParamsTester.mapperWithParams("parse", MetadataParsePostProcessorParams.class);
+
         String parseYaml = """
         type: parse
         metadata: tata

--- a/src/test/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataTruncatePostProcessorParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataTruncatePostProcessorParamsTest.java
@@ -1,11 +1,10 @@
 package com.ignfab.minalac.generator.parameters.processors.post;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.jsontype.NamedType;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
+import com.ignfab.minalac.generator.parameters.ParamsTester;
 import com.ignfab.minalac.generator.parameters.processors.post.MetadataTruncatePostProcessorParams.TruncationMethodParams;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -29,9 +28,8 @@ public class MetadataTruncatePostProcessorParamsTest {
     }
 
     @Test
-    public void testDeserialize() throws JsonProcessingException {
-        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
-        mapper.registerSubtypes(new NamedType(MetadataTruncatePostProcessorParams.class, "truncate"));
+    public void testDeserialize() throws JacksonException {
+        ObjectMapper mapper = ParamsTester.mapperWithParams("truncate", MetadataTruncatePostProcessorParams.class);
 
         MetadataTruncatePostProcessorParams params = assertDoesNotThrow(() -> mapper.readValue(
             """

--- a/src/test/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataValueMappingPostProcessorParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/processors/post/MetadataValueMappingPostProcessorParamsTest.java
@@ -4,20 +4,19 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.jsontype.NamedType;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+
+import com.ignfab.minalac.generator.parameters.ParamsTester;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 public class MetadataValueMappingPostProcessorParamsTest {
 
     @Test
-    public void testDeserialize() throws JsonProcessingException {
-        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
-        mapper.registerSubtypes(new NamedType(MetadataValueMappingPostProcessorParams.class, "remap"));
+    public void testDeserialize() throws JacksonException {
+        ObjectMapper mapper = ParamsTester.mapperWithParams("remap", MetadataValueMappingPostProcessorParams.class);
 
         assertDoesNotThrow(() -> mapper.readValue("""
         type: remap

--- a/src/test/java/com/ignfab/minalac/generator/parameters/processors/post/PostProcessorParamsDeserializerTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/processors/post/PostProcessorParamsDeserializerTest.java
@@ -1,10 +1,8 @@
 package com.ignfab.minalac.generator.parameters.processors.post;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.jsontype.NamedType;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.cfg.MapperBuilder;
 
 import com.ignfab.minalac.generator.parameters.ParamsTester;
 
@@ -14,13 +12,12 @@ public class PostProcessorParamsDeserializerTest {
     @Test
     @DisplayName("Test multiple post-processing steps deserialization using list")
     public void testList() {
-        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
-        mapper.registerSubtypes(new NamedType(IdentityPostProcessorParams.class, "identity"));
+        MapperBuilder<?, ?> builder = ParamsTester.mapperBuilderWithParams("identity", IdentityPostProcessorParams.class);
 
         PostProcessorParams params = assertDoesNotThrow(() -> ParamsTester.deserialize(PostProcessorParams.class, """
             - type: identity
             - type: identity
-            """, mapper));
+            """, builder));
         assertInstanceOf(SequentialPostProcessorParams.class, params);
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/parameters/tasks/CopyHeightmapTaskParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/tasks/CopyHeightmapTaskParamsTest.java
@@ -1,10 +1,8 @@
 package com.ignfab.minalac.generator.parameters.tasks;
 
-import com.fasterxml.jackson.core.JacksonException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.jsontype.NamedType;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.cfg.MapperBuilder;
 
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.generation.heightmaps.HeightmapDeclaration;
@@ -16,10 +14,7 @@ import com.ignfab.minalac.generator.parameters.models.ModelSelectionParams;
 import com.ignfab.minalac.generator.parameters.models.TestingModelSelectionParams;
 import com.ignfab.minalac.generator.utils.random.TestingSeed;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class CopyHeightmapTaskParamsTest {
     @Test
@@ -28,8 +23,7 @@ public class CopyHeightmapTaskParamsTest {
         generation.heightmaps().add(new HeightmapDeclaration("ground", 5));
         generation.heightmaps().add(new HeightmapDeclaration("water", 1));
 
-        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
-        mapper.registerSubtypes(new NamedType(CopyHeightmapTaskParams.class, "copyHeightmap"));
+        MapperBuilder<?, ?> builder = ParamsTester.mapperBuilderWithParams("copyHeightmap", CopyHeightmapTaskParams.class);
 
         CopyHeightmapTaskParams params = assertDoesNotThrow(() -> ParamsTester.deserialize(
             CopyHeightmapTaskParams.class,
@@ -40,7 +34,7 @@ public class CopyHeightmapTaskParamsTest {
             from: water
             to: ground
             """,
-            mapper
+            builder
         ));
         assertInstanceOf(ModelSelectionParams.class, params.models);
         assertInstanceOf(WritableHeightmapParams.class, params.from);
@@ -58,8 +52,9 @@ public class CopyHeightmapTaskParamsTest {
                 from: water
                 to: ground
                 """,
-            mapper
-        ));
+                builder
+            )
+        );
 
         assertThrows(
             JacksonException.class,
@@ -71,8 +66,9 @@ public class CopyHeightmapTaskParamsTest {
                   type: water
                 to: ground
                 """,
-                mapper
-            ));
+                builder
+            )
+        );
 
         assertThrows(
             JacksonException.class,
@@ -84,8 +80,9 @@ public class CopyHeightmapTaskParamsTest {
                   type: water
                 from: water
                 """,
-                mapper
-            ));
+                builder
+            )
+        );
     }
 
     @Test

--- a/src/test/java/com/ignfab/minalac/generator/parameters/tasks/FillBetweenHeightmapAndMetadataTaskParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/tasks/FillBetweenHeightmapAndMetadataTaskParamsTest.java
@@ -1,9 +1,7 @@
 package com.ignfab.minalac.generator.parameters.tasks;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.jsontype.NamedType;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.cfg.MapperBuilder;
 
 import com.ignfab.minalac.generator.parameters.ParamsTester;
 import com.ignfab.minalac.generator.parameters.heightmaps.TestingHeightmapParams;
@@ -68,8 +66,7 @@ public class FillBetweenHeightmapAndMetadataTaskParamsTest {
 
     @Test
     void testDeserialization() {
-        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
-        mapper.registerSubtypes(new NamedType(FillBetweenHeightmapAndMetadataTaskParams.class, "filling"));
+        MapperBuilder<?, ?> builder = ParamsTester.mapperBuilderWithParams("filling", FillBetweenHeightmapAndMetadataTaskParams.class);
 
         FillBetweenHeightmapAndMetadataTaskParams params = assertDoesNotThrow(() -> ParamsTester.deserialize(FillBetweenHeightmapAndMetadataTaskParams.class, """
         type: filling
@@ -79,7 +76,7 @@ public class FillBetweenHeightmapAndMetadataTaskParamsTest {
         altitudeMetadata: altitude
         placeAbove: voxelA
         placeBelow: voxelB
-        """, mapper));
+        """, builder));
         assertEquals("models", params.models.type);
         assertEquals("altitude", params.altitudeMetadata);
         assertEquals("voxelA", assertInstanceOf(TestingVoxelParams.class, params.placeAbove).name);

--- a/src/test/java/com/ignfab/minalac/generator/parameters/tasks/HeightmapStatsTaskParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/tasks/HeightmapStatsTaskParamsTest.java
@@ -1,9 +1,7 @@
 package com.ignfab.minalac.generator.parameters.tasks;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.jsontype.NamedType;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.cfg.MapperBuilder;
 
 import com.ignfab.minalac.generator.parameters.ParamsTester;
 import com.ignfab.minalac.generator.parameters.heightmaps.TestingHeightmapParams;
@@ -51,8 +49,7 @@ public class HeightmapStatsTaskParamsTest {
     public void testDeserialization() {
         HeightmapStatsTaskParams params;
 
-        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
-        mapper.registerSubtypes(new NamedType(HeightmapStatsTaskParams.class, "computeHeightmapStats"));
+        MapperBuilder<?, ?> builder = ParamsTester.mapperBuilderWithParams("computeHeightmapStats", HeightmapStatsTaskParams.class);
 
         params = assertDoesNotThrow(() -> ParamsTester.deserialize(HeightmapStatsTaskParams.class, """
         type: computeHeightmapStats
@@ -61,7 +58,7 @@ public class HeightmapStatsTaskParamsTest {
         heightmap: ground
         compute:
           maximum: max
-        """, mapper));
+        """, builder));
         assertEquals("building", params.models.type);
         assertNotNull(params.heightmap);
         assertEquals("max", params.compute.maximum);
@@ -74,7 +71,7 @@ public class HeightmapStatsTaskParamsTest {
         compute:
           maximum: max
           minimum: min
-        """, mapper));
+        """, builder));
         assertEquals("building", params.models.type);
         assertNotNull(params.heightmap);
         assertEquals("max", params.compute.maximum);

--- a/src/test/java/com/ignfab/minalac/generator/parameters/tasks/PopulateHeightmapTaskParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/tasks/PopulateHeightmapTaskParamsTest.java
@@ -1,10 +1,8 @@
 package com.ignfab.minalac.generator.parameters.tasks;
 
-import com.fasterxml.jackson.core.JacksonException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.jsontype.NamedType;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.cfg.MapperBuilder;
 
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.generation.heightmaps.HeightmapDeclaration;
@@ -15,10 +13,7 @@ import com.ignfab.minalac.generator.parameters.models.ModelSelectionParams;
 import com.ignfab.minalac.generator.parameters.models.TestingModelSelectionParams;
 import com.ignfab.minalac.generator.utils.random.TestingSeed;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class PopulateHeightmapTaskParamsTest {
     @Test
@@ -26,8 +21,7 @@ public class PopulateHeightmapTaskParamsTest {
         Generation generation = new Generation(new TestingVoxelWorld(), TestingSeed.UNUSED, null, 0, 0, 1, 1, 1.0, 1.0, 0.0, 100);
         generation.heightmaps().add(new HeightmapDeclaration("ground", 5));
 
-        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
-        mapper.registerSubtypes(new NamedType(PopulateHeightmapTaskParams.class, "matrixToHeightmap"));
+        MapperBuilder<?, ?> builder = ParamsTester.mapperBuilderWithParams("matrixToHeightmap", PopulateHeightmapTaskParams.class);
 
         PopulateHeightmapTaskParams params = assertDoesNotThrow(() -> ParamsTester.deserialize(
             PopulateHeightmapTaskParams.class,
@@ -37,7 +31,7 @@ public class PopulateHeightmapTaskParamsTest {
               type: mnt
             heightmap: ground
             """,
-            mapper
+            builder
         ));
         assertInstanceOf(ModelSelectionParams.class, params.models);
         assertEquals("ground", params.heightmap.stored);
@@ -53,8 +47,9 @@ public class PopulateHeightmapTaskParamsTest {
                 type: matrixToHeightmap
                 heightmap: ground
                 """,
-                mapper
-            ));
+                builder
+            )
+        );
 
         assertThrows(
             JacksonException.class,
@@ -65,9 +60,9 @@ public class PopulateHeightmapTaskParamsTest {
                 models:
                   type: mnt
                 """,
-                mapper
-            ));
-
+                builder
+            )
+        );
     }
 
     @Test

--- a/src/test/java/com/ignfab/minalac/generator/parameters/tasks/RenderBuildingsTaskParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/tasks/RenderBuildingsTaskParamsTest.java
@@ -1,10 +1,8 @@
 package com.ignfab.minalac.generator.parameters.tasks;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.exc.InvalidNullException;
-import com.fasterxml.jackson.databind.jsontype.NamedType;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.cfg.MapperBuilder;
+import tools.jackson.databind.exc.InvalidNullException;
 
 import com.ignfab.minalac.generator.parameters.ParamsTester;
 import com.ignfab.minalac.generator.parameters.models.TestingModelSelectionParams;
@@ -27,8 +25,7 @@ public class RenderBuildingsTaskParamsTest {
 
     @Test
     public void testDeserialization() {
-        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
-        mapper.registerSubtypes(new NamedType(RenderBuildingsTaskParams.class, "building"));
+        MapperBuilder<?, ?> builder = ParamsTester.mapperBuilderWithParams("building", RenderBuildingsTaskParams.class);
 
         RenderBuildingsTaskParams params = assertDoesNotThrow(() -> ParamsTester.deserialize(RenderBuildingsTaskParams.class, """
         type: building
@@ -37,7 +34,7 @@ public class RenderBuildingsTaskParamsTest {
         roof: voxelA
         wall: voxelB
         window: voxelC
-        """, mapper));
+        """, builder));
         assertEquals("building", params.models.type);
         assertEquals("voxelA", assertInstanceOf(TestingVoxelParams.class, params.roof).name);
         assertEquals("voxelB", assertInstanceOf(TestingVoxelParams.class, params.wall).name);
@@ -50,7 +47,7 @@ public class RenderBuildingsTaskParamsTest {
         roof:
         wall: voxelB
         window: voxelC
-        """, mapper));
+        """, builder));
 
         assertThrows(InvalidNullException.class, () -> ParamsTester.deserialize(RenderBuildingsTaskParams.class, """
         type: building
@@ -59,7 +56,7 @@ public class RenderBuildingsTaskParamsTest {
         roof: voxelA
         wall:
         window: voxelC
-        """, mapper));
+        """, builder));
 
         assertThrows(InvalidNullException.class, () -> ParamsTester.deserialize(RenderBuildingsTaskParams.class, """
         type: building
@@ -68,6 +65,6 @@ public class RenderBuildingsTaskParamsTest {
         roof: voxelA
         wall: voxelB
         window:
-        """, mapper));
+        """, builder));
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/parameters/tasks/RenderHeightmapTaskParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/tasks/RenderHeightmapTaskParamsTest.java
@@ -1,9 +1,7 @@
 package com.ignfab.minalac.generator.parameters.tasks;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.jsontype.NamedType;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.cfg.MapperBuilder;
 
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.generation.heightmaps.HeightmapDeclaration;
@@ -15,10 +13,7 @@ import com.ignfab.minalac.generator.parameters.placeables.TestingPlaceableParams
 import com.ignfab.minalac.generator.parameters.placeables.voxels.TestingVoxelParams;
 import com.ignfab.minalac.generator.utils.random.TestingSeed;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class RenderHeightmapTaskParamsTest {
     @Test
@@ -26,8 +21,7 @@ public class RenderHeightmapTaskParamsTest {
         Generation generation = new Generation(new TestingVoxelWorld(), TestingSeed.UNUSED, null, 0, 0, 1, 1, 1.0, 1.0, 0.0, 100);
         generation.heightmaps().add(new HeightmapDeclaration("ground", 5));
 
-        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
-        mapper.registerSubtypes(new NamedType(RenderHeightmapTaskParams.class, "heightmapRenderer"));
+        MapperBuilder<?, ?> builder = ParamsTester.mapperBuilderWithParams("heightmapRenderer", RenderHeightmapTaskParams.class);
 
         RenderHeightmapTaskParams params = assertDoesNotThrow(() -> ParamsTester.deserialize(
             RenderHeightmapTaskParams.class,
@@ -36,7 +30,7 @@ public class RenderHeightmapTaskParamsTest {
             at: ground
             place: somethingInvisible
             """,
-            mapper
+            builder
         ));
         assertInstanceOf(WritableHeightmapParams.class, params.at);
         assertEquals("somethingInvisible",  assertInstanceOf(TestingVoxelParams.class, params.place).name);
@@ -51,8 +45,7 @@ public class RenderHeightmapTaskParamsTest {
         generation.heightmaps().add(new HeightmapDeclaration("water", 5));
         generation.heightmaps().add(new HeightmapDeclaration("ground", 25));
 
-        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
-        mapper.registerSubtypes(new NamedType(RenderHeightmapTaskParams.class, "heightmapRenderer"));
+        MapperBuilder<?, ?> builder = ParamsTester.mapperBuilderWithParams("heightmapRenderer", RenderHeightmapTaskParams.class);
 
         RenderHeightmapTaskParams params = assertDoesNotThrow(() -> ParamsTester.deserialize(
             RenderHeightmapTaskParams.class,
@@ -62,7 +55,7 @@ public class RenderHeightmapTaskParamsTest {
             maximum: ground
             place: somethingInvisible
             """,
-            mapper
+            builder
         ));
         assertInstanceOf(WritableHeightmapParams.class, params.minimum);
         assertInstanceOf(WritableHeightmapParams.class, params.maximum);

--- a/src/test/java/com/ignfab/minalac/generator/parameters/tasks/SetSpawnTaskParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/tasks/SetSpawnTaskParamsTest.java
@@ -1,9 +1,7 @@
 package com.ignfab.minalac.generator.parameters.tasks;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.jsontype.NamedType;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.cfg.MapperBuilder;
 
 import com.ignfab.minalac.generator.generation.TestingGenerationTile;
 import com.ignfab.minalac.generator.parameters.ParamsTester;
@@ -22,8 +20,7 @@ public class SetSpawnTaskParamsTest {
 
     @Test
     public void testDeserialize() {
-        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
-        mapper.registerSubtypes(new NamedType(SetSpawnTaskParams.class, "setSpawn"));
+        MapperBuilder<?, ?> builder = ParamsTester.mapperBuilderWithParams("setSpawn", SetSpawnTaskParams.class);
 
         SetSpawnTaskParams params = assertDoesNotThrow(() -> ParamsTester.deserialize(
             SetSpawnTaskParams.class,
@@ -33,9 +30,8 @@ public class SetSpawnTaskParamsTest {
             x: 2
             y: 5
             """,
-            mapper
-            )
-        );
+            builder
+        ));
 
         assertInstanceOf(WritableHeightmapParams.class, params.heightmap);
         assertEquals(2, params.x);

--- a/src/test/java/com/ignfab/minalac/generator/parameters/utils/IntegerIntervalParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/utils/IntegerIntervalParamsTest.java
@@ -1,9 +1,8 @@
 package com.ignfab.minalac.generator.parameters.utils;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectReader;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectReader;
+import tools.jackson.dataformat.yaml.YAMLMapper;
 
 import com.ignfab.minalac.generator.utils.IntegerInterval;
 
@@ -11,7 +10,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class IntegerIntervalParamsTest {
 
-    private ObjectReader reader = new ObjectMapper(new YAMLFactory()).readerFor(IntegerIntervalParams.class);
+    private ObjectReader reader = YAMLMapper.shared().readerFor(IntegerIntervalParams.class);
 
     @Test
     void testFromToParams() {

--- a/src/test/java/com/ignfab/minalac/generator/parameters/utils/WorldBBox3dParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/utils/WorldBBox3dParamsTest.java
@@ -1,9 +1,8 @@
 package com.ignfab.minalac.generator.parameters.utils;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectReader;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectReader;
+import tools.jackson.dataformat.yaml.YAMLMapper;
 
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 
@@ -11,7 +10,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class WorldBBox3dParamsTest {
 
-    private ObjectReader reader = new ObjectMapper(new YAMLFactory()).readerFor(WorldBBox3dParams.class);
+    private ObjectReader reader = YAMLMapper.shared().readerFor(WorldBBox3dParams.class);
 
     @Test
     void testDeserialization() {


### PR DESCRIPTION
### Changes

This PR migrates from Jackson 2.x to 3.x, which released in early October.

#### Feature description

We use FasterXML/Jackson v2.x to parse generation parameters since the beginning:
- https://github.com/ignfab/minalac-generator/commit/ce1e32072953c4b5617a8b18793b2b34663d18a3: 2.17.0
  Initial introduction of Jackson to parse parameters
- https://github.com/ignfab/minalac-generator/commit/a0dd7b92a4daa331510f1391985db3337a40d7a2: 2.20.0
  Removal of direct SnakeYAML dependency used to preprocess anchors (added in https://github.com/ignfab/minalac-generator/commit/e5232d3bc7ebbaa4e6f331f714d69be7f12d3163), replaced by the `YAMLAnchorReplayingFactory`

In early October, FasterXML team released Jackson 3.0.0, under a different Maven group ID: `tools.jackson`, which went under our radars during 2 months for that reason.

This PR updates Jackson to v3.x, which included quite a lot of breaking changes to tackle. Thankfully, most of them were properly documented in the [Jackson 3 migration guide](https://github.com/FasterXML/jackson/blob/main/jackson3/MIGRATING_TO_JACKSON_3.md). However, the `YAMLAnchorReplayingFactory` introduced in 2.x was not released to 3.x (see https://github.com/FasterXML/jackson-dataformats-text/pull/502#issuecomment-2557939127), which prevented us from completing migration.

I submitted a PR to their repo adding back that feature, which got merged a week later: https://github.com/FasterXML/jackson-dataformats-text/pull/596. It is yet to be released in the upcoming 3.1.0, which is why this commit relies on release candidate version. My PR also fixed an issue with nested anchors replaying.

Main changes (affecting us) include:
- Jackson annotations module unaffected (same annotations used in 2.x and 3.x)
- Package renamed from `com.fasterxml.jackson` to `tools.jackson`
- Some classes/methods renamed to remove irrelevant occurrences of "JSON" or "text"
- New underlying SnakeYAML engine
- Immutable `ObjectMapper`, created via builder for a specific format
- Removal of `ObjectCodec`, with features moved to classes with more suitable responsibilities

#### Technical changes

Jackson moved from `com.fasterxml.jackson` (v2.x) to `tools.jackson` (v3.x).

### Reason

Staying up-to-date with the latest dependency version should provides us with more powerful and maintained tools, through a cleaner API. The presence of their migration guide helped a lot reducing the cumbersome refactoring.

The issue with nested anchors was first identified in the [`indy/lego`](https://github.com/ignfab/minalac-generator/tree/indy/lego) PoC, because of how I structured the bricks definition in the parameters. This same issue is likely to manifest again in the main parameters, as they grow bigger. Fixing it was a necessity.

### Self-checks

- [x] The code has unit tests associated
- [x] The code has Javadoc Comments associated
- [x] Complex / Unexpected code is explained / justified with a small comment
- ~~Relevant documentation inside the `/docs` folder has been updated~~
- [x] All examples in `examples/` work the same (or have been adapted if subject to changes in this PR)
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [x] The texts have been proofread (documentation, error messages, logs, comments...)
