### PR TITLE
Add retry capabilities to fetchData task

### DIFF
--- a/docs/usage/parameters/FetchDataTask.md
+++ b/docs/usage/parameters/FetchDataTask.md
@@ -47,6 +47,8 @@ fetchBuildings:
     - Additional parameters specific to the given [type](#processors)
 - `postProcessing` (optional): Additional post-processing steps.
     - [Post-processing](PostProcessing.md) definition
+- `retry` (optional, default 0): Number of retries before giving up.
+- `retryDelay` (optional, default 10): Delay (in seconds) between two retries.
 
 Not all processors are compatible with all provider. See [providers](#provider-parameters) and [processors](#processor-parameters) documentation for compatibility.
 

--- a/src/main/java/com/ignfab/minalac/generator/models/ModelStore.java
+++ b/src/main/java/com/ignfab/minalac/generator/models/ModelStore.java
@@ -1,8 +1,8 @@
 package com.ignfab.minalac.generator.models;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -13,22 +13,17 @@ public class ModelStore {
     private final Map<String, List<Model>> byType = new HashMap<>();
 
     /**
-     * Add a model of a given type in store.
+     * Add models of a given type in store.
      * Store is quite dumb, it is not able to retrieve type from model (anyway Models do not have type for now).
      *
-     * @param type Type to associate with stored model
-     * @param model Model to be stored
+     * @param type Type to associate with stored models
+     * @param models Models to be stored
      */
-    public void add(String type, Model model) {
+    public void add(String type, List<Model> models) {
         if (type == null || type.isEmpty())
             throw new IllegalArgumentException("Type must be a non empty string");
 
-        List<Model> list = byType.get(type);
-        if (list == null) {
-            list = new LinkedList<>();
-            byType.put(type, list);
-        }
-        list.add(model);
+        byType.computeIfAbsent(type, k -> new ArrayList<>()).addAll(models);
     }
 
     /**

--- a/src/main/java/com/ignfab/minalac/generator/parameters/tasks/FetchDataTaskParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/tasks/FetchDataTaskParams.java
@@ -1,6 +1,7 @@
 package com.ignfab.minalac.generator.parameters.tasks;
 
 import java.beans.ConstructorProperties;
+import java.time.Duration;
 
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
@@ -21,6 +22,18 @@ public class FetchDataTaskParams extends TaskParams {
      */
     @JsonSetter(nulls = Nulls.FAIL)
     public String modelType;
+
+    /**
+     * Number of retries in case of failure (optional, default 0).
+     */
+    @JsonSetter(nulls = Nulls.SKIP)
+    public int retry = 0;
+
+    /**
+     * Delay in seconds between two retries (optional, default 10).
+     */
+    @JsonSetter(nulls = Nulls.SKIP)
+    public int retryDelay = 10;
 
     /**
      * Data provider (required).
@@ -57,14 +70,18 @@ public class FetchDataTaskParams extends TaskParams {
         if (modelType.isBlank())
             throw new IllegalArgumentException("The 'modelType' field cannot be empty or contain only whitespace.");
 
-        super.validate();
-        provider.validate();
+        if (retry < 0)
+            throw new IllegalArgumentException("`retry` must be a positive integer.");
+
+        if (retryDelay < 0)
+            throw new IllegalArgumentException("`retryDelay` must be a positive integer.");
 
         if (processor == null)
             throw new IllegalArgumentException("Missing processor and no default processor");
 
+        super.validate();
+        provider.validate();
         processor.validate();
-
         postProcessing.validate();
     }
 
@@ -74,7 +91,9 @@ public class FetchDataTaskParams extends TaskParams {
             modelType,
             provider.create(generation),
             processor.create(generation),
-            postProcessing.create()
+            postProcessing.create(),
+            retry + 1,
+            Duration.ofSeconds(retryDelay)
         );
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/tasks/FetchDataTask.java
+++ b/src/main/java/com/ignfab/minalac/generator/tasks/FetchDataTask.java
@@ -1,5 +1,9 @@
 package com.ignfab.minalac.generator.tasks;
 
+import java.time.Duration;
+import java.util.LinkedList;
+import java.util.List;
+
 import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
 import com.ignfab.minalac.generator.exceptions.IgnorableException;
 import com.ignfab.minalac.generator.exceptions.RetryableException;
@@ -17,6 +21,8 @@ public class FetchDataTask implements TileTask {
     private final Provider<?> provider;
     private final Processor<Object, ?> processor;
     private final PostProcessor<Model, ?> postProcessor;
+    private final int maxTries;
+    private final Duration retryDelay;
 
     /**
      * Creates a new {@code FetchDataTask}.
@@ -25,12 +31,16 @@ public class FetchDataTask implements TileTask {
      * @param provider data provider
      * @param processor processor converting provided data to models
      * @param postProcessor post-processor to run on created models
+     * @param maxTries maximum number of tries
+     * @param retryDelay retry delay in seconds
      */
     public FetchDataTask(
         String modelType,
         Provider<?> provider,
         Processor<?, ? extends Model> processor,
-        PostProcessor<?, ?> postProcessor
+        PostProcessor<?, ?> postProcessor,
+        int maxTries,
+        Duration retryDelay
     ) {
         if (!processor.acceptedType().isAssignableFrom(provider.providedType()))
             throw new IllegalArgumentException("%s cannot treat provided type. Provided = %s, Accepted = %s".formatted(
@@ -49,14 +59,14 @@ public class FetchDataTask implements TileTask {
         this.provider = provider;
         this.processor = uncheckedProcessor;
         this.postProcessor = uncheckedPostProcessor;
+        this.maxTries = maxTries;
+        this.retryDelay = retryDelay;
     }
 
-    /**
-     * Fetches data from provider, and create and process models.
-     *
-     * @param tile tile for which data is fetched (it gives the wanted area)
-     */
-    public void run(GenerationTile tile) {
+    private void tryOnce(GenerationTile tile) throws RetryableException {
+        // Resulting list of models. Will be added to store only if fetch succeeds
+        List<Model> models = new LinkedList<>();
+
         try (Provider.Result<?> result = provider.provide(tile.limits())) {
             processor.initialize(result.crs());
             while (result.hasNext()) {
@@ -66,7 +76,7 @@ public class FetchDataTask implements TileTask {
                     if (model != null) {
                         model = postProcessor.process(model);
                         if (model != null)
-                            tile.models().add(modelType, model);
+                            models.add(model);
                     }
                 } catch (IgnorableException e) {
                     // TODO Add an exception handling policy
@@ -74,9 +84,6 @@ public class FetchDataTask implements TileTask {
                     // throw new GenerationFailedException(e);
                 }
             }
-        } catch (RetryableException e) {
-            // TODO Implement a retry mechanism
-            throw new RuntimeException(e);
         } catch (IgnorableException e) {
             // TODO Handle this according to the policy
             // This can be thrown if unable to close a Provider.Result
@@ -84,5 +91,44 @@ public class FetchDataTask implements TileTask {
         } catch (GenerationFailedException e) {
             throw new RuntimeException(e);
         }
+
+        tile.models().add(modelType, models);
+    }
+
+    @Override
+    public void run(GenerationTile tile) {
+        String taskName = Thread.currentThread().getName();
+        List<RetryableException> suppressedRetryableExceptions = new LinkedList<>();
+        int tries = 0;
+
+        do {
+            try {
+                tryOnce(tile);
+
+                // Successful task
+                return;
+
+            } catch (RetryableException e) {
+                suppressedRetryableExceptions.add(e);
+
+                tries++;
+                if (tries >= maxTries) {
+                    System.err.printf("%s task failed (try %d of %d), giving up.%n", taskName, tries, maxTries);
+                    RuntimeException exception = new RuntimeException("%s task failed after %d tries".formatted(taskName, maxTries));
+                    suppressedRetryableExceptions.forEach(exception::addSuppressed);
+                    throw exception;
+                }
+
+                System.out.printf("%s task failed (try %d of %d), retrying in %d seconds.%n", taskName, tries, maxTries, retryDelay.toSeconds());
+
+                try {
+                    Thread.sleep(retryDelay.toMillis());
+                } catch (InterruptedException e2) {
+                    throw new RuntimeException(e2);
+                }
+            }
+
+        // loop exits on successful return or if max number of tries exceeded
+        } while (true);
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/inputs/TestingProvider.java
+++ b/src/test/java/com/ignfab/minalac/generator/inputs/TestingProvider.java
@@ -1,16 +1,45 @@
 package com.ignfab.minalac.generator.inputs;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.NoSuchElementException;
 
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 
+import com.ignfab.minalac.generator.exceptions.RetryableException;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 
 public class TestingProvider implements Provider<String> {
     private final CoordinateReferenceSystem crs;
+    private final List<String> data;
+    private final int failAfterElementNumber;
+    private final int failsBeforeSucceed;
+    private int tries = 0;
+
+    /**
+     * Creates a TestingProvider, a provider usable for tests.
+     * @param crs Coordinate reference system (probably unused in most tests)
+     * @param data A list of string used to create provided models (provider will provide as many model as there are strings here)
+     * @param failAfterElementNumber If positive, provider will fail after returning that number of elements
+     * @param failsBeforeSucceed Number of failing tries before provider succeeds, ignoring failAfterElementNumber
+     */
+    public TestingProvider(CoordinateReferenceSystem crs, List<String> data, int failAfterElementNumber, int failsBeforeSucceed) {
+        this.crs = crs;
+        this.data = data;
+        this.failAfterElementNumber = failAfterElementNumber;
+        this.failsBeforeSucceed = failsBeforeSucceed;
+    }
+
+    public TestingProvider(CoordinateReferenceSystem crs, List<String> data) {
+        this(crs, data, -1, 0);
+    }
 
     public TestingProvider(CoordinateReferenceSystem crs) {
-        this.crs = crs;
+        this(crs, Collections.emptyList());
+    }
+
+    public int tries() {
+        return tries;
     }
 
     @Override
@@ -20,7 +49,11 @@ public class TestingProvider implements Provider<String> {
 
     @Override
     public Result<String> provide(WorldBBox3d bbox) {
+        tries++;
+
         return new Result<>() {
+            private int index = 0;
+
             @Override
             public CoordinateReferenceSystem crs() {
                 return crs;
@@ -31,13 +64,20 @@ public class TestingProvider implements Provider<String> {
 
             @Override
             public boolean hasNext() {
-                return false;
+                return index < data.size();
             }
 
             @Override
-            public String next() {
-                throw new NoSuchElementException();
+            public String next() throws RetryableException {
+                if (!hasNext())
+                    throw new NoSuchElementException();
+                if (tries <= failsBeforeSucceed && failAfterElementNumber >= 0 && index >= failAfterElementNumber)
+                    throw new RetryableException("Failure for tests");
+                index++;
+                return data.get(index - 1);
             }
         };
     }
+
+
 }

--- a/src/test/java/com/ignfab/minalac/generator/inputs/TestingProviderTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/inputs/TestingProviderTest.java
@@ -1,0 +1,67 @@
+package com.ignfab.minalac.generator.inputs;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.ignfab.minalac.generator.exceptions.RetryableException;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+public class TestingProviderTest {
+    @Test
+    public void testProvide() {
+        List<String> data = List.of("one", "two", "three", "four");
+
+        TestingProvider provider;
+        Provider.Result<String> result;
+        boolean next;
+
+        // Test not failing behavior
+
+        provider = new TestingProvider(null, data);
+        result = provider.provide(WorldBBox3d.EMPTY);
+
+        for (int i = 0; i < data.size(); i++) {
+            next = assertDoesNotThrow(result::hasNext, "Not failing provider Result::hasNext should not fail for item number %d".formatted(i));
+            assertTrue(next, "Not failing provider should have more than %d items".formatted(i));
+            assertDoesNotThrow(result::next, "Not failing provider should provide item %d".formatted(i));
+        }
+        next = assertDoesNotThrow(result::hasNext, "Result::hasNext should not fail after last item");
+        assertFalse(next, "Not failing provider should not provide more than %d results".formatted(data.size()));
+
+        // Test failing behavior
+
+        int failAfter = 3;
+
+        provider = new TestingProvider(null, data, failAfter, 2);
+
+        int t;
+
+        // First and second try: should fail after failAfter results
+        for (t = 0; t < 2; t++) {
+            result = provider.provide(WorldBBox3d.EMPTY);
+
+            for (int i = 0; i < failAfter; i++) {
+                next = assertDoesNotThrow(result::hasNext, "Try %d, provider Result::hasNext should not fail for item number %d".formatted(t, i));
+                assertTrue(next, "Try %d, provider should return more than %d items".formatted(t, i));
+                assertDoesNotThrow(result::next, "Try %d, provider should not fail for item number %d".formatted(t, i));
+            }
+
+            next = assertDoesNotThrow(result::hasNext, "Try %d, provider Result::hasNext should not fail for item number %d".formatted(t, failAfter));
+            assertTrue(next, "Try %d, provider should have at least %d results".formatted(t, failAfter));
+            assertThrows(RetryableException.class, result::next, "Try %d, provider should throw RetryableException for item number %d".formatted(t, failAfter));
+        }
+
+        // Third try: should succeed
+        result = provider.provide(WorldBBox3d.EMPTY);
+
+        for (int i = 0; i < data.size(); i++) {
+            next = assertDoesNotThrow(result::hasNext, "Try %d, Result::hasNext should not fail for item number %d".formatted(t, i));
+            assertTrue(next, "Try %d, provider should return more than %d items".formatted(t, i));
+            assertDoesNotThrow(result::next, "Try %d, provider should not fail for item number %d".formatted(t, i));
+        }
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/models/ModelSelectionTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/models/ModelSelectionTest.java
@@ -1,6 +1,7 @@
 package com.ignfab.minalac.generator.models;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -21,11 +22,9 @@ public class ModelSelectionTest {
         Model modelB = new TestingModel("B", Map.of("b", 2));
         Model modelC = new TestingModel("C");
 
-        tile.models().add("X", modelA);
-        tile.models().add("Y", modelA);
-        tile.models().add("X", modelB);
-        tile.models().add("X", modelA);
-        tile.models().add("Y", modelC);
+        tile.models().add("X", List.of(modelA, modelB));
+        tile.models().add("Y", List.of(modelA, modelC));
+        tile.models().add("X", List.of(modelA));
 
         assertBrowsesAllOnce(Arrays.asList(modelA, modelA, modelB), new ModelSelection("X", null).forTile(tile));
 

--- a/src/test/java/com/ignfab/minalac/generator/models/ModelStoreTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/models/ModelStoreTest.java
@@ -1,5 +1,7 @@
 package com.ignfab.minalac.generator.models;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -15,9 +17,8 @@ public class ModelStoreTest {
     @Test
     void testAddByType() {
         ModelStore store = new ModelStore();
-        store.add("toto", new TestModel());
-        store.add("toto", new TestModel());
-        store.add("titi", new TestModel());
+        store.add("toto", List.of(new TestModel(), new TestModel()));
+        store.add("titi", List.of(new TestModel()));
         assertEquals(2, store.getByType("toto").size());
         assertEquals(1, store.getByType("titi").size());
         assertEquals(0, store.getByType("tata").size());

--- a/src/test/java/com/ignfab/minalac/generator/processors/TestingProcessor.java
+++ b/src/test/java/com/ignfab/minalac/generator/processors/TestingProcessor.java
@@ -5,6 +5,11 @@ import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import com.ignfab.minalac.generator.models.TestingModel;
 
 public class TestingProcessor implements Processor<String, TestingModel> {
+    private int processed = 0;
+
+    public int processed() {
+        return processed;
+    }
 
     @Override
     public Class<String> acceptedType() {
@@ -21,6 +26,7 @@ public class TestingProcessor implements Processor<String, TestingModel> {
 
     @Override
     public TestingModel process(String object) {
+        processed++;
         return new TestingModel();
     }
 

--- a/src/test/java/com/ignfab/minalac/generator/tasks/CopyHeightmapTaskTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/tasks/CopyHeightmapTaskTest.java
@@ -1,5 +1,7 @@
 package com.ignfab.minalac.generator.tasks;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import com.ignfab.minalac.generator.generation.TestingGenerationTile;
@@ -40,7 +42,7 @@ public class CopyHeightmapTaskTest {
             }
 
         Model model = new TestingRectangleShape2dModel(new WorldBBox2d(0, 1, 2, 2));
-        tile.models().add("square", model);
+        tile.models().add("square", List.of(model));
         ModelSelection selection = new ModelSelection("square", null);
 
         new CopyHeightmapTask(selection, from.spec(), to.spec()).run(tile);
@@ -81,7 +83,7 @@ public class CopyHeightmapTaskTest {
         TestingHeightmap to = tile.newStoredHeightmap("to", new WorldBBox2d(-1, -3, 3, 4), 2);
 
         Model model = new TestingRectangleShape2dModel(new WorldBBox2d(0, 0, 2, 3));
-        tile.models().add("rectangle", model);
+        tile.models().add("rectangle", List.of(model));
         ModelSelection selection = new ModelSelection("rectangle", null);
 
         // Below

--- a/src/test/java/com/ignfab/minalac/generator/tasks/FetchDataTaskTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/tasks/FetchDataTaskTest.java
@@ -1,0 +1,62 @@
+package com.ignfab.minalac.generator.tasks;
+
+import java.time.Duration;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.ignfab.minalac.generator.generation.TestingGenerationTile;
+import com.ignfab.minalac.generator.inputs.TestingProvider;
+import com.ignfab.minalac.generator.processors.TestingProcessor;
+import com.ignfab.minalac.generator.processors.post.IdentityPostProcessor;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class FetchDataTaskTest {
+    private static List<String> data = List.of("one", "two", "three", "four");
+
+    @Test
+    @DisplayName("Test retry works")
+    public void testRetry() {
+        TestingProvider provider = new TestingProvider(null, data, 2, 3); // Three fails after two models
+        TestingProcessor processor = new TestingProcessor();
+        FetchDataTask task = new FetchDataTask("test", provider, processor, IdentityPostProcessor.INSTANCE, 10, Duration.ZERO);
+
+        TestingGenerationTile tile = new TestingGenerationTile(WorldBBox3d.EMPTY);
+        assertDoesNotThrow(() -> task.run(tile));
+
+        assertEquals(10, processor.processed()); // 3 fails x 2 models + 1 success x 4 models
+        assertEquals(4, tile.models().getByType("test").size());
+    }
+
+    @Test
+    @DisplayName("Test task fails if not enough retries")
+    public void testRetryFail() {
+        TestingProvider provider = new TestingProvider(null, data, 2, 3);
+        TestingProcessor processor = new TestingProcessor();
+        FetchDataTask task = new FetchDataTask("test", provider, processor, IdentityPostProcessor.INSTANCE, 2, Duration.ZERO);
+
+        TestingGenerationTile tile = new TestingGenerationTile(WorldBBox3d.EMPTY);
+        assertThrows(RuntimeException.class, () -> task.run(tile));
+
+        assertEquals(4, processor.processed()); // 2 fails x 2 models
+        assertEquals(0, tile.models().getByType("test").size());
+    }
+
+    @Test
+    @DisplayName("Test task works with delay")
+    public void testRetryWithDelay() {
+        FetchDataTask task = new FetchDataTask(
+            "test",
+            new TestingProvider(null, data, 2, 1),
+            new TestingProcessor(),
+            IdentityPostProcessor.INSTANCE,
+            10,
+            Duration.ofMillis(10)
+        );
+
+        assertDoesNotThrow(() -> task.run(new TestingGenerationTile(WorldBBox3d.EMPTY)));
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/tasks/FillBetweenHeightmapAndModelTaskTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/tasks/FillBetweenHeightmapAndModelTaskTest.java
@@ -1,5 +1,7 @@
 package com.ignfab.minalac.generator.tasks;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import com.ignfab.minalac.generator.generation.TestingGenerationTile;
@@ -28,7 +30,7 @@ public class FillBetweenHeightmapAndModelTaskTest {
         Model model = new TestingRectangleShape2dModel(tile.limits().to2d());
         int zMetadata = 5;
         model.setMetadata("zTest", zMetadata);
-        tile.models().add("model", model);
+        tile.models().add("model", List.of(model));
 
         // Run leveling
         assertDoesNotThrow(() -> new FillBetweenHeightmapAndMetadataTask(

--- a/src/test/java/com/ignfab/minalac/generator/tasks/HeightmapStatsTaskTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/tasks/HeightmapStatsTaskTest.java
@@ -1,5 +1,7 @@
 package com.ignfab.minalac.generator.tasks;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import com.ignfab.minalac.generator.generation.TestingGenerationTile;
@@ -29,9 +31,8 @@ public class HeightmapStatsTaskTest {
 
         // Prepare a single square model
         Model modelA = new TestingRectangleShape2dModel(new WorldBBox2d(0, -1, 5, 3));
-        tile.models().add("model", modelA);
         Model modelB = new TestingRectangleShape2dModel(new WorldBBox2d(3, 3, 4, 3));
-        tile.models().add("model", modelB);
+        tile.models().add("model", List.of(modelA, modelB));
 
         // Try to compute
         assertDoesNotThrow(() -> new HeightmapStatsTask(
@@ -53,7 +54,7 @@ public class HeightmapStatsTaskTest {
         TestingHeightmap ground = tile.newStoredHeightmap("heightmap", 0);
 
         Model model = new TestingRectangleShape2dModel(new WorldBBox2d(0, -1, 5, 3));
-        tile.models().add("model", model);
+        tile.models().add("model", List.of(model));
 
         assertDoesNotThrow(() -> new HeightmapStatsTask(
             new ModelSelection("model", null),

--- a/src/test/java/com/ignfab/minalac/generator/tasks/ModelTaskTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/tasks/ModelTaskTest.java
@@ -21,11 +21,8 @@ public class ModelTaskTest {
     public void testRun() {
         GenerationTile tile = new TestingGenerationTile(WorldBBox3d.ORIGIN);
 
-        tile.models().add("digit", new ModelImplTester('1'));
-        tile.models().add("digit", new ModelImplTester('1'));
-        tile.models().add("digit", new ModelImplTester('2'));
-        tile.models().add("letter", new ModelImplTester('b'));
-        tile.models().add("letter", new ModelImplTester('a'));
+        tile.models().add("digit", List.of(new ModelImplTester('1'), new ModelImplTester('1'), new ModelImplTester('2')));
+        tile.models().add("letter", List.of(new ModelImplTester('b'), new ModelImplTester('a')));
 
         ModelTaskImpl task = new ModelTaskImpl("digit");
         assertEquals(0, task.modelsRendered.size());

--- a/src/test/java/com/ignfab/minalac/generator/tasks/PopulateHeightmapTaskTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/tasks/PopulateHeightmapTaskTest.java
@@ -1,5 +1,7 @@
 package com.ignfab.minalac.generator.tasks;
 
+import java.util.List;
+
 import org.geotools.referencing.operation.transform.IdentityTransform;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.util.AffineTransformation;
@@ -35,7 +37,7 @@ public class PopulateHeightmapTaskTest {
         FloatGeographicDataMatrix2d data = new FloatArrayGeographicDataMatrix2d(values, 3, 4, 0, -1, 1.0, 1.0);
         FloatMatrixModel model = new FloatMatrixModel(data, converter);
 
-        tile.models().add("matrix", model);
+        tile.models().add("matrix", List.of(model));
         ModelSelection selection = new ModelSelection("matrix", null);
 
         new PopulateHeightmapTask(selection, heightmap.spec()).run(tile);

--- a/src/test/java/com/ignfab/minalac/generator/tasks/RenderBuildingsTaskTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/tasks/RenderBuildingsTaskTest.java
@@ -1,5 +1,7 @@
 package com.ignfab.minalac.generator.tasks;
 
+import java.util.List;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -39,7 +41,7 @@ public class RenderBuildingsTaskTest {
         building.setMetadata("height", expectedHeight);
         building.setMetadata("minimum-ground-altitude", 0);
         building.setMetadata("ground-floor-altitude", 0);
-        tile.models().add("building", building);
+        tile.models().add("building", List.of(building));
 
         assertDoesNotThrow(() -> new RenderBuildingsTask(
             new ModelSelection("building", new ModelFilterHasMetadata("height")),
@@ -88,7 +90,7 @@ public class RenderBuildingsTaskTest {
     void testBuildingRenderingWithoutMetadata() {
         WorldBBox2d modelBbox = new WorldBBox2d(0, 0, 3, 3);
         Model building = new TestingRectangleShape2dModel(modelBbox);
-        tile.models().add("building", building);
+        tile.models().add("building", List.of(building));
 
         Placeable placeable = new TestingVoxelParams("voxel").create(TestingSeed.UNUSED);
         assertDoesNotThrow(() -> new RenderBuildingsTask(
@@ -109,7 +111,7 @@ public class RenderBuildingsTaskTest {
         Model building = new TestingRectangleShape2dModel(modelBbox);
 
         building.setMetadata("height", -20);
-        tile.models().add("building", building);
+        tile.models().add("building", List.of(building));
 
         Placeable placeable = new TestingVoxelParams("voxel").create(TestingSeed.UNUSED);
         assertDoesNotThrow(() -> new RenderBuildingsTask(

--- a/src/test/java/com/ignfab/minalac/generator/tasks/RenderLinesTaskTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/tasks/RenderLinesTaskTest.java
@@ -1,5 +1,7 @@
 package com.ignfab.minalac.generator.tasks;
 
+import java.util.List;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -41,7 +43,7 @@ class RenderLinesTaskTest {
     @Test
     public void testRenderWithoutHeightmap() {
 
-        tile.models().add("testing", new TestingShape3dModel(LineString3d.fromPoints(bbox.min(), bbox.max())));
+        tile.models().add("testing", List.of(new TestingShape3dModel(LineString3d.fromPoints(bbox.min(), bbox.max()))));
         PlaceableStructure structure = PlaceableStructure.builder()
             .set(new WorldCoords3d(0, 0, 0), new TestingVoxel("TEST"))
             .build();
@@ -70,7 +72,7 @@ class RenderLinesTaskTest {
     @Test
     public void testRenderWithHeightmap() {
 
-        tile.models().add("testing", new TestingShape3dModel(LineString3d.fromPoints(bbox.min(), bbox.max())));
+        tile.models().add("testing", List.of(new TestingShape3dModel(LineString3d.fromPoints(bbox.min(), bbox.max()))));
         PlaceableStructure structure = PlaceableStructure.builder()
             .set(new WorldCoords3d(0, 0, 0), new TestingVoxel("TEST"))
             .build();

--- a/src/test/java/com/ignfab/minalac/generator/tasks/RenderSurfacesTaskTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/tasks/RenderSurfacesTaskTest.java
@@ -1,5 +1,7 @@
 package com.ignfab.minalac.generator.tasks;
 
+import java.util.List;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -43,7 +45,7 @@ class RenderSurfacesTaskTest {
     public void testRenderFlatSmaller() {
 
         WorldBBox2d modelBbox = new WorldBBox2d(0, -1, 3, 4);
-        tile.models().add("testing", new TestingRectangleShape2dModel(modelBbox));
+        tile.models().add("testing", List.of(new TestingRectangleShape2dModel(modelBbox)));
 
         new RenderSurfacesTask(modelSelection, heightmap.spec(), voxel).run(tile);
 
@@ -64,7 +66,7 @@ class RenderSurfacesTaskTest {
             heightmap.set(pos, (pos.x() + pos.y()) / 2);
 
         // Add one model covering the whole map
-        tile.models().add("testing", new TestingRectangleShape2dModel(bbox.to2d()));
+        tile.models().add("testing", List.of(new TestingRectangleShape2dModel(bbox.to2d())));
 
         new RenderSurfacesTask(modelSelection, heightmap.spec(), voxel).run(tile);
 
@@ -86,7 +88,7 @@ class RenderSurfacesTaskTest {
             heightmap.set(pos, pos.x() + pos.y() * 2);
 
         // Add one model covering the whole map with BORDER voxels
-        tile.models().add("testing", new TestingRectangleShape2dModel(bbox.to2d()));
+        tile.models().add("testing", List.of(new TestingRectangleShape2dModel(bbox.to2d())));
 
         new RenderSurfacesTask(modelSelection, heightmap.spec(), voxel).run(tile);
 
@@ -103,7 +105,7 @@ class RenderSurfacesTaskTest {
     public void testRenderHorizontalOverflow() {
         // Prepare a larger model bbox
         WorldBBox2d modelBbox = new WorldBBox2d(bbox.minX() - 1, bbox.minY() - 1, bbox.sizeX() + 2, bbox.sizeY() + 2);
-        tile.models().add("testing", new TestingRectangleShape2dModel(modelBbox));
+        tile.models().add("testing", List.of(new TestingRectangleShape2dModel(modelBbox)));
 
         new RenderSurfacesTask(modelSelection, heightmap.spec(), voxel).run(tile);
 


### PR DESCRIPTION
### Changes

Add retry capabilities to `fetchData` task.

#### Feature description

Adds two tags: `retry` and `retryDelay` to `fetchData` task to tell how many time retry and delay between them before giving up in case of failing source.

By default, only one try is given.

### Reason
Because sometimes you need to retrBecause sometimes you need to retrBecause sometimes you need to retrBecause sometimes you need to retry before it works.

### Self-checks

- [ ] The code has unit tests associated
- [x] The code has Javadoc Comments associated
- ~~Complex / Unexpected code is explained / justified with a small comment~~
- [x] Relevant documentation inside the `/docs` folder has been updated
- [x] All examples in `examples/` work the same (or have been adapted if subject to changes in this PR)
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [ ] The texts have been proofread (documentation, error messages, logs, comments...)
