### PR TITLE
fix(examples): now water and glaciers are distinguished

### DIFF
--- a/examples/formats/minecraft.yaml
+++ b/examples/formats/minecraft.yaml
@@ -1,6 +1,7 @@
 format: minecraft
 references:
   - &voxel-stone minecraft:stone
+  - &voxel-snowfields minecraft:snow_block
   - &voxel-dirt minecraft:dirt
   - &voxel-cobble minecraft:cobblestone
   - &voxel-empty minecraft:air

--- a/examples/formats/minetest.yaml
+++ b/examples/formats/minetest.yaml
@@ -1,6 +1,7 @@
 format: minetest
 references:
   - &voxel-stone default:stone
+  - &voxel-snowfields default:snowblock
   - &voxel-dirt default:dirt
   - &voxel-cobble default:cobble
   - &voxel-empty default:air

--- a/examples/places/meije.yaml
+++ b/examples/places/meije.yaml
@@ -1,0 +1,10 @@
+# La Meije is a mountain in the Massif des Écrins range.
+worldName: La Meije - Massif des Écrins range
+verticalScale: 1.0
+horizontalScale: 1.0
+area:
+  center:
+    latitude: 45.005
+    longitude: 6.308
+  extentX: 2000
+  extentY: 2000

--- a/examples/processes/full.yaml
+++ b/examples/processes/full.yaml
@@ -3,6 +3,8 @@ heightmaps:
     default: 0
   water:
     default: 0
+  snowfields:
+    default: 0
 
 forEachTile:
 
@@ -54,9 +56,9 @@ forEachTile:
     processor:
       type: geoToolsVector
 
-  fetchWater:
+  fetchHydrographic:
     type: fetchData
-    modelType: water
+    modelType: hydrographic
     provider:
       type: wfs
       url: https://data.geopf.fr/wfs/wfs
@@ -91,11 +93,15 @@ forEachTile:
 
   flattenWater:
     after:
-      - fetchWater
+      - fetchHydrographic
       - setAltitude
     type: copyHeightmap
     models:
-      type: water
+      type: hydrographic
+      filter:
+        not:
+          metadata: nature
+          equals: "Glacier, névé"
     from:
       localMin: ground
       range: 9
@@ -187,18 +193,37 @@ forEachTile:
           place: *forest-tree2
 
   populateWaterPresence:
-    after: fetchWater
+    after: fetchHydrographic
     type: copyHeightmap
     models:
-      type: water
+      type: hydrographic
+      filter:
+        not:
+          metadata: nature
+          equals: "Glacier, névé"
     from: 1
     to: water
+
+  populateSnowfieldsPresence:
+    after: fetchHydrographic
+    type: copyHeightmap
+    models:
+      type: hydrographic
+      filter:
+        metadata: nature
+        equals: "Glacier, névé"
+    from: 1
+    to: snowfields
 
   computeWaterDepth:
     after: populateWaterPresence
     type: copyHeightmap
     models:
-      type: water
+      type: hydrographic
+      filter:
+        not:
+          metadata: nature
+          equals: "Glacier, névé"
     from:
       remap:
         manhattan: water
@@ -234,6 +259,21 @@ forEachTile:
         # This a dirt fix to remove vegetation on water
         - put: *voxel-air
           at: [ 0, 0, 1..12 ]
+
+  renderSnowfields:
+    after:
+      - renderGround
+    type: renderHeightmap
+    minimum:
+      sum:
+        - ground
+        - 1
+        - product: [ -5, snowfields ]
+    maximum: ground
+    place:
+      structure:
+        - put: *voxel-snowfields
+          at: [ 0, 0, 0 ]
 
   path:
     after:


### PR DESCRIPTION
### Changes

Mise à jour de `full.yaml` pour remplacer `fetchWater` par `fetchHydrographic` et ajout d'une nouvelle heightmaps `snowfields` afin de différencier les cours d'eau des glaciers.

Ajout de `meije.yaml` (montagne de La Meije) dans les exemples afin de mettre en valeurs les ombres de la minimap et l'ajout des glaciers.

### Self-checks

<!--
Check everything you did about your work in this PR.
The goal here is to save some precious time by self-checking common issues.

In case something is irrelevant to the subject, please remove the [ ] checkbox and ~~strike through~~ the text.
Example:
- [x] This task is done
- ~~This task does not apply to the work done in this PR~~
- [ ] This task still needs to be done
-->

- [ ] The code has unit tests associated
- [ ] The code has Javadoc Comments associated
- [ ] Complex / Unexpected code is explained / justified with a small comment
- [ ] Relevant documentation inside the `/docs` folder has been updated
- [ ] All examples in `examples/` work the same (or have been adapted if subject to changes in this PR)
- [ ] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [ ] The texts have been proofread (documentation, error messages, logs, comments...)
