### PR TITLE
Fix segment iterator when bevels intersect within thickness

### DIFF
--- a/src/main/java/com/ignfab/minalac/generator/voxelization/shape2d/iterator/ThickSegment2dIterator.java
+++ b/src/main/java/com/ignfab/minalac/generator/voxelization/shape2d/iterator/ThickSegment2dIterator.java
@@ -57,6 +57,8 @@ import com.ignfab.minalac.generator.voxelization.shape2d.Segment2d;
      * <p>
      * These four parameters describes the four side of the surface to draw: two borders parallel to the segment and two bevels intersecting them.
      * <p>
+     * Bevels direction must not be same as segment.
+     * <p>
      * Start and end bevel direction must be in opposite direction.
      *
      * @param segment the segment to iterator over.
@@ -109,7 +111,7 @@ import com.ignfab.minalac.generator.voxelization.shape2d.Segment2d;
 
         // Test if bevels intersection is in segment thickness
         if (Math.abs(bevelIntersectionPosition) <= thickness) {
-            Vector2d thickPoint = bevelIntersectionPosition > 0 ? thickPoint1 : thickPoint2;
+            Vector2d thickPoint = bevelIntersectionPosition < 0 ? thickPoint1 : thickPoint2;
             bbox = new WorldBBox2d(
                 bevelIntersection.round(),
                 intersection(start, startBevelDirection, thickPoint, direction).round(),


### PR DESCRIPTION
A change in `signedDistance` sign to fit to normal direction has created a bug in `ThickSegment2dIterator`.
The fix is trivial and simply reflect that change in the only place this distance was compared to 0.

Without fix:
<img width="731" height="422" alt="Capture d’écran du 2026-02-16 11-14-20" src="https://github.com/user-attachments/assets/41554b98-3d5a-461d-b98a-e3ac4b77102b" />

With fix
<img width="731" height="422" alt="Capture d’écran du 2026-02-16 11-15-58" src="https://github.com/user-attachments/assets/9faa830f-8054-489d-a365-5b12d13fbbe3" />

