### PR TITLE
feat(params): Add @JsonWrapper annotation for params class wrapping a single field

### DIFF
--- a/src/main/java/com/ignfab/minalac/generator/parameters/JsonDelegateDeserialize.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/JsonDelegateDeserialize.java
@@ -44,13 +44,7 @@ public @interface JsonDelegateDeserialize {
 
     /**
      * Jackson handler to wrap deserializer of annotated beans with the requested one.
-     * This should be registered in the {@link tools.jackson.databind.cfg.MapperBuilder}:
-     * <pre>{@code
-     *  MapperBuilder<?, ?> mapperBuilder = ...;
-     *  SimpleModule module = new SimpleModule("MyModule");
-     *  module.setDeserializerModifier(new JsonDelegateDeserialize.BeanModifier());
-     *  mapperBuilder.addModule(module);
-     * }</pre>
+     * This is bundled by default with the {@link com.ignfab.minalac.generator.parameters.ParamsParser.MinalacParserModule}.
      */
     class BeanModifier extends ValueDeserializerModifier {
         @Override

--- a/src/main/java/com/ignfab/minalac/generator/parameters/JsonWrapper.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/JsonWrapper.java
@@ -1,0 +1,245 @@
+package com.ignfab.minalac.generator.parameters;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.BeanDescription;
+import tools.jackson.databind.BeanProperty;
+import tools.jackson.databind.DeserializationConfig;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.deser.SettableBeanProperty;
+import tools.jackson.databind.deser.ValueDeserializerModifier;
+import tools.jackson.databind.deser.ValueInstantiator;
+import tools.jackson.databind.deser.bean.BeanDeserializerBase;
+import tools.jackson.databind.util.AccessPattern;
+
+/**
+ * Annotation for params classes that are purely Java wrapper around a single field.
+ * The params will be deserialized as the type of the underlying field, then the
+ * wrapper object will be created using either single-arg constructor or field injection.
+ * Thus, the name of the underlying field is irrelevant for params (only visible in Java).
+ * <p>
+ * Note: The type this annotation is applied to MUST only have one single property,
+ * otherwise it will result in a runtime exception when creating the deserializer!
+ * <p>
+ * Direct {@code null} handling can be done either on the underlying field or where
+ * the type is used. If either one or both specifies {@link com.fasterxml.jackson.annotation.Nulls#FAIL Nulls.FAIL},
+ * no {@code null} will be allowed. If unspecified at usage, a {@code null} params
+ * will result in a wrapper being created with a value according to the {@code null}
+ * handling policy of the underlying field of that wrapping class.
+ * This means that if the underlying field disallows {@code null}, an exception
+ * will occur.
+ * <p>
+ * This is particularly useful to make a params class transparent for the user.
+ */
+@Target({ ElementType.ANNOTATION_TYPE, ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface JsonWrapper {
+    /**
+     * Jackson handler to set deserializer of annotated beans with the appropriate one.
+     * This is bundled by default with the {@link com.ignfab.minalac.generator.parameters.ParamsParser.MinalacParserModule}.
+     */
+    class BeanModifier extends ValueDeserializerModifier {
+        @Override
+        public ValueDeserializer<?> modifyDeserializer(DeserializationConfig config, BeanDescription.Supplier beanDescRef, ValueDeserializer<?> deserializer) {
+            // Ensure that the annotation is present on the type
+            JsonWrapper annotation = beanDescRef.getClassAnnotations().get(JsonWrapper.class);
+            if (annotation == null)
+                return deserializer;
+
+            // Find a bean deserializer somewhere in the delegation tree of the original deserializer
+            // It is useful to get information about the underlying property, and how to instantiate the wrapper
+            BeanDeserializerBase beanDeser = findBeanDeserializerBase(deserializer);
+            // Unlikely to happen as most deserializers are based on a bean deserializer, but we never know...
+            if (beanDeser == null)
+                throw new IllegalStateException(beanDescRef.getType() + " is not a valid wrapper (not deserialized as a bean)");
+
+            // We must make sure there is only a single property
+            if (beanDeser.getPropertyCount() != 1)
+                throw new IllegalStateException(beanDescRef.getType() + " is not a valid wrapper (not a single property)");
+            SettableBeanProperty property = beanDeser.findProperty(0);
+
+            // Then we create an instantiator for the wrapper class based on the one of the original deserializer
+            WrapperInstantiator instantiator = createWrapperInstantiator(config, beanDeser.getValueInstantiator(), property);
+            if (instantiator == null)
+                throw new IllegalStateException(beanDescRef.getType() + " is not a valid wrapper (cannot instantiate class)");
+
+            // And finally we replace the deserializer with our custom one
+            return new Deserializer(instantiator, beanDeser, property);
+        }
+
+        // A BeanDeserializerBase is needed to get a SettableBeanProperty for the underlying field
+        private static BeanDeserializerBase findBeanDeserializerBase(ValueDeserializer<?> deserializer) {
+            ValueDeserializer<?> deser = deserializer;
+            // Traverse the delegation tree until we find a bean deserializer... or not
+            while (deser != null && !(deser instanceof BeanDeserializerBase))
+                deser = deser.getDelegatee();
+            // The value returned can be null if no bean deserializer was present in the delegation tree
+            return (BeanDeserializerBase) deser;
+        }
+
+        // Instantiation must be done with the appropriate method of the ValueInstantiator
+        private static WrapperInstantiator createWrapperInstantiator(DeserializationConfig config, ValueInstantiator valueInstantiator, SettableBeanProperty property) {
+            // Prefer delegation if available
+            if (valueInstantiator.canCreateUsingDelegate())
+                return new DelegateInstantiator(valueInstantiator);
+            // Otherwise try to use the single-arg creator
+            SettableBeanProperty[] args = valueInstantiator.getFromObjectArguments(config);
+            if (args != null && args.length == 1 && args[0] == property)
+                return new CreatorArgInstantiator(valueInstantiator);
+            // Fallback to default instantiator with manual property assignment
+            if (valueInstantiator.canCreateUsingDefault())
+                return new DefaultInstantiator(valueInstantiator, property);
+            // Or fail if no instantiation method suits our requirements
+            return null;
+        }
+    }
+
+    /**
+     * Custom deserializer handling wrapper instantiation.
+     */
+    class Deserializer extends ValueDeserializer<Object> {
+        private final WrapperInstantiator instantiator;
+        private final BeanDeserializerBase beanDeser;
+        private SettableBeanProperty property;
+
+        Deserializer(WrapperInstantiator instantiator, BeanDeserializerBase beanDeser, SettableBeanProperty property) {
+            this.instantiator = instantiator;
+            this.beanDeser = beanDeser;
+            this.property = property;
+        }
+
+        @Override
+        public ValueDeserializer<?> getDelegatee() {
+            return beanDeser;
+        }
+
+        @Override
+        public void resolve(DeserializationContext context) {
+            // Resolve original bean deserializer to get the fully resolved property
+            beanDeser.resolve(context);
+            // Find resolved property (might have changed, especially for null handling)
+            property = beanDeser.findProperty(0).withName(property.getFullName());
+        }
+
+        @Override
+        public ValueDeserializer<?> createContextual(DeserializationContext context, BeanProperty property) {
+            // If no contextual property available, this is not a big deal, we can still process with original name
+            if (property == null)
+                return this;
+            // Carry over the name of the contextual property to make it
+            // fully transparent for the user (i.e. in error messages)
+            return new Deserializer(instantiator, beanDeser, this.property.withName(property.getFullName()));
+        }
+
+        @Override
+        public Object deserialize(JsonParser parser, DeserializationContext context) throws JacksonException {
+            // Deserialize using the property's deserializer, then wrap the result
+            return wrap(context, context.findContextualValueDeserializer(property.getType(), property).deserialize(parser, context));
+        }
+
+        @Override
+        public Object getNullValue(DeserializationContext context) {
+            // Null value should also be wrapped, which will result in either an exception
+            // if the property does not support nulls or in an "empty" wrapper
+            return wrap(context, property.getNullValueProvider().getNullValue(context));
+        }
+
+        @Override
+        public AccessPattern getNullAccessPattern() {
+            // The wrapper should be recreated because no further assumption can be made on mutability
+            return AccessPattern.DYNAMIC;
+        }
+
+        private Object wrap(DeserializationContext context, Object value) {
+            try {
+                return instantiator.create(context, value);
+            } catch (Exception e) {
+                // This generally throws an exception but maybe the situation can somehow be recovered...
+                return context.handleInstantiationProblem(instantiator.getValueClass(), value, e);
+            }
+        }
+    }
+
+    /**
+     * Simple tool to instantiate the wrapper class using the wrapped object.
+     */
+    abstract class WrapperInstantiator {
+        /**
+         * The instantiator of the wrapper class from Jackson.
+         */
+        protected final ValueInstantiator instantiator;
+
+        WrapperInstantiator(ValueInstantiator instantiator) {
+            this.instantiator = instantiator;
+        }
+
+        /**
+         * Instantiates the wrapper object.
+         * @param context Deserialization context
+         * @param wrapped The wrapped object value
+         * @return A new wrapper object wrapping the wrapped value
+         * @throws JacksonException when unable to instantiate the class
+         */
+        public abstract Object create(DeserializationContext context, Object wrapped) throws JacksonException;
+
+        /**
+         * {@return the Java class of the wrapper}
+         */
+        public Class<?> getValueClass() {
+            return instantiator.getValueClass();
+        }
+    }
+
+    /**
+     * Wrapper instantiator relying on the creator with a single argument.
+     */
+    class CreatorArgInstantiator extends WrapperInstantiator {
+        CreatorArgInstantiator(ValueInstantiator instantiator) {
+            super(instantiator);
+        }
+
+        @Override
+        public Object create(DeserializationContext context, Object wrapped) throws JacksonException {
+            return instantiator.createFromObjectWith(context, new Object[] { wrapped });
+        }
+    }
+
+    /**
+     * Wrapper instantiator relying on the default creator and then mutating the property.
+     */
+    class DefaultInstantiator extends WrapperInstantiator {
+        private final SettableBeanProperty property;
+
+        DefaultInstantiator(ValueInstantiator instantiator, SettableBeanProperty property) {
+            super(instantiator);
+            this.property = property;
+        }
+
+        @Override
+        public Object create(DeserializationContext context, Object wrapped) throws JacksonException {
+            Object wrapper = instantiator.createUsingDefaultOrWithoutArguments(context);
+            property.set(context, wrapper, wrapped);
+            return wrapper;
+        }
+    }
+
+    /**
+     * Wrapper instantiator relying on Jackson's own delegation-based instantiation.
+     */
+    class DelegateInstantiator extends WrapperInstantiator {
+        DelegateInstantiator(ValueInstantiator instantiator) {
+            super(instantiator);
+        }
+
+        @Override
+        public Object create(DeserializationContext context, Object wrapped) throws JacksonException {
+            return instantiator.createUsingDelegate(context, wrapped);
+        }
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/parameters/ParamsParser.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/ParamsParser.java
@@ -35,16 +35,14 @@ public class ParamsParser {
      * @param serialized A string containing the generation parameters data in Json or Yaml format
      * @return the corresponding generation parameters object.
      * @throws ParseException if an error occurs during deserialization such as an invalid structure
-     * @throws JacksonException
      */
-    public GenerationParams parse(String serialized) throws ParseException, JacksonException {
+    public GenerationParams parse(String serialized) throws ParseException {
         GenerationParams params;
-        SimpleModule module;
 
         // Custom deserializers
-        module = new SimpleModule("MinalacParserModule");
+        MinalacParserModule module = new MinalacParserModule();
+        // TODO OutputFormat handling might be relocated to the MinalacParserModule (not sure)
         module.addDeserializer(OutputFormat.class, formatDeserializer);
-        module.setDeserializerModifier(new JsonDelegateDeserialize.BeanModifier());
         mapperBuilder.addModule(module);
 
         YAMLMapper mapper = mapperBuilder.build();
@@ -103,4 +101,22 @@ public class ParamsParser {
         formatDeserializer.registerFormat(name, format);
     }
 
+    /**
+     * Jackson module used by this parser.
+     */
+    public static class MinalacParserModule extends SimpleModule {
+        /**
+         * Creates a new instante of this module.
+         */
+        public MinalacParserModule() {
+            super("MinalacParserModule");
+        }
+
+        @Override
+        public void setupModule(SetupContext context) {
+            super.setupModule(context);
+            context.addDeserializerModifier(new JsonDelegateDeserialize.BeanModifier());
+            context.addDeserializerModifier(new JsonWrapper.BeanModifier());
+        }
+    }
 }

--- a/src/main/java/com/ignfab/minalac/generator/parameters/placeables/CombinedPlaceableParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/placeables/CombinedPlaceableParams.java
@@ -1,12 +1,11 @@
 package com.ignfab.minalac.generator.parameters.placeables;
 
-import java.util.LinkedList;
 import java.util.List;
 
-import tools.jackson.core.JacksonException;
-import tools.jackson.databind.DeserializationContext;
-import tools.jackson.databind.JsonNode;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
 
+import com.ignfab.minalac.generator.parameters.JsonWrapper;
 import com.ignfab.minalac.generator.placeables.CombinedPlaceable;
 import com.ignfab.minalac.generator.placeables.Placeable;
 import com.ignfab.minalac.generator.utils.random.Seed;
@@ -15,24 +14,13 @@ import com.ignfab.minalac.generator.utils.random.Seed;
  * Parameters for a {@link CombinedPlaceable}.
  * CombinedPlaceable is actually represented by a list of placeables in parameter file.
  */
+@JsonWrapper
 public class CombinedPlaceableParams extends PlaceableParams {
     /**
      * Contained placeable params.
      */
-    public List<PlaceableParams> placeableParams = new LinkedList<>();
-
-    /**
-     * Creates a new {@code CombinedPlaceableParams}.
-     *
-     * This class is suposed to be instantiated only from {@link PlaceableParams} custom deserializer.
-     *
-     * @param array Array of {@code JsonNode} deserializable into {@code Placeable}
-     * @param context Context to use to deserialize placeables
-     */
-    public CombinedPlaceableParams(Iterable<JsonNode> array, DeserializationContext context) throws JacksonException {
-        for (JsonNode node : array)
-            placeableParams.add(context.readTreeAsValue(node, PlaceableParams.class));
-    }
+    @JsonSetter(nulls = Nulls.FAIL, contentNulls = Nulls.FAIL)
+    public List<PlaceableParams> placeableParams;
 
     @Override
     public void validate() {

--- a/src/main/java/com/ignfab/minalac/generator/parameters/placeables/PlaceableParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/placeables/PlaceableParams.java
@@ -50,7 +50,7 @@ public abstract class PlaceableParams {
                 return format.createVoxelParams(node.asString());
             }
             if (node.isArray())
-                return new CombinedPlaceableParams(node, context);
+                return context.readTreeAsValue(node, CombinedPlaceableParams.class);
 
             if (!node.isObject())
                 throw new InputCoercionException(parser, "Placeable should be either a string, an object or a list of placeables", node.asToken(), PlaceableParams.class);

--- a/src/main/java/com/ignfab/minalac/generator/parameters/placeables/structures/PlaceableStructureParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/placeables/structures/PlaceableStructureParams.java
@@ -1,18 +1,14 @@
 package com.ignfab.minalac.generator.parameters.placeables.structures;
 
-import java.util.LinkedList;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import tools.jackson.core.JacksonException;
-import tools.jackson.core.JsonParser;
-import tools.jackson.core.exc.InputCoercionException;
-import tools.jackson.databind.DeserializationContext;
-import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.ValueDeserializer;
-import tools.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.annotation.Nulls;
 
+import com.ignfab.minalac.generator.parameters.JsonWrapper;
 import com.ignfab.minalac.generator.parameters.placeables.PlaceableParams;
 import com.ignfab.minalac.generator.placeables.PlaceableStructure;
 import com.ignfab.minalac.generator.utils.random.Seed;
@@ -22,14 +18,15 @@ import com.ignfab.minalac.generator.utils.random.Seed;
  * <p>
  * Structure can be described using one of PlaceableStructureParams.Variant subclass or a combination of several.
  */
-@JsonDeserialize(using = PlaceableStructureParams.Deserializer.class)
+@JsonWrapper
 public final class PlaceableStructureParams extends PlaceableParams {
 
-    private final List<Variant> params;
-
-    private PlaceableStructureParams(List<Variant> params) {
-        this.params = params;
-    }
+    /**
+     * Structure contents.
+     */
+    @JsonSetter(nulls = Nulls.FAIL, contentNulls = Nulls.FAIL)
+    @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+    public List<Variant> params;
 
     @Override
     public void validate() {
@@ -45,34 +42,6 @@ public final class PlaceableStructureParams extends PlaceableParams {
             param.apply(seed, structureBuilder);
 
         return structureBuilder.build();
-    }
-
-    /**
-     * Custom deserializer creating a PlaceableStructureParams out of a structure list or single structure.
-     */
-    public static class Deserializer extends ValueDeserializer<PlaceableStructureParams> {
-
-        @Override
-        public PlaceableStructureParams deserialize(JsonParser parser, DeserializationContext context) throws JacksonException {
-            JsonNode node = parser.readValueAsTree();
-
-            // Decode array into structure list
-            if (node.isArray()) {
-                List<Variant> list = new LinkedList<>();
-                for (JsonNode item : node)
-                    list.add(context.readTreeAsValue(item, Variant.class));
-
-                return new PlaceableStructureParams(list);
-            }
-
-            // Decode single structure into a single value list
-            if (node.isObject()) {
-                Variant structure = context.readTreeAsValue(node, Variant.class);
-                return new PlaceableStructureParams(List.of(structure));
-            }
-
-            throw new InputCoercionException(parser, "Structure should be either a list or an single structure", node.asToken(), PlaceableStructureParams.class);
-        }
     }
 
     /**

--- a/src/main/java/com/ignfab/minalac/generator/parameters/utils/WorldBBox3dParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/utils/WorldBBox3dParams.java
@@ -1,26 +1,36 @@
 package com.ignfab.minalac.generator.parameters.utils;
 
-import java.util.ArrayList;
+import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+
+import com.ignfab.minalac.generator.parameters.JsonWrapper;
 import com.ignfab.minalac.generator.utils.IntegerInterval;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 
 /**
  * Parameters describing a {@link WorldBBox3d}.
  * <p>
- * A BBox can be described as an array of tree coordinates or coorinates intervals (in x, y, z order).
+ * A BBox can be described as an array of three coordinates or coordinates intervals (in x, y, z order).
  */
-public class WorldBBox3dParams extends ArrayList<IntegerIntervalParams> {
+@JsonWrapper
+public class WorldBBox3dParams {
+    /**
+     * The three intervals (required).
+     */
+    @JsonSetter(nulls = Nulls.FAIL, contentNulls = Nulls.FAIL)
+    public List<IntegerIntervalParams> intervals;
 
     /**
      * Validates parameters.
      */
     public void validate() {
-        if (size() != 3)
+        if (intervals.size() != 3)
             throw new IllegalArgumentException("3d box should have three coordinates");
-        get(0).validate();
-        get(1).validate();
-        get(2).validate();
+        intervals.get(0).validate();
+        intervals.get(1).validate();
+        intervals.get(2).validate();
     }
 
     /**
@@ -29,9 +39,9 @@ public class WorldBBox3dParams extends ArrayList<IntegerIntervalParams> {
      * @return created {@link WorldBBox3d}
      */
     public WorldBBox3d create() {
-        IntegerInterval xs = get(0).create();
-        IntegerInterval ys = get(1).create();
-        IntegerInterval zs = get(2).create();
+        IntegerInterval xs = intervals.get(0).create();
+        IntegerInterval ys = intervals.get(1).create();
+        IntegerInterval zs = intervals.get(2).create();
 
         return new WorldBBox3d(xs.begin(), ys.begin(), zs.begin(), xs.size(), ys.size(), zs.size());
     }

--- a/src/test/java/com/ignfab/minalac/generator/parameters/JsonWrapperTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/JsonWrapperTest.java
@@ -1,0 +1,120 @@
+package com.ignfab.minalac.generator.parameters;
+
+import java.beans.ConstructorProperties;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import org.junit.jupiter.api.Test;
+import tools.jackson.core.JacksonException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SuppressWarnings({ "checkstyle:VisibilityModifier", "checkstyle:JavadocVariable" }) // For nested testing params classes
+public class JsonWrapperTest {
+    @Test
+    void testBeanDeserializerModifier() {
+        // Simple case (with primitive wrapper)
+        IntWrapper intWrapper = assertDoesNotThrow(() -> ParamsTester.deserialize(IntWrapper.class, "7"));
+        assertEquals(7, intWrapper.i);
+
+        // Simple case (with object wrapper)
+        StringWrapper stringWrapper = assertDoesNotThrow(() -> ParamsTester.deserialize(StringWrapper.class, "toto"));
+        assertEquals("toto", stringWrapper.wrappedStr);
+
+        // Null failing policy handling
+        assertThrows(JacksonException.class, () -> ParamsTester.deserialize(StringWrapper.class, "null"));
+
+        // Simple case (with list wrapper)
+        ListWrapper listWrapper = assertDoesNotThrow(() -> ParamsTester.deserialize(ListWrapper.class, "[3, -7]"));
+        assertEquals(
+            List.of(3, -7),
+            listWrapper.list.stream().map(w -> w.i).toList()
+        );
+
+        // Null as empty policy handling
+        ListWrapper emptyListWrapper = assertDoesNotThrow(() -> ParamsTester.deserialize(ListWrapper.class, "null"));
+        assertNotNull(emptyListWrapper.list);
+        assertTrue(emptyListWrapper.list.isEmpty());
+
+        // Special features handling
+        ListWrapper singletonListWrapper = assertDoesNotThrow(() -> ParamsTester.deserialize(ListWrapper.class, "-3"));
+        assertEquals(1, singletonListWrapper.list.size());
+        assertEquals(-3, singletonListWrapper.list.get(0).i);
+
+        // Creator instantiation
+        CreatorWrapper creatorWrapper = assertDoesNotThrow(() -> ParamsTester.deserialize(CreatorWrapper.class, "true"));
+        assertTrue(creatorWrapper.arg);
+
+        // Invalid wrapper class (multiple properties)
+        assertThrows(IllegalStateException.class, () -> ParamsTester.deserialize(InvalidWrapper1.class, "42"));
+
+        // Invalid wrapper class (no instantiation method)
+        assertThrows(IllegalStateException.class, () -> ParamsTester.deserialize(InvalidWrapper2.class, "text"));
+
+        // Wrapper usage
+        DummyParams dummyParams = assertDoesNotThrow(() -> ParamsTester.deserialize(DummyParams.class, "wrapperProperty: str"));
+        assertEquals("str", dummyParams.wrapperProperty.wrappedStr);
+
+        // Validates that the wrapped property name was overridden by the wrapper one in errors
+        JacksonException e = assertThrows(JacksonException.class, () -> ParamsTester.deserialize(DummyParams.class, "wrapperProperty: []"));
+        List<JacksonException.Reference> path = e.getPath();
+        assertEquals("wrapperProperty", path.get(path.size() - 1).getPropertyName());
+    }
+
+    // Unless otherwise specified, all wrapper classes are instantiated using the DefaultInstantiator
+
+    // Very basic primitive wrapper
+    @JsonWrapper
+    public static class IntWrapper {
+        public int i;
+    }
+
+    // Simple wrapper with null policy
+    @JsonWrapper
+    public static class StringWrapper {
+        @JsonSetter(nulls = Nulls.FAIL)
+        public String wrappedStr;
+    }
+
+    // Evolved wrapper with special feature
+    @JsonWrapper
+    public static class ListWrapper {
+        @JsonSetter(nulls = Nulls.AS_EMPTY, contentNulls = Nulls.FAIL)
+        @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+        public List<IntWrapper> list;
+    }
+
+    // Simple wrapper with creator
+    // This wrapper class is instantiated with the CreatorArgInstantiator
+    @JsonWrapper
+    public static class CreatorWrapper {
+        public boolean arg;
+
+        @ConstructorProperties("arg")
+        public CreatorWrapper(boolean arg) {
+            this.arg = arg;
+        }
+    }
+
+    // Illegal wrapper with multiple properties
+    @JsonWrapper
+    public static class InvalidWrapper1 {
+        public int x;
+        public int y;
+    }
+
+    // Illegal wrapper with no instantiation method (only constructor available requires an int but property is a string)
+    @JsonWrapper
+    public static class InvalidWrapper2 {
+        public String value;
+
+        public InvalidWrapper2(int ignored) {}
+    }
+
+    // Dummy class using a wrapper
+    public static class DummyParams {
+        public StringWrapper wrapperProperty;
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/parameters/ParamsTester.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/ParamsTester.java
@@ -7,7 +7,6 @@ import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.cfg.MapperBuilder;
 import tools.jackson.databind.jsontype.NamedType;
-import tools.jackson.databind.module.SimpleModule;
 import tools.jackson.dataformat.yaml.YAMLMapper;
 
 import com.ignfab.minalac.generator.parameters.placeables.voxels.TestingVoxelParams;
@@ -43,9 +42,7 @@ public final class ParamsTester {
         builder.configure(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES, true);
         builder.enable(StreamReadFeature.STRICT_DUPLICATE_DETECTION);
 
-        SimpleModule module = new SimpleModule("ParamsTesterModule");
-        module.setDeserializerModifier(new JsonDelegateDeserialize.BeanModifier());
-        builder.addModule(module);
+        builder.addModule(new ParamsParser.MinalacParserModule());
 
         format.registerPlaceableDeserializer(builder);
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/placeables/CombinedPlaceableParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/placeables/CombinedPlaceableParamsTest.java
@@ -20,24 +20,24 @@ public class CombinedPlaceableParamsTest {
         PlaceableParams invalid = new TestingPlaceableParams(null);
         PlaceableParams valid = new TestingPlaceableParams(new TestingPlaceable());
 
-        CombinedPlaceableParams params = new CombinedPlaceableParams(List.of(), null);
+        CombinedPlaceableParams params = new CombinedPlaceableParams();
 
-        params.placeableParams.add(valid);
-        params.placeableParams.add(valid);
+        params.placeableParams = List.of(valid, valid);
         assertDoesNotThrow(params::validate);
 
-        params.placeableParams.add(invalid);
-        params.placeableParams.add(valid);
+        params.placeableParams = List.of(invalid, valid);
         assertThrows(IllegalArgumentException.class, params::validate);
     }
 
     @Test
     public void testCreate() throws JacksonException {
         TestingPlaceable placeable = new TestingPlaceable();
-        CombinedPlaceableParams params = new CombinedPlaceableParams(List.of(), null);
-        params.placeableParams.add(new TestingPlaceableParams(placeable));
-        params.placeableParams.add(new TestingPlaceableParams(placeable));
-        params.placeableParams.add(new TestingPlaceableParams(placeable));
+        CombinedPlaceableParams params = new CombinedPlaceableParams();
+        params.placeableParams = List.of(
+            new TestingPlaceableParams(placeable),
+            new TestingPlaceableParams(placeable),
+            new TestingPlaceableParams(placeable)
+        );
 
         Placeable result = assertDoesNotThrow(() -> params.create(TestingSeed.UNUSED));
         CombinedPlaceable combined = assertInstanceOf(CombinedPlaceable.class, result);

--- a/src/test/java/com/ignfab/minalac/generator/parameters/utils/WorldBBox3dParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/utils/WorldBBox3dParamsTest.java
@@ -1,44 +1,44 @@
 package com.ignfab.minalac.generator.parameters.utils;
 
 import org.junit.jupiter.api.Test;
-import tools.jackson.databind.ObjectReader;
-import tools.jackson.dataformat.yaml.YAMLMapper;
 
+import com.ignfab.minalac.generator.parameters.ParamsTester;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 public class WorldBBox3dParamsTest {
-
-    private ObjectReader reader = YAMLMapper.shared().readerFor(WorldBBox3dParams.class);
-
     @Test
     void testDeserialization() {
         WorldBBox3dParams params;
         WorldBBox3d box;
 
-        params = assertDoesNotThrow(() -> reader.readValue("[]"));
+        params = assertDeserialize("[]");
         assertThrows(IllegalArgumentException.class, params::validate);
 
-        params = assertDoesNotThrow(() -> reader.readValue("[1, 2]"));
+        params = assertDeserialize("[1, 2]");
         assertThrows(IllegalArgumentException.class, params::validate);
 
-        params = assertDoesNotThrow(() -> reader.readValue("[1, 2, 3, 4]"));
+        params = assertDeserialize("[1, 2, 3, 4]");
         assertThrows(IllegalArgumentException.class, params::validate);
 
-        params = assertDoesNotThrow(() -> reader.readValue("[1, 2, 3]"));
+        params = assertDeserialize("[1, 2, 3]");
         assertDoesNotThrow(params::validate);
         box = assertDoesNotThrow(params::create);
         assertEquals(new WorldBBox3d(1, 2, 3, 1, 1, 1), box);
 
-        params = assertDoesNotThrow(() -> reader.readValue("[1, 2, 3]"));
+        params = assertDeserialize("[1, 2, 3]");
         assertDoesNotThrow(params::validate);
         box = assertDoesNotThrow(params::create);
         assertEquals(new WorldBBox3d(1, 2, 3, 1, 1, 1), box);
 
-        params = assertDoesNotThrow(() -> reader.readValue("[1..1, 1..2, 1..3]"));
+        params = assertDeserialize("[1..1, 1..2, 1..3]");
         assertDoesNotThrow(params::validate);
         box = assertDoesNotThrow(params::create);
         assertEquals(new WorldBBox3d(1, 1, 1, 1, 2, 3), box);
+    }
+
+    private static WorldBBox3dParams assertDeserialize(String serialized) {
+        return assertDoesNotThrow(() -> ParamsTester.deserialize(WorldBBox3dParams.class, serialized));
     }
 }


### PR DESCRIPTION
### Type of modification

- Code
  - Parameters
- Documentation
  - Javadoc Comments
  - Code Comments
- Tests

### Changes

This PR adds an annotation to make a params class with only one field transparent to the user.

#### Feature description

When a Java params has only one field and serves only as a technical wrapper around that value and it makes no sense for it to be an object with a single property in the YAML params, that Java class can now be annotated with `@JsonWrapper` to seamlessly hide it from the YAML representation, while still being deserialized automatically by Jackson.

Jackson will automatically call a custom deserializer suited for this case. That deserializer will delegate the actual deserialization of the YAML params to the deserializer of the underlying property. Then, it will instantiate the Java wrapper class with the resulting object, using Jackson's own instantiation mechanisms (thus able to handle either single-argument creator, default creator with manual property assignation, or delegation-based instantiation).

It will try to respect the `nulls` handling policies of both the underlying field, and where it is used. However when both policies are conflicting, only the most restrictive applies (i.e. when nulls are both allowed and forbidden, it will result in a forbid policy).

Error messages could refer to the name of the underlying property, despite it being hidden, which could be misleading for the user. Thus, the deserializer will try to replace that name with the external one. However, note that this is a best-effort, and in some cases the external name is not available that easily by Jackson. This should not be a huge issue, since error messages are rather technical anyway, and would need further refinements to make them really user-friendly.

This is particularly useful when an object is expressed by a collection. This removes the single-property object from the YAML params without the need to either inherit from a collection type, or write a custom deserializer.

#### Showcase

In both cases, the YAML params is unchanged.

**WorldBBox3dParams**
Without this annotation, we had to make our params class inherit the collection type:
```java
public class WorldBBox3dParams extends ArrayList<IntegerIntervalParams> {
    // Using `this` to access the params...
}
```

Now, it can be written as composition instead:
```java
@JsonWrapper
public class WorldBBox3dParams {
    @JsonSetter(nulls = Nulls.FAIL, contentNulls = Nulls.FAIL)
    public List<IntegerIntervalParams> intervals;

    // Using `intervals` to access the params...
}
```

**PlaceableStructureParams**
Without this annotation, we had to rely on a custom deserializer to have our params class inherit `PlaceableParams` AND be expressed as a list:
```java
@JsonDeserialize(using = PlaceableStructureParams.Deserializer.class)
public final class PlaceableStructureParams extends PlaceableParams {
    private final List<Variant> params;

    private PlaceableStructureParams(List<Variant> params) {
        this.params = params;
    }

    public static class Deserializer extends ValueDeserializer<PlaceableStructureParams> {
        // Custom deserializer...
    }
}
```

Now, it can be handled automatically:
```java
@JsonWrapper
public final class PlaceableStructureParams extends PlaceableParams {
    @JsonSetter(nulls = Nulls.FAIL, contentNulls = Nulls.FAIL)
    @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
    public List<Variant> params;

    // No custom deserializer!
}
```

### Reason

With our current structure of params classes, it is rather common to have some kind of params expressed by a list or similar structure. Since we materialize all our params by a Java class with a `create` method (and `validate` when applicable), we need to introduce a wrapper layer around those params. But having such wrapping layer in the YAML params is completely useless and redundant.

The current solution was to either inherit from the wrapped type, or write a custom deserializer. 

The first option had three downsides:
a. It is not possible to inherit from 2 classes, so when we already inherit from another params class, we can't also inherit from the wrapped type.
b. Some classes are declared `final` (such as `String`), so we could not inherit from them.
c. Inheritance is public, and thus exposes the implementation of the wrapped type. When wrapping lists, for example, it forces us to declare the list implementation (`ArrayList`, `LinkedList`...), which is considered not a good practice in Java.

The second option was obviously more permissive, without all the previously mentioned limitations, but at the cost of writing more code (to write the custom deserializer). It was rather tedious and added unnecessary boilerplate code to our params classes. Finally, it was possible to introduce a bug if not careful with that deserializer, so it also required writing unit tests to make sure everything was fine.

This new solution brings a concise, clean, `@JsonWrapper` annotation to put on the appropriate params classes, and then Jackson handles everything automatically thanks to the custom deserializer written and tested once for all.

### TODOs

It might be interesting to write some dev-docs in a Markdown file to better document all those Jackson-related tools, along with our philosophy regarding params classes. This could however be done later, in a separate PR.

### Self-checks

- [x] The code has unit tests associated
- [x] The code has Javadoc Comments associated
- [x] Complex / Unexpected code is explained / justified with a small comment
- [ ] Relevant documentation inside the `/docs` folder has been updated
- [x] All examples in `examples/` work the same (or have been adapted if subject to changes in this PR)
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [x] The texts have been proofread (documentation, error messages, logs, comments...)
