### PR TITLE
chore(geotools): Migrate to GeoTools BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,6 @@
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <geotools.version>31.0</geotools.version>
         <osm4j.version>1.4.1</osm4j.version>
     </properties>
 
@@ -59,6 +58,13 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.geotools</groupId>
+                <artifactId>gt-bom</artifactId>
+                <version>34.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -98,32 +104,26 @@
         <dependency>
             <groupId>org.geotools</groupId>
             <artifactId>gt-main</artifactId>
-            <version>${geotools.version}</version>
         </dependency>
         <dependency>
             <groupId>org.geotools.xsd</groupId>
             <artifactId>gt-xsd-wfs</artifactId>
-            <version>${geotools.version}</version>
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>
             <artifactId>gt-referencing</artifactId>
-            <version>${geotools.version}</version>
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>
             <artifactId>gt-geopkg</artifactId>
-            <version>${geotools.version}</version>
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>
             <artifactId>gt-shapefile</artifactId>
-            <version>${geotools.version}</version>
         </dependency>
         <dependency>
             <groupId>org.geotools</groupId>
             <artifactId>gt-geotiff</artifactId>
-            <version>${geotools.version}</version>
         </dependency>
         <!--
             Required to identify coordinates reference systems
@@ -132,7 +132,6 @@
         <dependency>
             <groupId>org.geotools</groupId>
             <artifactId>gt-epsg-hsql</artifactId>
-            <version>${geotools.version}</version>
         </dependency>
         <!-- Minecraft NBT file format -->
         <dependency>
@@ -273,19 +272,15 @@
                         <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                             <!-- With at least an entry "Main-Class: ..." to make it executable -->
                             <mainClass>com.ignfab.minalac.generator.MinalacGenerator</mainClass>
-                            <!-- And manifest entries from javax.media:jai_imageio, required for GeoTools GeoTiff module -->
-                            <manifestEntries>
-                                <Name>javax/media/jai/</Name>
-                                <Specification-Title>Java Advanced Imaging Image I/O Tools</Specification-Title>
-                                <Specification-Version>1.1</Specification-Version>
-                                <Specification-Vendor>Sun Microsystems, Inc.</Specification-Vendor>
-                                <Implementation-Title>com.sun.media.imageio</Implementation-Title>
-                                <Implementation-Version>1.1</Implementation-Version>
-                                <Implementation-Vendor>Sun Microsystems, Inc.</Implementation-Vendor>
-                            </manifestEntries>
                         </transformer>
-                        <!-- Properly shades all resources, required for GeoTools HSQL embedded databases -->
+                        <!-- Properly shades all resources, required for GeoTools HSQL embedded databases and GeoTIFF module -->
                         <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                            <resource>META-INF/org.eclipse.imagen.registryFile.jai</resource>
+                        </transformer>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                            <resource>META-INF/registryFile.jai</resource>
+                        </transformer>
                     </transformers>
                     <filters>
                         <!-- Removes some duplicated resources being shaded together -->
@@ -311,19 +306,11 @@
                                 <exclude>plugin.properties</exclude>
                             </excludes>
                         </filter>
-                        <!-- Removes JAI-EXT registry files overlapping with each-other -->
+                        <!-- Removes utility class of "scale2" already provided by "scale" -->
                         <filter>
-                            <artifact>*:jt-*</artifact>
+                            <artifact>org.eclipse.imagen:scale2</artifact>
                             <excludes>
-                                <exclude>META-INF/registryFile.jai*</exclude>
-                            </excludes>
-                        </filter>
-                        <!-- Removes some files of jt-scale2 that are already provided by jt-scale -->
-                        <filter>
-                            <artifact>it.geosolutions.jaiext.scale2:jt-scale2</artifact>
-                            <excludes>
-                                <exclude>it/geosolutions/jaiext/scale/JaiI18N.class</exclude>
-                                <exclude>it/geosolutions/jaiext/resources/image/it.geosolutions.jaiext.scale.properties</exclude>
+                                <exclude>org/eclipse/imagen/media/scale/JaiI18N.class</exclude>
                             </excludes>
                         </filter>
                     </filters>

--- a/src/main/java/com/ignfab/minalac/generator/inputs/FloatImageGeographicDataMatrix2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/FloatImageGeographicDataMatrix2d.java
@@ -1,6 +1,6 @@
 package com.ignfab.minalac.generator.inputs;
 
-import javax.media.jai.iterator.RandomIter;
+import org.eclipse.imagen.iterator.RandomIter;
 
 /**
  * A matrix of float values.

--- a/src/main/java/com/ignfab/minalac/generator/inputs/GeoTiffDataProvider.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/GeoTiffDataProvider.java
@@ -2,9 +2,9 @@ package com.ignfab.minalac.generator.inputs;
 
 import java.io.File;
 import java.io.IOException;
-import javax.media.jai.iterator.RandomIter;
-import javax.media.jai.iterator.RandomIterFactory;
 
+import org.eclipse.imagen.iterator.RandomIter;
+import org.eclipse.imagen.iterator.RandomIterFactory;
 import org.geotools.api.referencing.FactoryException;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.coverage.grid.GridCoverage2D;
@@ -50,7 +50,7 @@ public class GeoTiffDataProvider implements Provider<FloatGeographicDataMatrix2d
     public Provider.Result<FloatGeographicDataMatrix2d> provide(WorldBBox3d bbox) throws GenerationFailedException, RetryableException {
         GridCoverage2D grid;
         try {
-            grid = new GeoTiffReader(file, crsOverride == null ? null : new Hints(Hints.DEFAULT_COORDINATE_REFERENCE_SYSTEM, crsOverride)).read(null);
+            grid = new GeoTiffReader(file, crsOverride == null ? null : new Hints(Hints.DEFAULT_COORDINATE_REFERENCE_SYSTEM, crsOverride)).read();
         } catch (IOException e) {
             throw new RetryableException(e);
         }


### PR DESCRIPTION
### Type of modification

- Other: pom.xml

### Changes

This PR rewrites the `pom.xml` file to rely on the GeoTools BOM to manage modules' version.

#### Feature description

Previously, the version of GeoTools modules was centralized as a Maven property (`${geotools.version}`), which was used for every GeoTools module imported as a dependency.

Maven has a built-in system to centralize version of such modules, called "Bill of Materials" (BOM). GeoTools provides one, containing the version for each of its module.

Version was bumped from 31.0 to 34.0 (latest at the time of writing) at the same time. This caused some minor changes due to the GeoTIFF module, which updated one of its dependency.

#### Technical changes

Added GeoTools BOM (`gt-bom`): https://docs.geotools.org/latest/developer/procedures/bom.html

### Reason

Using a BOM reduces the amount of constraints in the POM by delegating the version management of some related dependencies to the author of those dependencies. It ensures compatibility between the version used for each dependency covered by that BOM, and centralizes the choice of the version. Furthermore, if the version of a single dependency should be different for any reason, it still allows overriding those versions.

### Self-checks

- ~~The code has unit tests associated~~
- ~~The code has Javadoc Comments associated~~
- [x] Complex / Unexpected code is explained / justified with a small comment
- ~~Relevant documentation inside the `/docs` folder has been updated~~
- ~~All examples in `examples/` work the same (or have been adapted if subject to changes in this PR)~~
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [x] The texts have been proofread (documentation, error messages, logs, comments...)
