### PR TITLE
feat(minecraft): Add Minecraft schematic placeable

### DIFF
--- a/src/main/java/com/ignfab/minalac/generator/MinalacGenerator.java
+++ b/src/main/java/com/ignfab/minalac/generator/MinalacGenerator.java
@@ -102,7 +102,7 @@ public final class MinalacGenerator {
         ParamsParser parser = new ParamsParser();
 
         // Register game formats
-        parser.registerFormat("minecraft", new OutputFormat(() -> new MCVoxelWorld(destination), MCVoxelParams.class, MCVoxelParams::new));
+        parser.registerFormat("minecraft", new OutputFormat(() -> new MCVoxelWorld(destination), MCVoxelParams.class, MCVoxelParams::packed));
         parser.registerFormat("minetest", new OutputFormat(() -> new MTVoxelWorld(destination), MTVoxelParams.class, MTVoxelParams::new));
 
         // TODO: Static method that provides a ParamsParser with all default renderers

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCBlockEntityVoxel.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCBlockEntityVoxel.java
@@ -1,47 +1,123 @@
 package com.ignfab.minalac.generator.outputs.minecraft;
 
+import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
 
+import io.github.ensgijs.nbt.io.NamedTag;
+import io.github.ensgijs.nbt.io.TextNbtHelpers;
 import io.github.ensgijs.nbt.tag.CompoundTag;
 
 /**
- * {@code MCBlockEntityVoxel} abstract class represents a Minecraft block with additional data associated with it.
+ * {@code MCBlockEntityVoxel} class represents a Minecraft block with additional data associated with it.
  * That additional information is known as block entity.
- * @see <a href="https://minecraft.wiki/w/Block_entity"> Block entity (Minecraft wiki)</a>
+ * <p>
+ * Like {@link MCVoxel}, it is immutable. A builder pattern may help to abstract the raw NBT structure
+ * used to represent its data.
+ * @see <a href="https://minecraft.wiki/w/Block_entity"> Block entity (Minecraft Wiki)</a>
  */
-public abstract class MCBlockEntityVoxel extends MCVoxel {
+public class MCBlockEntityVoxel extends MCVoxel {
+    /**
+     * The block entity ID.
+     * @see <a href="https://minecraft.wiki/w/Block_entity_format#Types">List of block entities (Minecraft Wiki)</a>
+     */
+    private final String id;
+    /**
+     * The block entity data, according to its {@link #id}.
+     */
+    private final CompoundTag data; // NBT data has no order, which may cause trouble with equality checks
+
     /**
      * Constructs a new {@code MCBlockEntityVoxel}.
      *
-     * @param type the block type string
+     * @param voxel the block state as an existing voxel
+     * @param id the block entity ID
+     * @param data the block entity data
      */
-    public MCBlockEntityVoxel(String type) {
-        super(type);
+    public MCBlockEntityVoxel(MCVoxel voxel, String id, CompoundTag data) {
+        this(voxel.type(), id, voxel.properties(), data);
     }
 
     /**
      * Constructs a new {@code MCBlockEntityVoxel}.
      *
      * @param type the block type string
+     * @param id the block entity ID
      * @param properties the block state properties
+     * @param data the block entity data
      */
-    public MCBlockEntityVoxel(String type, Map<String, String> properties) {
+    public MCBlockEntityVoxel(String type, String id, Map<String, String> properties, CompoundTag data) {
         super(type, properties);
+        this.id = MCHelpers.ensureNamespaced(id);
+        this.data = data == null ? new CompoundTag() : data.clone();
     }
-
-    protected abstract void serialize(CompoundTag tag);
 
     @Override
     protected void place(MCVoxelTile tile, int x, int y, int z)  {
         super.place(tile, x, y, z);
         CompoundTag block = new CompoundTag();
-        block.putString("id", type);
+        block.putString("id", id);
         block.putBoolean("keepPacked", false);
-        // X/Y/Z => X/Z/-Y
-        block.putInt("x", x);
-        block.putInt("y", z);
-        block.putInt("z", -y - 1);
-        serialize(block);
+        for (NamedTag tag : data)
+            block.put(tag);
         tile.addBlockEntity(x, z, -y - 1, block); // X/Y/Z => X/Z/-Y
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!super.equals(o)) return false;
+        MCBlockEntityVoxel that = (MCBlockEntityVoxel) o;
+        return id.equals(that.id) && data.equals(that.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), id, data);
+    }
+
+    /**
+     * Creates a new instance of {@link MCBlockEntityVoxel} from a {@link CompoundTag} and an existing {@link MCVoxel}.
+     *
+     * @param block the {@code CompoundTag} representing a block entity.
+     * @param voxel the {@code MCVoxel} representing the block state to use as a base.
+     * @return a new {@code MCBlockEntityVoxel}
+     */
+    public static MCBlockEntityVoxel fromBlockEntity(CompoundTag block, MCVoxel voxel) {
+        String id = block.getStringTag("id").getValue();
+        CompoundTag data = block.clone();
+        data.remove("id");
+        data.remove("keepPacked");
+        data.remove("x");
+        data.remove("y");
+        data.remove("z");
+        return new MCBlockEntityVoxel(voxel, id, data);
+    }
+
+    /**
+     * Creates a new instance of {@link MCBlockEntityVoxel} from a serialized block state string and a block entity ID.
+     * Example: {@code minecraft:jukebox[has_record=true]{RecordItem: {id: "minecraft:music_disc_cat"}, ticks_since_song_started: 0}}.
+     * Extra whitespaces outside of data tags are not allowed!
+     *
+     * @param block the string representing a block.
+     * @param id the block entity ID.
+     * @return a new {@code MCBlockEntityVoxel}
+     */
+    public static MCBlockEntityVoxel fromString(String block, String id) {
+        int bracket = block.indexOf('{');
+        if (bracket == -1) {
+            MCVoxel voxel = MCVoxel.fromString(block);
+            return new MCBlockEntityVoxel(voxel, id, null);
+        }
+        if (block.indexOf('}') != block.length() - 1)
+            throw new IllegalArgumentException("Invalid block entity definition: " + block);
+        MCVoxel voxel = MCVoxel.fromString(block.substring(0, bracket));
+        String dataTags = block.substring(bracket);
+        CompoundTag data;
+        try {
+            data = TextNbtHelpers.fromTextNbt(dataTags).getTagAutoCast();
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Malformed data tags: " + dataTags, e);
+        }
+        return new MCBlockEntityVoxel(voxel, id, data);
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCHelpers.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCHelpers.java
@@ -1,0 +1,34 @@
+package com.ignfab.minalac.generator.outputs.minecraft;
+
+import io.github.ensgijs.nbt.tag.CompoundTag;
+
+/**
+ * Miscellaneous utility functions for Minecraft-related operations.
+ */
+public final class MCHelpers {
+    private MCHelpers() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@return the given resource location with explicit namespace}
+     * If the input string already has a namespace, it is returned untouched,
+     * otherwise the default namespace {@code minecraft:} is prepended.
+     * @param resourceLocation the resource location
+     */
+    public static String ensureNamespaced(String resourceLocation) {
+        return resourceLocation.indexOf(':') == -1 ? "minecraft:" + resourceLocation : resourceLocation;
+    }
+
+    /**
+     * Checks that the position contained in the data is equals to the given one.
+     * @param data the data containing the position as {@code x}, {@code y} and {code z} fields
+     * @param x the test value of the x-coordinate
+     * @param y the test value of the y-coordinate
+     * @param z the test value of the z-coordinate
+     * @return {@code true} if the position are the same, {@code false} otherwise
+     */
+    public static boolean xyzEquals(CompoundTag data, int x, int y, int z) {
+        return data.getInt("x") == x && data.getInt("y") == y && data.getInt("z") == z;
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCSchematic.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCSchematic.java
@@ -1,0 +1,159 @@
+package com.ignfab.minalac.generator.outputs.minecraft;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import io.github.ensgijs.nbt.io.BinaryNbtHelpers;
+import io.github.ensgijs.nbt.io.NamedTag;
+import io.github.ensgijs.nbt.tag.CompoundTag;
+import io.github.ensgijs.nbt.tag.IntTag;
+import io.github.ensgijs.nbt.tag.ListTag;
+
+import com.ignfab.minalac.generator.placeables.Placeable;
+import com.ignfab.minalac.generator.placeables.PlaceableStructure;
+import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
+import com.ignfab.minalac.generator.world.VoxelTile;
+
+// TODO This might only be a way to create the structure instead of a full class implementing placeable
+// The extra offset (called placementOffset here) should be generalized to every placeable during the placeable parameterization revamp!
+public class MCSchematic implements Placeable {
+    private final WorldCoords3d placementOffset;
+    private final PlaceableStructure structure;
+
+    public MCSchematic(File file, boolean excludeAir, WorldCoords3d placementOffset) {
+        this.placementOffset = placementOffset;
+
+        // https://github.com/SpongePowered/Schematic-Specification/blob/master/versions/schematic-3.md
+        try {
+            CompoundTag root = BinaryNbtHelpers.read(file).getTagAutoCast();
+            CompoundTag schematic = root.getCompoundTag("Schematic");
+
+            int version = schematic.getInt("Version");
+            if (version != 3)
+                throw new IOException("Invalid schematic version (only version 3 is supported): " + version);
+
+            // DataVersion could be checked to ensure it is compatible with current generated version,
+            // but exact match would be too restrictive, and range is not straightforward...
+            // So it's up to the user to give a schematic for the correct version of the game!
+
+            // Metadata is irrelevant here
+
+            int width = schematic.getShort("Width") & 0xFFFF;
+            int height = schematic.getShort("Height") & 0xFFFF;
+            int length = schematic.getShort("Length") & 0xFFFF;
+
+            int[] offset = schematic.getIntArray("Offset");
+            int offsetX = offset[0];
+            int offsetY = offset[1];
+            int offsetZ = offset[2];
+
+            CompoundTag blocks = schematic.getCompoundTag("Blocks");
+            Map<Integer, MCVoxel> palette = readBlockPalette(blocks.getCompoundTag("Palette"));
+            int[] data = readVarInts(blocks.getByteArray("Data"));
+            if (data.length != width * height * length)
+                throw new IllegalArgumentException("Invalid data length: " + data.length + ". Expected: " + width * height * length);
+            BlockPalette blockPalette = new BlockPalette(palette, data, width, height, length);
+            Map<WorldCoords3d, MCBlockEntityVoxel> blockEntities = readBlockEntities(blocks.getCompoundList("BlockEntities"), offsetX, offsetY, offsetZ, blockPalette);
+
+            PlaceableStructure structure = new PlaceableStructure();
+            for (int y = 0; y < height; y++) {
+                for (int z = 0; z < length; z++) {
+                    for (int x = 0; x < width; x++) {
+                        MCVoxel voxel = blockPalette.at(x, y, z);
+                        if (excludeAir && voxel.equals(MCVoxel.DEFAULTVOXEL))
+                            continue;
+                        WorldCoords3d pos = new WorldCoords3d(x + offsetX, -z - offsetZ, y + offsetY); // X/Z/-Y => X/Y/Z
+                        structure.set(pos, Objects.requireNonNullElse(blockEntities.get(pos), voxel));
+                    }
+                }
+            }
+
+            // Biomes and Entities are not handled here
+
+            this.structure = structure;
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Unable to read Minecraft schematic: " + file.getAbsolutePath(), e);
+        }
+    }
+
+    @Override
+    public void place(VoxelTile tile, int x, int y, int z) {
+        if (!(tile instanceof MCVoxelTile))
+            throw new IllegalArgumentException("Minecraft schematic can only be placed in a Minecraft world");
+        structure.place(tile, x + placementOffset.x(), y + placementOffset.y(), z + placementOffset.z());
+    }
+
+    private static Map<Integer, MCVoxel> readBlockPalette(CompoundTag paletteData) {
+        Map<Integer, MCVoxel> palette = new HashMap<>(paletteData.size());
+        for (NamedTag entry : paletteData) {
+            palette.put(
+                entry.<IntTag>getTagAutoCast().asInt(),
+                MCVoxel.fromString(entry.getName())
+            );
+        }
+        return palette;
+    }
+
+    private static Map<WorldCoords3d, MCBlockEntityVoxel> readBlockEntities(ListTag<CompoundTag> blockEntitiesData, int offsetX, int offsetY, int offsetZ, BlockPalette blockPalette) {
+        Map<WorldCoords3d, MCBlockEntityVoxel> blockEntities = new HashMap<>(blockEntitiesData.size());
+        for (CompoundTag blockEntity : blockEntitiesData) {
+            int[] pos = blockEntity.getIntArray("Pos");
+            int posX = pos[0];
+            int posY = pos[1];
+            int posZ = pos[2];
+            MCVoxel voxel = blockPalette.at(posX, posY, posZ);
+            CompoundTag data = blockEntity.getCompoundTag("Data");
+            blockEntities.put(
+                new WorldCoords3d(posX + offsetX, -posZ - offsetZ, posY + offsetY), // X/Z/-Y => X/Y/Z
+                MCBlockEntityVoxel.fromBlockEntity(data, voxel)
+            );
+        }
+        return blockEntities;
+    }
+
+    private static int[] readVarInts(byte[] varInts) {
+        int[] result = new int[varIntsLength(varInts)];
+        int index = 0;
+        int i = 0;
+        while (i < varInts.length) {
+            int value = 0;
+            int varIntLength = 0;
+
+            byte b;
+            do {
+                b = varInts[i];
+                i++;
+                value |= (b & 0x7F) << (varIntLength * 7);
+                varIntLength++;
+                if (varIntLength > 5)
+                    throw new IllegalArgumentException("Invalid VarInt data: " + Arrays.toString(varInts));
+            } while ((b & 0x80) != 0);
+
+            result[index] = value;
+            index++;
+        }
+        return result;
+    }
+
+    private static int varIntsLength(byte[] varInts) {
+        int len = 0;
+        for (byte varInt : varInts)
+            if ((varInt & 0x80) == 0)
+                len++;
+        return len;
+    }
+
+    private record BlockPalette(Map<Integer, MCVoxel> palette, int[] data, int width, int height, int length) {
+        public MCVoxel at(int x, int y, int z) {
+            int index = data[x + (y * length + z) * width];
+            MCVoxel voxel = palette.get(index);
+            if (voxel == null)
+                throw new IllegalArgumentException("Invalid palette index: " + index);
+            return voxel;
+        }
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxel.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxel.java
@@ -21,16 +21,8 @@ public class MCVoxel implements Placeable {
      */
     public static final MCVoxel DEFAULTVOXEL = new MCVoxel("minecraft:air");
 
-
-    /**
-     * The block type string.
-     * @see <a href="https://minecraft.wiki/w/Block">List of block types (Minecraft Wiki)</a>
-     */
-    protected final String type;
-    /**
-     * The block state properties.
-     */
-    protected final Map<String, String> properties;
+    private final String type;
+    private final Map<String, String> properties;
 
     // Lazily-initialized reusable block data
     private CompoundTag block;
@@ -51,8 +43,23 @@ public class MCVoxel implements Placeable {
      * @param properties the block state properties
      */
     public MCVoxel(String type, Map<String, String> properties) {
-        this.type = type;
-        this.properties = properties;
+        this.type = MCHelpers.ensureNamespaced(type);
+        this.properties = properties == null ? Map.of() : Map.copyOf(properties);
+    }
+
+    /**
+     * {@return the block type string}
+     * @see <a href="https://minecraft.wiki/w/Block">List of block types (Minecraft Wiki)</a>
+     */
+    public String type() {
+        return type;
+    }
+
+    /**
+     * {@return the block state properties}
+     */
+    public Map<String, String> properties() {
+        return properties;
     }
 
     /**
@@ -77,6 +84,31 @@ public class MCVoxel implements Placeable {
         return new MCVoxel(type);
     }
 
+    /**
+     * Creates a new instance of {@link MCVoxel} from a serialized block state string.
+     * Example: {@code minecraft:blue_candle[candles=3,lit=true]}.
+     * Extra whitespaces are not allowed!
+     *
+     * @param block the string representing a block.
+     * @return a new {@code MCVoxel}
+     */
+    public static MCVoxel fromString(String block) {
+        int bracket = block.indexOf('[');
+        if (bracket == -1)
+            return new MCVoxel(block);
+        if (block.indexOf(']') != block.length() - 1)
+            throw new IllegalArgumentException("Invalid block state definition: " + block);
+        String type = block.substring(0, bracket);
+        Map<String, String> properties = new HashMap<>();
+        for (String property : block.substring(bracket + 1, block.length() - 1).split(",")) {
+            int eq = property.indexOf('=');
+            if (eq == -1)
+                throw new IllegalArgumentException("Invalid property definition: " + property);
+            properties.put(property.substring(0, eq), property.substring(eq + 1));
+        }
+        return new MCVoxel(type, properties);
+    }
+
     @Override
     public void place(VoxelTile tile, int x, int y, int z)  {
         if (tile instanceof MCVoxelTile mcTile) {
@@ -98,7 +130,7 @@ public class MCVoxel implements Placeable {
         if (block == null) {
             block = new CompoundTag();
             block.putString("Name", type);
-            if (properties != null) {
+            if (!properties.isEmpty()) {
                 CompoundTag state = new CompoundTag();
                 properties.forEach(state::putString);
                 block.put("Properties", state);
@@ -112,7 +144,7 @@ public class MCVoxel implements Placeable {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         MCVoxel that = (MCVoxel) o;
-        return type.equals(that.type) && Objects.equals(properties, that.properties);
+        return type.equals(that.type) && properties.equals(that.properties);
     }
 
     @Override

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxel.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxel.java
@@ -19,7 +19,7 @@ public class MCVoxel implements Placeable {
     /**
      * Default voxel used on map initialization.
      */
-    public static final MCVoxel DEFAULTVOXEL = new MCVoxel("minecraft:air", new HashMap<>());
+    public static final MCVoxel DEFAULTVOXEL = new MCVoxel("minecraft:air");
 
 
     /**

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelTile.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/MCVoxelTile.java
@@ -69,6 +69,7 @@ public class MCVoxelTile extends VoxelTile {
             McaFileHelpers.blockAbsoluteToChunkRelative(blockZ),
             block
         );
+        clearBlockEntity(blockX, blockY, blockZ); // TODO This negatively affects performances and should be optimized!
         // (In-Game coords to world coords) X/Z/-Y => X/Y/Z
         updateHeightmaps(blockX, -(blockZ + 1), blockY);
     }
@@ -82,7 +83,19 @@ public class MCVoxelTile extends VoxelTile {
             blockEntities = new ListTag<>(CompoundTag.class);
             chunk.setTileEntities(blockEntities);
         }
+        block.putInt("x", blockX);
+        block.putInt("y", blockY);
+        block.putInt("z", blockZ);
         blockEntities.add(block);
+    }
+
+    private void clearBlockEntity(int blockX, int blockY, int blockZ) {
+        if (isOutOfLimits(blockX, blockY, blockZ)) return;
+        TerrainChunk chunk = getOrCreateRegion(blockX, blockZ).getOrCreateChunk(McaFileHelpers.blockToChunk(blockX), McaFileHelpers.blockToChunk(blockZ));
+        ListTag<CompoundTag> blockEntities = chunk.getTileEntities();
+        if (blockEntities == null)
+            return;
+        blockEntities.removeIf(blockEntity -> MCHelpers.xyzEquals(blockEntity, blockX, blockY, blockZ));
     }
 
     // In-Game coords
@@ -103,11 +116,21 @@ public class MCVoxelTile extends VoxelTile {
      */
     @Override
     public Placeable getVoxel(int x, int y, int z) {
-        Region region = regions.get(Region.computeKeyFromBlock(x, -y - 1));
-
-        if (region == null) return MCVoxel.DEFAULTVOXEL;
-
         // (World coords to In-Game coords) X/Y/Z => X/Z/-Y-1
-        return region.getBlock(x, z, -y - 1);
+        int blockX = x;
+        int blockY = z;
+        int blockZ = -y - 1;
+
+        Region region = regions.get(Region.computeKeyFromBlock(blockX, blockZ));
+        if (region == null)
+            return MCVoxel.DEFAULTVOXEL;
+
+        CompoundTag blockState = region.getBlockState(blockX, blockY, blockZ);
+        if (blockState == null)
+            return MCVoxel.DEFAULTVOXEL;
+        MCVoxel voxel = MCVoxel.fromBlockState(blockState);
+
+        CompoundTag blockEntity = region.getBlockEntity(blockX, blockY, blockZ);
+        return blockEntity == null ? voxel : MCBlockEntityVoxel.fromBlockEntity(blockEntity, voxel);
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/Region.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/Region.java
@@ -105,13 +105,13 @@ public record Region(int regionX, int regionZ, McaRegionFile file) {
     public MCVoxel getBlock(int blockX, int blockY, int blockZ) {
         TerrainChunk chunk = file.getChunk(McaFileHelpers.blockToChunk(blockX), McaFileHelpers.blockToChunk(blockZ));
         if (chunk == null)
-            return null;
+            return MCVoxel.DEFAULTVOXEL;
         CompoundTag block = chunk.getBlockAtByRef(
             McaFileHelpers.blockAbsoluteToChunkRelative(blockX),
             blockY,
             McaFileHelpers.blockAbsoluteToChunkRelative(blockZ)
         );
-        return block == null ? null : MCVoxel.fromBlockState(block);
+        return block == null ? MCVoxel.DEFAULTVOXEL : MCVoxel.fromBlockState(block);
     }
 
     /**

--- a/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/Region.java
+++ b/src/main/java/com/ignfab/minalac/generator/outputs/minecraft/Region.java
@@ -7,6 +7,7 @@ import io.github.ensgijs.nbt.mca.McaRegionFile;
 import io.github.ensgijs.nbt.mca.TerrainChunk;
 import io.github.ensgijs.nbt.mca.io.McaFileHelpers;
 import io.github.ensgijs.nbt.tag.CompoundTag;
+import io.github.ensgijs.nbt.tag.ListTag;
 
 /**
  * Represents a Minecraft region.
@@ -95,23 +96,41 @@ public record Region(int regionX, int regionZ, McaRegionFile file) {
     }
 
     /**
-     * Returns a block as a new {@link MCVoxel}.
+     * Returns the block state at the given coordinates.
      *
      * @param blockX the in-game x-coordinate
      * @param blockY the in-game y-coordinate
      * @param blockZ the in-game z-coordinate
-     * @return the corresponding voxel, or {@code null} if it doesn't exist
+     * @return the corresponding block state, or {@code null} if it doesn't exist
      */
-    public MCVoxel getBlock(int blockX, int blockY, int blockZ) {
+    public CompoundTag getBlockState(int blockX, int blockY, int blockZ) {
         TerrainChunk chunk = file.getChunk(McaFileHelpers.blockToChunk(blockX), McaFileHelpers.blockToChunk(blockZ));
-        if (chunk == null)
-            return MCVoxel.DEFAULTVOXEL;
-        CompoundTag block = chunk.getBlockAtByRef(
+        return chunk == null ? null : chunk.getBlockAtByRef(
             McaFileHelpers.blockAbsoluteToChunkRelative(blockX),
             blockY,
             McaFileHelpers.blockAbsoluteToChunkRelative(blockZ)
         );
-        return block == null ? MCVoxel.DEFAULTVOXEL : MCVoxel.fromBlockState(block);
+    }
+
+    /**
+     * Returns the block entity at the given coordinates.
+     *
+     * @param blockX the in-game x-coordinate
+     * @param blockY the in-game y-coordinate
+     * @param blockZ the in-game z-coordinate
+     * @return the corresponding block entity, or {@code null} if it doesn't exist
+     */
+    public CompoundTag getBlockEntity(int blockX, int blockY, int blockZ) {
+        TerrainChunk chunk = file.getChunk(McaFileHelpers.blockToChunk(blockX), McaFileHelpers.blockToChunk(blockZ));
+        if (chunk == null)
+            return null;
+        ListTag<CompoundTag> blockEntities = chunk.getTileEntities();
+        if (blockEntities == null)
+            return null;
+        for (CompoundTag blockEntity : blockEntities)
+            if (MCHelpers.xyzEquals(blockEntity, blockX, blockY, blockZ))
+                return blockEntity;
+        return null;
     }
 
     /**

--- a/src/main/java/com/ignfab/minalac/generator/parameters/placeables/PlaceableParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/placeables/PlaceableParams.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.ignfab.minalac.generator.parameters.OutputFormat;
 import com.ignfab.minalac.generator.parameters.placeables.patterns.PatternParams;
 import com.ignfab.minalac.generator.parameters.placeables.structures.PlaceableStructureParams;
+import com.ignfab.minalac.generator.parameters.placeables.voxels.MCSchematicParams;
 import com.ignfab.minalac.generator.placeables.Placeable;
 import com.ignfab.minalac.generator.utils.random.Seed;
 
@@ -76,6 +77,9 @@ public abstract class PlaceableParams {
                     // For patterns, relies on PatternParams type deduction
                     case "pattern":
                         return codec.treeToValue(property.getValue(), PatternParams.class);
+                    // TODO find a better way to handle this!
+                    case "schematic":
+                        return codec.treeToValue(property.getValue(), MCSchematicParams.class);
                 }
             }
 

--- a/src/main/java/com/ignfab/minalac/generator/parameters/placeables/voxels/MCBlockEntityVoxelParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/placeables/voxels/MCBlockEntityVoxelParams.java
@@ -1,0 +1,66 @@
+package com.ignfab.minalac.generator.parameters.placeables.voxels;
+
+import java.beans.ConstructorProperties;
+import java.io.IOException;
+
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import io.github.ensgijs.nbt.io.TextNbtHelpers;
+import io.github.ensgijs.nbt.tag.CompoundTag;
+
+import com.ignfab.minalac.generator.outputs.minecraft.MCBlockEntityVoxel;
+import com.ignfab.minalac.generator.placeables.Placeable;
+import com.ignfab.minalac.generator.utils.random.Seed;
+
+/**
+ * Parameters for Minecraft block entity voxel.
+ */
+public class MCBlockEntityVoxelParams extends MCVoxelParams {
+    /**
+     * Block entity ID (required).
+     * Special case: If value is {@code "true"}, block type name will be used.
+     * This is needed to determine that a block entity is wanted.
+     */
+    @JsonSetter(nulls = Nulls.FAIL)
+    public String blockEntity;
+
+    /**
+     * Block state data (optional).
+     */
+    @JsonSetter(nulls = Nulls.SKIP)
+    public String dataTags = null;
+
+    /**
+     * Creates a new {@code MCBlockEntityVoxelParams}.
+     *
+     * @param block Block type name
+     * @param blockEntity Block entity ID
+     */
+    @ConstructorProperties({ "block", "blockEntity" })
+    public MCBlockEntityVoxelParams(String block, String blockEntity) {
+        super(block);
+        this.blockEntity = blockEntity.equals("true") ? block : blockEntity;
+    }
+
+    @Override
+    public void validate() throws IllegalArgumentException {
+        super.validate();
+        if (blockEntity.isBlank())
+            throw new IllegalArgumentException("blockEntity should not be empty or blank");
+    }
+
+    @Override
+    public Placeable create(Seed seed) {
+        CompoundTag data;
+        if (dataTags == null)
+            data = null;
+        else {
+            try {
+                data = TextNbtHelpers.fromTextNbt(dataTags).getTagAutoCast();
+            } catch (IOException e) {
+                throw new IllegalArgumentException("Malformed data tags: " + dataTags, e);
+            }
+        }
+        return new MCBlockEntityVoxel(block, blockEntity, properties, data);
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/parameters/placeables/voxels/MCSchematicParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/placeables/voxels/MCSchematicParams.java
@@ -1,0 +1,40 @@
+package com.ignfab.minalac.generator.parameters.placeables.voxels;
+
+import java.beans.ConstructorProperties;
+import java.io.File;
+
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+
+import com.ignfab.minalac.generator.outputs.minecraft.MCSchematic;
+import com.ignfab.minalac.generator.parameters.placeables.PlaceableParams;
+import com.ignfab.minalac.generator.placeables.Placeable;
+import com.ignfab.minalac.generator.utils.FileHelpers;
+import com.ignfab.minalac.generator.utils.random.Seed;
+import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
+
+public class MCSchematicParams extends PlaceableParams {
+    @JsonSetter(nulls = Nulls.FAIL)
+    public String file;
+
+    public boolean excludeAir = false;
+
+    public int xOffset = 0;
+
+    public int yOffset = 0;
+
+    public int zOffset = 0;
+
+    @ConstructorProperties("file")
+    public MCSchematicParams(String file) {
+        this.file = file;
+    }
+
+    @Override
+    public Placeable create(Seed seed) {
+        File schematic = new File(file);
+        if (!FileHelpers.isReadableRegularFile(schematic))
+            throw new IllegalArgumentException("Schematic file \"%s\" does not exist".formatted(schematic.getAbsolutePath()));
+        return new MCSchematic(schematic, excludeAir, new WorldCoords3d(xOffset, yOffset, zOffset));
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/parameters/placeables/voxels/MCVoxelParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/placeables/voxels/MCVoxelParams.java
@@ -4,6 +4,8 @@ import java.beans.ConstructorProperties;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.Nulls;
 
 import com.ignfab.minalac.generator.outputs.minecraft.MCVoxel;
@@ -14,6 +16,10 @@ import com.ignfab.minalac.generator.utils.random.Seed;
 /**
  * Parameters for simple Minecraft voxel with only block type name.
  */
+// defaultImpl is needed because Jackson deduction cannot rely on absence of field to determine a subtype
+// See this GitHub issue for more info: https://github.com/FasterXML/jackson-databind/issues/2976
+@JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION, defaultImpl = MCVoxelParams.class)
+@JsonSubTypes(@JsonSubTypes.Type(MCBlockEntityVoxelParams.class))
 public class MCVoxelParams extends PlaceableParams {
     /**
      * Block type name (required).
@@ -46,5 +52,21 @@ public class MCVoxelParams extends PlaceableParams {
     @Override
     public Placeable create(Seed seed) {
         return new MCVoxel(block, properties);
+    }
+
+    // TODO probably find a better name
+    public static MCVoxelParams packed(String block) {
+        return new Packed(block);
+    }
+
+    private static final class Packed extends MCVoxelParams {
+        private Packed(String block) {
+            super(block);
+        }
+
+        @Override
+        public Placeable create(Seed seed) {
+            return MCVoxel.fromString(block);
+        }
     }
 }


### PR DESCRIPTION
Cette PR contient 3 commits pour la JDC 2026.

Le premier, 4352dfffab2360763d62a4da6e2869df455dfc6d, est un fix qui était déjà présent sur `main` dès son introduction via #148 après FDS, et qui n'était donc pas dans `fds/main`, depuis laquelle la branche `jdc/main` avait été basée.

Le second, 84a2660b4a890ad01ee81fee22b6cc40d334a0c4, est le plus conséquent ici. Il représente des améliorations nécessaires pour rendre le format Minecraft pleinement fonctionnel et simple à utiliser. Jusqu'à présent, le développement s'était concentré autour de Minetest, ce qui explique pourquoi le format Minecraft n'avait pas tant que ça été expérimenté. Puisque JDC 2026 se base quant à lui sur Minecraft, un certain nombre de petits détails, loupés, erreurs de conception, etc... qui étaient passées à la trappe ont remonté, et ont été adressées dans ce commit. On peut y noter :
- Introduction de `MCHelpers` pour centraliser des opérations utilitaires liées au format Minecraft
  - Il y a probablement d'autres méthodes (dans le code existant qui n'a pas bougé) qui pourraient mériter d'y être relocalisées
- Normalisation des données au niveau du `MCVoxel`
  - Le `type` est désormais toujours préfixé d'un namespace (si pas précisé, `minecraft:` par défaut)
  - Les `properties` sont désormais toujours non-`null`, et sont complètement immutables
  - L'intérêt majeur est que la méthode `.equals` est désormais plus fiable : `new MCVoxel("air").equals(new MCVoxel("minecraft:air", new HashMap<>()))` sera `true`
  - Les deux champs sont également exposés à travers leur getter respectif, au besoin (grâce à l'immutabilité des properties)
- Ajout d'une méthode pour créer un `MCVoxel` à partir d'une chaîne de caractères représentant un block state (exemple : `minecraft:blue_candle[candles=3,lit=true]`)
  - C'est la syntaxe utilisée nativement dans les commandes en jeu
  - Par défaut, la notation courte des voxels dans le paramétrage utilise ce format (paramétrage plus concis et lisible)
- Refonte du `MCBlockEntityVoxel` qui nécessitait avant des sous-classes sans raison particulière. Désormais, la classe peut traiter des données NBT brutes, et l'ID du block entity n'est plus nécessairement le type du block state
  - On peut créer un `MCBlockEntityVoxel` par dessus un `MCVoxel` existant (en rajoutant seulement le block entity), ou de 0 (avec à la fois les infos du block state et du block entity dans le constructeur)
  - Le test d'égalité est possible, mais l'absence d'ordre dans les données NBT brutes peut poser problème (`{foo:1,bar:2}` est identique à `{bar:2,foo:1}` mais selon comment l'ordre dans lequel les propriétés ont été ajoutées à la création de l'objet, leur représentation Java peuvent être différentes...)
  - Possibilité de créer un `MCBlockEntityVoxel` depuis la forme sérialisée et depuis une chaîne de caractères (même si non utilisé à l'heure actuelle)
  - À noter que `CompoundTag` ne peut pas être immutable, donc seule une copie interne non exposée est utilisée
- Ajout d'un paramétrage pour les `MCBlockEntityVoxel`, qui étend par déduction celui des `MCVoxel`
  - Comme Jackson a besoin d'une propriété pour la déduction, il est obligatoire de préciser le champ `blockEntity` pour créer un block entity, mais une valeur spéciale (`true`) est possible pour éviter la répétition quand elle est censée être identique à `block` (la grande majorité des cas)
  - Les données NBT brutes sont spécifiées dans l'encodage SNBT (string NBT), utilisé nativement par Minecraft
- Correction d'un bug lorsqu'un block state + block entity était ajouté puis remplacé par un block state seul, le block entity restait
  - Ce correctif a un impact sur les performances, car il doit aller parcourir la liste des block entities du chunk (16x16) à chaque fois qu'un block state est placé, pour savoir si il y avait un block entity à remplacer
  - Une optimisation simple serait de garder une référence vers chaque block entity à partir de sa position (au sein d'une région par exemple) pour un accès direct
- Adaptation de la méthode `MCVoxelTile#getVoxel` pour tenir compte des block entities, ce qui implique une réévaluation des responsabilités avec la région, qui ne gère désormais plus que des block state et block entity bruts
Une nette amélioration semble possible autour de la répartition des responsabilités entre la tuile et la région, mais n'ayant aucun impact fonctionnel, pourra être faite ultérieurement)

Le dernier, d045670f578973379586e793bb2b253bafdeb650, est intéressant pour JDC, et ce qui a motivé cette PR à l'origine, car il ajoute la possibilité d'importer des schematics dans le format Sponge V3 (utilisé par le plugin très répandu WorldEdit notamment). Les builders et joueurs MC savent très bien créer des schematics dans ce format, et ça permet à n'importe qui de construire un modèle en jeu (lampadaire, feu rouge...) et l'utiliser pour le générateur ! Actuellement, le schematic est un placeable qu'on peut référencer dans le paramétrage, mais à terme il pourrait être simplifié pour n'être qu'un moyen depuis le paramétrage de créer une `PlaceableStructure`

Pour info, voici à quoi ressemble les données d'un schematic dans ce format, une fois décodées (NBT compressé) et représentée en SNBT :
<details>
<summary><code>lamp_post.schem</code></summary>

```
{
	Schematic: {
		Blocks: {
			Palette: {
				"minecraft:nether_brick_fence[east=false,north=false,south=true,waterlogged=false,west=false]": 3
				"minecraft:nether_brick_fence[east=false,north=false,south=false,waterlogged=false,west=false]": 2
				"minecraft:nether_brick_fence[east=true,north=false,south=false,waterlogged=false,west=false]": 4
				"minecraft:air": 0
				"minecraft:nether_brick_fence[east=false,north=true,south=false,waterlogged=false,west=false]": 7
				"minecraft:player_head[powered=false,rotation=0]": 9
				"minecraft:redstone_lamp[lit=false]": 8
				"minecraft:daylight_detector[inverted=true,power=0]": 10
				"minecraft:nether_brick_fence[east=true,north=true,south=true,waterlogged=false,west=true]": 5
				"minecraft:polished_blackstone_wall[east=none,north=none,south=none,up=true,waterlogged=false,west=none]": 1
				"minecraft:nether_brick_fence[east=false,north=false,south=false,waterlogged=false,west=true]": 6
			}
			Data: [B; 0B, 0B, 0B, 0B, 1B, 0B, 0B, 0B, 0B, 0B, 0B, 0B, 0B, 1B, 0B, 0B, 0B, 0B, 0B, 0B, 0B, 0B, 1B, 0B, 0B, 0B, 0B, 0B, 0B, 0B, 0B, 2B, 0B, 0B, 0B, 0B, 0B, 0B, 0B, 0B, 2B, 0B, 0B, 0B, 0B, 0B, 0B, 0B, 0B, 2B, 0B, 0B, 0B, 0B, 0B, 0B, 0B, 0B, 2B, 0B, 0B, 0B, 0B, 0B, 0B, 0B, 0B, 2B, 0B, 0B, 0B, 0B, 0B, 0B, 0B, 0B, 2B, 0B, 0B, 0B, 0B, 0B, 0B, 0B, 0B, 2B, 0B, 0B, 0B, 0B, 0B, 3B, 0B, 4B, 5B, 6B, 0B, 7B, 0B, 0B, 8B, 0B, 8B, 9B, 8B, 0B, 8B, 0B, 0B, 10B, 0B, 10B, 0B, 10B, 0B, 10B, 0B]
			BlockEntities: [
				{
					Pos: [I; 1, 11, 1]
					Data: {
						components: {}
						profile: {
							properties: [
								{
									name: textures
									value: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNzI3YmY4NzY0MzVlMDRkZGU5ZGExOTkyNDMxNWFlNTlhOGVmYzI3YWYxZGRiZWY4MTNkODljZmFmZmU5MTY0NyJ9fX0="
								},
							]
						}
						x: 1
						y: 11
						z: 1
						id: "minecraft:skull"
					}
					Id: "minecraft:skull"
				},
				{
					Pos: [I; 1, 12, 0]
					Data: {
						components: {}
						x: 1
						y: 12
						z: 0
						id: "minecraft:daylight_detector"
					}
					Id: "minecraft:daylight_detector"
				},
				{
					Pos: [I; 0, 12, 1]
					Data: {
						components: {}
						x: 0
						y: 12
						z: 1
						id: "minecraft:daylight_detector"
					}
					Id: "minecraft:daylight_detector"
				},
				{
					Pos: [I; 2, 12, 1]
					Data: {
						components: {}
						x: 2
						y: 12
						z: 1
						id: "minecraft:daylight_detector"
					}
					Id: "minecraft:daylight_detector"
				},
				{
					Pos: [I; 1, 12, 2]
					Data: {
						components: {}
						x: 1
						y: 12
						z: 2
						id: "minecraft:daylight_detector"
					}
					Id: "minecraft:daylight_detector"
				},
			]
		}
		Version: 3
		Length: 3S
		Metadata: {
			WorldEdit: {
				Origin: [I; -48, 72, 16]
				Platforms: {
					"intellectualsites:bukkit": {
						Version: "2.15.1-SNAPSHOT-1266+c4a5914"
						Name: "Bukkit-Official"
					}
				}
				EditingPlatform: "intellectualsites:bukkit"
				Version: "2.15.1-SNAPSHOT-1266"
			}
			Date: 1768838796399L
		}
		Height: 13S
		DataVersion: 4671
		Width: 3S
		Offset: [I; -1, 1, -1]
	}
}
```
</details>

D'autres formats de "schematic" existent, les "structures" vanilla (assez limitées et peu connues), et les "blueprints" notamment, qui sont l'équivalent dans un mod moderne "Axiom" très utilisé par les builders. Leur format n'est pas beaucoup plus compliqué, donc ça pourra valloir le coup de les supporter... plus tard. Un embryon d'expérimentation du format du fichier est sur la branche `jdc/blueprint-mc`