### PR TITLE
Add default processors to provider and make processor optional

### DIFF
--- a/docs/usage/parameters/FetchDataTask.md
+++ b/docs/usage/parameters/FetchDataTask.md
@@ -42,7 +42,7 @@ fetchBuildings:
 - `provider` (required): Definition of the [data provider](#providers) to use.
     - `type` (required): Type of data provider.
     - Additional parameters specific to the given [type](#providers)
-- `processor` (required): Definition of the [data processor](#processors) to use.
+- `processor` (required if provider has no default processor): Definition of the [data processor](#processors) to use.
     - `type` (required): Type of data processor.
     - Additional parameters specific to the given [type](#processors)
 - `postProcessing` (optional): Additional post-processing steps.
@@ -63,7 +63,7 @@ Provider of type `wfs` fetches vector data from a [Web Feature Service](https://
 - `crs` (optional): Wanted CRS for these features (defaults to target CRS)
 - `maxFeaturesPerQuery` (optional): Maximum number of features fetched per query (default 1000)
 
-**Suitable processors**: `geoToolsVector`
+**Default processor**: `geoToolsVector`
 
 ### `gpkg` (GeoPackage)
 Provider of type `gpkg` reads vector data from a [GeoPackage](https://en.wikipedia.org/wiki/GeoPackage) file.
@@ -73,7 +73,7 @@ Provider of type `gpkg` reads vector data from a [GeoPackage](https://en.wikiped
 - `typeName` (required): Name of feature type to read
 - `crsOverride` (optional, default none): CRS to use when reading data. By default, the CRS is read from the GeoPackage itself. You should only use this parameter if the CRS is invalid or missing from the file. This **DOES NOT** reproject data!
 
-**Suitable processors**: `geoToolsVector`
+**Default processor**: `geoToolsVector`
 
 ### `shapefile` (Shapefile)
 Provider of type `shapefile` reads vector data from a [Shapefile](https://en.wikipedia.org/wiki/Shapefile).
@@ -82,7 +82,7 @@ Provider of type `shapefile` reads vector data from a [Shapefile](https://en.wik
 - `filePath` (required): Path of the Shapefile (absolute, or relative to execution context)
 - `crsOverride` (optional, default none): CRS to use when reading data. By default, the CRS is read from the Shapefile itself. You should only use this parameter if the CRS is invalid or missing from the file. This **DOES NOT** reproject data!
 
-**Suitable processors**: `geoToolsVector`
+**Default processor**: `geoToolsVector`
 
 ### `wmsFloat` (Web Map Service with floating point values)
 Provider of type `wmsFloat` fetches **float** data from a [Web Map Service](https://en.wikipedia.org/wiki/Web_Map_Service) source. Source must be able to provide `x-bil` format.
@@ -92,7 +92,7 @@ Provider of type `wmsFloat` fetches **float** data from a [Web Map Service](http
 - `layer` (required): Name of layer to fetch
 - `crs` (optional): Wanted CRS for this layer (defaults to target CRS)
 
-**Suitable processors**: `floatMatrix`
+**Default processor**: `floatMatrix`
 
 ### `geotiff` (GeoTiff)
 Provider of type `geotiff` reads **float** (for now) raster data from a [GeoTiff](https://en.wikipedia.org/wiki/GeoTIFF) file.
@@ -101,7 +101,7 @@ Provider of type `geotiff` reads **float** (for now) raster data from a [GeoTiff
 - `filePath` (required): Path of the GeoTiff file (absolute, or relative to execution context)
 - `crsOverride` (optional, default none): CRS to use when reading data. By default, the CRS is read from the GeoTiff itself. You should only use this parameter if the CRS is invalid or missing from the file. This **DOES NOT** reproject data!
 
-**Suitable processors**: `floatMatrix`
+**Default processor**: `floatMatrix`
 
 ## Processors
 

--- a/examples/processes/full.yaml
+++ b/examples/processes/full.yaml
@@ -75,21 +75,6 @@ forEachTile:
     processor:
       type: geoToolsVector
 
-  setAltitude:
-    after: altitude
-    type: populateHeightmap
-    models:
-      type: altitude
-    heightmap: ground
-
-  setSpawn:
-    after: setAltitude
-    type: setSpawn
-    heightmap:
-      sum: [ground, 1]
-    x: 0
-    y: 0
-
   flattenWater:
     after:
       - fetchWater

--- a/examples/processes/full.yaml
+++ b/examples/processes/full.yaml
@@ -15,8 +15,6 @@ forEachTile:
         type: wmsFloat
         url: https://data.geopf.fr/wms-r/wms
         layer: RGEALTI-MNT_PYR-ZIP_FXX_LAMB93_WMS
-      processor:
-        type: floatMatrix
     - type: populateHeightmap
       models:
         type: altitude
@@ -35,8 +33,6 @@ forEachTile:
       url: https://data.geopf.fr/wfs/wfs
       features: BDTOPO_V3:batiment
       maxFeaturesPerQuery: 500
-    processor:
-      type: geoToolsVector
     postProcessing:
       - type: copy
         metadata: hauteur
@@ -62,8 +58,6 @@ forEachTile:
       type: wfs
       url: https://data.geopf.fr/wfs/wfs
       features: BDTOPO_V3:surface_hydrographique
-    processor:
-      type: geoToolsVector
 
   fetchRoads:
     type: fetchData
@@ -72,8 +66,6 @@ forEachTile:
       type: wfs
       url: https://data.geopf.fr/wfs/wfs
       features: BDTOPO_V3:troncon_de_route
-    processor:
-      type: geoToolsVector
 
   flattenWater:
     after:
@@ -147,8 +139,6 @@ forEachTile:
           type: wfs
           url: https://data.geopf.fr/wfs/wfs
           features: BDTOPO_V3:zone_de_vegetation
-        processor:
-          type: geoToolsVector
       - type: renderSurfaces
         after: renderGround
         models:

--- a/src/main/java/com/ignfab/minalac/generator/parameters/providers/GeoPackageProviderParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/providers/GeoPackageProviderParams.java
@@ -13,6 +13,8 @@ import org.geotools.referencing.CRS;
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.inputs.GeoPackageDataProvider;
 import com.ignfab.minalac.generator.inputs.Provider;
+import com.ignfab.minalac.generator.parameters.processors.GeoToolsVectorProcessorParams;
+import com.ignfab.minalac.generator.parameters.processors.ProcessorParams;
 import com.ignfab.minalac.generator.utils.FileHelpers;
 
 /**
@@ -69,5 +71,10 @@ public class GeoPackageProviderParams extends ProviderParams {
             throw new IllegalArgumentException("File \"%s\" does not exist".formatted(file.getAbsolutePath()));
 
         return new GeoPackageDataProvider(file, typeName, crsOverride, generation::getEnvelopeForCRS);
+    }
+
+    @Override
+    public ProcessorParams defaultProcessor() {
+        return new GeoToolsVectorProcessorParams();
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/parameters/providers/GeoTiffProviderParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/providers/GeoTiffProviderParams.java
@@ -13,6 +13,8 @@ import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.inputs.FloatGeographicDataMatrix2d;
 import com.ignfab.minalac.generator.inputs.GeoTiffDataProvider;
 import com.ignfab.minalac.generator.inputs.Provider;
+import com.ignfab.minalac.generator.parameters.processors.FloatMatrixProcessorParams;
+import com.ignfab.minalac.generator.parameters.processors.ProcessorParams;
 import com.ignfab.minalac.generator.utils.FileHelpers;
 
 /**
@@ -61,5 +63,10 @@ public class GeoTiffProviderParams extends ProviderParams {
             throw new IllegalArgumentException("File \"%s\" does not exist".formatted(file.getAbsolutePath()));
 
         return new GeoTiffDataProvider(file, crsOverride, generation::getEnvelopeForCRS);
+    }
+
+    @Override
+    public ProcessorParams defaultProcessor() {
+        return new FloatMatrixProcessorParams();
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/parameters/providers/ProviderParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/providers/ProviderParams.java
@@ -3,6 +3,7 @@ package com.ignfab.minalac.generator.parameters.providers;
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.inputs.Provider;
 import com.ignfab.minalac.generator.parameters.PolymorphicParams;
+import com.ignfab.minalac.generator.parameters.processors.ProcessorParams;
 
 /**
  * Represents the parameters of a type of {@link Provider}.
@@ -15,4 +16,9 @@ public abstract class ProviderParams extends PolymorphicParams {
      * @return the resulting provider
      */
     public abstract Provider<?> create(Generation generation);
+
+    /**
+     * {@return the default processor params for this provider, if any}
+     */
+    public abstract ProcessorParams defaultProcessor();
 }

--- a/src/main/java/com/ignfab/minalac/generator/parameters/providers/ShapefileProviderParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/providers/ShapefileProviderParams.java
@@ -13,6 +13,8 @@ import org.geotools.referencing.CRS;
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.inputs.Provider;
 import com.ignfab.minalac.generator.inputs.ShapefileDataProvider;
+import com.ignfab.minalac.generator.parameters.processors.GeoToolsVectorProcessorParams;
+import com.ignfab.minalac.generator.parameters.processors.ProcessorParams;
 import com.ignfab.minalac.generator.utils.FileHelpers;
 
 /**
@@ -61,5 +63,10 @@ public class ShapefileProviderParams extends ProviderParams {
             throw new IllegalArgumentException("File \"%s\" does not exist".formatted(file.getAbsolutePath()));
 
         return new ShapefileDataProvider(file, crsOverride, generation::getEnvelopeForCRS);
+    }
+
+    @Override
+    public ProcessorParams defaultProcessor() {
+        return new GeoToolsVectorProcessorParams();
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/parameters/providers/WFSProviderParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/providers/WFSProviderParams.java
@@ -12,6 +12,8 @@ import org.geotools.referencing.CRS;
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.inputs.Provider;
 import com.ignfab.minalac.generator.inputs.WFS1_1_GML3_1_DataProvider;
+import com.ignfab.minalac.generator.parameters.processors.GeoToolsVectorProcessorParams;
+import com.ignfab.minalac.generator.parameters.processors.ProcessorParams;
 
 /**
  * Parameters for WFS providers.
@@ -64,4 +66,10 @@ public class WFSProviderParams extends ProviderParams {
 
         return new WFS1_1_GML3_1_DataProvider(url, features, layerCrs, generation::getEnvelopeForCRS, maxFeaturesPerQuery);
     }
+
+    @Override
+    public ProcessorParams defaultProcessor() {
+        return new GeoToolsVectorProcessorParams();
+    }
+
 }

--- a/src/main/java/com/ignfab/minalac/generator/parameters/providers/WMSFloatBilProviderParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/providers/WMSFloatBilProviderParams.java
@@ -10,6 +10,8 @@ import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.inputs.FloatGeographicDataMatrix2d;
 import com.ignfab.minalac.generator.inputs.Provider;
 import com.ignfab.minalac.generator.inputs.WMSFloatBilDataProvider;
+import com.ignfab.minalac.generator.parameters.processors.FloatMatrixProcessorParams;
+import com.ignfab.minalac.generator.parameters.processors.ProcessorParams;
 
 /**
  * Parameters for WMS float providers.
@@ -55,5 +57,10 @@ public class WMSFloatBilProviderParams extends ProviderParams {
             layerCrs = generation.crs();
 
         return new WMSFloatBilDataProvider(url, layer, layerCrs, generation::getEnvelopeForCRS);
+    }
+
+    @Override
+    public ProcessorParams defaultProcessor() {
+        return new FloatMatrixProcessorParams();
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/parameters/tasks/FetchDataTaskParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/tasks/FetchDataTaskParams.java
@@ -28,8 +28,9 @@ public class FetchDataTaskParams extends TaskParams {
     public ProviderParams provider;
 
     /**
-     * Data processor (required).
+     * Data processor (required if provider has no default processor).
      */
+    @JsonSetter(nulls = Nulls.SKIP)
     public ProcessorParams processor;
 
     /**
@@ -43,13 +44,12 @@ public class FetchDataTaskParams extends TaskParams {
      *
      * @param modelType type to give to resulting models
      * @param provider data provider for this source
-     * @param processor data processor for provided data
      */
-    @ConstructorProperties({"modelType", "provider", "processor"})
-    public FetchDataTaskParams(String modelType, ProviderParams provider, ProcessorParams processor) {
+    @ConstructorProperties({"modelType", "provider"})
+    public FetchDataTaskParams(String modelType, ProviderParams provider) {
         this.modelType = modelType;
         this.provider = provider;
-        this.processor = processor;
+        this.processor = provider.defaultProcessor();
     }
 
     @Override
@@ -59,7 +59,12 @@ public class FetchDataTaskParams extends TaskParams {
 
         super.validate();
         provider.validate();
+
+        if (processor == null)
+            throw new IllegalArgumentException("Missing processor and no default processor");
+
         processor.validate();
+
         postProcessing.validate();
     }
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/GenerationParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/GenerationParamsTest.java
@@ -9,7 +9,6 @@ import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.generation.heightmaps.HeightmapDeclaration;
 import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
 import com.ignfab.minalac.generator.parameters.placeables.voxels.TestingVoxelParams;
-import com.ignfab.minalac.generator.parameters.processors.TestingProcessorParams;
 import com.ignfab.minalac.generator.parameters.providers.TestingProviderParams;
 import com.ignfab.minalac.generator.parameters.tasks.FetchDataTaskParams;
 import com.ignfab.minalac.generator.parameters.tasks.NoOperationTaskParams;
@@ -118,8 +117,8 @@ public class GenerationParamsTest {
         params.heightmaps.put("altitude", new HeightmapDeclarationParams("minimal"));
         params.forEachTile.tasks.put("task1", new NoOperationTaskParams());
         params.forEachTile.tasks.put("task2", new NoOperationTaskParams());
-        params.forEachTile.tasks.put("source1", new FetchDataTaskParams("models1", new TestingProviderParams("value1"), new TestingProcessorParams("value2")));
-        params.forEachTile.tasks.put("source2", new FetchDataTaskParams("models2", new TestingProviderParams("value3"), new TestingProcessorParams("value3")));
+        params.forEachTile.tasks.put("source1", new FetchDataTaskParams("models1", new TestingProviderParams("value1")));
+        params.forEachTile.tasks.put("source2", new FetchDataTaskParams("models2", new TestingProviderParams("value3")));
 
         TestingVoxelParams placeable = new TestingVoxelParams("voxel");
         RenderBuildingsTaskParams task = new RenderBuildingsTaskParams(

--- a/src/test/java/com/ignfab/minalac/generator/parameters/processors/TestingProcessorParams.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/processors/TestingProcessorParams.java
@@ -1,37 +1,42 @@
 package com.ignfab.minalac.generator.parameters.processors;
 
-import java.beans.ConstructorProperties;
-
-import com.fasterxml.jackson.annotation.JsonSetter;
-import com.fasterxml.jackson.annotation.Nulls;
-
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.processors.Processor;
 import com.ignfab.minalac.generator.processors.TestingProcessor;
 
 public class TestingProcessorParams extends ProcessorParams {
     /**
-     * A required field.
+     * An invalid TestingProcessorParams.
      */
-    public String requiredField;
-    /**
-     * An optional field.
-     */
-    @JsonSetter(nulls = Nulls.SKIP)
-    public String optionalField = "defaultOptionalValue";
+    public static final TestingProcessorParams INVALID = new TestingProcessorParams(false);
 
     /**
-     * Constructor used to ensure that the required fields are present during deserialization.
-     *
-     * @param requiredField the required field.
+     * A valid TestingProcessorParams.
      */
-    @ConstructorProperties({"requiredField"})
-    public TestingProcessorParams(String requiredField) {
-        this.requiredField = requiredField;
+    public static final TestingProcessorParams VALID = new TestingProcessorParams(true);
+
+    private final boolean valid;
+
+    private TestingProcessorParams(boolean valid) {
+        this.valid = valid;
+    }
+
+    /**
+     * Creates a new valid {@code TestingProcessorParams}.
+     */
+    public TestingProcessorParams() {
+        this(true);
+    }
+
+    @Override
+    public void validate() {
+        if (!valid)
+            throw new IllegalArgumentException("Invalid test processor params");
     }
 
     @Override
     public Processor<?, ?> create(Generation generation) {
         return new TestingProcessor();
     }
+
 }

--- a/src/test/java/com/ignfab/minalac/generator/parameters/providers/TestingProviderParams.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/providers/TestingProviderParams.java
@@ -8,6 +8,8 @@ import com.fasterxml.jackson.annotation.Nulls;
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.inputs.Provider;
 import com.ignfab.minalac.generator.inputs.TestingProvider;
+import com.ignfab.minalac.generator.parameters.processors.ProcessorParams;
+import com.ignfab.minalac.generator.parameters.processors.TestingProcessorParams;
 
 public class TestingProviderParams extends ProviderParams {
     /**
@@ -35,4 +37,8 @@ public class TestingProviderParams extends ProviderParams {
         return new TestingProvider(generation.crs());
     }
 
+    @Override
+    public ProcessorParams defaultProcessor() {
+        return new TestingProcessorParams();
+    }
 }

--- a/src/test/java/com/ignfab/minalac/generator/parameters/tasks/FetchDataTaskParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/tasks/FetchDataTaskParamsTest.java
@@ -1,0 +1,140 @@
+package com.ignfab.minalac.generator.parameters.tasks;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.cfg.MapperBuilder;
+import tools.jackson.databind.jsontype.NamedType;
+import tools.jackson.dataformat.yaml.YAMLMapper;
+
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.inputs.Provider;
+import com.ignfab.minalac.generator.parameters.ParamsTester;
+import com.ignfab.minalac.generator.parameters.processors.ProcessorParams;
+import com.ignfab.minalac.generator.parameters.processors.TestingProcessorParams;
+import com.ignfab.minalac.generator.parameters.providers.ProviderParams;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class FetchDataTaskParamsTest {
+
+    @Test
+    public void testValidate() {
+        FetchDataTaskParams params;
+
+        params = new FetchDataTaskParams("dummy", new TestingProviderWithoutDefaultParams());
+        assertThrows(IllegalArgumentException.class, params::validate);
+
+        params = new FetchDataTaskParams("dummy", new TestingProviderWithoutDefaultParams());
+        params.processor = TestingProcessorParams.VALID;
+        assertDoesNotThrow(params::validate);
+
+        params = new FetchDataTaskParams("dummy", new TestingProviderWithDefaultParams());
+        assertDoesNotThrow(params::validate);
+
+        params = new FetchDataTaskParams(" ", new TestingProviderWithDefaultParams());
+        assertThrows(IllegalArgumentException.class, params::validate);
+
+        params = new FetchDataTaskParams("dummy", new TestingProviderWithoutDefaultParams());
+        params.processor = TestingProcessorParams.INVALID;
+        assertThrows(IllegalArgumentException.class, params::validate);
+
+        params = new FetchDataTaskParams("dummy", TestingProviderWithoutDefaultParams.INVALID);
+        assertThrows(IllegalArgumentException.class, params::validate);
+    }
+
+    @Test
+    public void testDefaultProcessor() {
+        MapperBuilder<?, ?> builder = YAMLMapper.builder()
+            .registerSubtypes(new NamedType(FetchDataTaskParams.class, "fetchData"))
+            .registerSubtypes(new NamedType(TestingProviderWithoutDefaultParams.class, "testProviderWithoutDefault"))
+            .registerSubtypes(new NamedType(TestingProviderWithDefaultParams.class, "testProviderWithDefault"))
+            .registerSubtypes(new NamedType(TestingProcessorParams.class, "testProcessor"));
+
+        FetchDataTaskParams params;
+
+        params = assertDoesNotThrow(() -> ParamsTester.deserialize(FetchDataTaskParams.class, """
+            type: fetchData
+            modelType: test
+            provider:
+                type: testProviderWithoutDefault
+        """, builder));
+
+        assertNotNull(params.provider);
+        assertNull(params.processor);
+
+        params = assertDoesNotThrow(() -> ParamsTester.deserialize(FetchDataTaskParams.class, """
+            type: fetchData
+            modelType: test
+            provider:
+                type: testProviderWithoutDefault
+            processor:
+                type: testProcessor
+        """, builder));
+
+        assertNotNull(params.provider);
+        assertNotNull(params.processor);
+
+        params = assertDoesNotThrow(() -> ParamsTester.deserialize(FetchDataTaskParams.class, """
+            type: fetchData
+            modelType: test
+            provider:
+                type: testProviderWithDefault
+        """, builder));
+
+        assertNotNull(params.provider);
+        assertEquals(TestingProviderWithDefaultParams.DEFAULT_PROCESSOR, params.processor);
+
+        params = assertDoesNotThrow(() -> ParamsTester.deserialize(FetchDataTaskParams.class, """
+            type: fetchData
+            modelType: test
+            provider:
+                type: testProviderWithDefault
+            processor:
+                type: testProcessor
+        """, builder));
+
+        assertNotNull(params.provider);
+        assertNotNull(params.processor);
+        assertNotEquals(TestingProviderWithDefaultParams.DEFAULT_PROCESSOR, params.processor);
+    }
+
+    // Params for a test provider without default processor. Could be valid (default) or invalid.
+    private static class TestingProviderWithoutDefaultParams extends ProviderParams {
+        private static final TestingProviderWithoutDefaultParams INVALID = new TestingProviderWithoutDefaultParams(false);
+
+        private final boolean valid;
+
+        private TestingProviderWithoutDefaultParams(boolean valid) {
+            this.valid = valid;
+        }
+
+        TestingProviderWithoutDefaultParams() {
+            this(true);
+        }
+
+        @Override
+        public Provider<?> create(Generation generation) {
+            throw new UnsupportedOperationException("Unimplemented method 'create'");
+        }
+
+        @Override
+        public ProcessorParams defaultProcessor() {
+            return null;
+        }
+
+        @Override
+        public void validate() {
+            if (!valid)
+                throw new IllegalArgumentException("Invalid test processor params");
+        }
+    }
+
+    // Params for a test provider with default processor. Always valid.
+    private static final class TestingProviderWithDefaultParams extends TestingProviderWithoutDefaultParams {
+        private static final TestingProcessorParams DEFAULT_PROCESSOR = new TestingProcessorParams();
+
+        @Override
+        public ProcessorParams defaultProcessor() {
+            return DEFAULT_PROCESSOR;
+        }
+    }
+}


### PR DESCRIPTION
### Changes

In fetchData task, make processor optional for provider that have a default processor.

### Reason

Cost-less reduction of parameters verbosity and complexity.

### Self-checks

- [ ] The code has unit tests associated
- [x] The code has Javadoc Comments associated
- ~~Complex / Unexpected code is explained / justified with a small comment~~
- [x] Relevant documentation inside the `/docs` folder has been updated
- [x] All examples in `examples/` work the same (or have been adapted if subject to changes in this PR)
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [ ] The texts have been proofread (documentation, error messages, logs, comments...)
