### PR TITLE
Add Overpass (OSM) provider and processor

### DIFF
--- a/docs/usage/parameters/FetchDataTask.md
+++ b/docs/usage/parameters/FetchDataTask.md
@@ -7,12 +7,14 @@ Task of type `fetchData` fetches data from geographic data source, processes it,
 * [Example](#example)
 * [Extra parameters](#extra-parameters)
 * [Providers](#providers)
+  * [`overpass` (Open Street Map)](#overpass-open-street-map)
   * [`wfs` (Web Feature Service)](#wfs-web-feature-service)
   * [`gpkg` (GeoPackage)](#gpkg-geopackage)
   * [`shapefile` (Shapefile)](#shapefile-shapefile)
   * [`wmsFloat` (Web Map Service with floating point values)](#wmsfloat-web-map-service-with-floating-point-values)
   * [`geotiff` (GeoTiff)](#geotiff-geotiff)
 * [Processors](#processors)
+  * [`osm` (Open Street Map)](#osm-open-street-map)
   * [`geoToolsVector` (GeoTools vector processor)](#geotoolsvector-geotools-vector-processor)
   * [`floatMatrix` (Float matrix processor)](#floatmatrix-float-matrix-processor)
 
@@ -55,6 +57,29 @@ Not all processors are compatible with all provider. See [providers](#provider-p
 ## Providers
 
 A provider fetches data from a source and provides it as-is to a processor. Provider type is identified by `type` field.
+
+### `overpass` (Open Street Map)
+Provider of type `overpass` fetches Open Street Map vector data from [Overpass API](https://wiki.openstreetmap.org/wiki/Overpass_API).
+
+**Extra parameters**:
+- `url` (required): URL of the Overpass service to use.
+- `query` (required): [Overpass query](https://wiki.openstreetmap.org/wiki/Overpass_API/Overpass_QL) to use to get data.
+
+Each entity returned by the Overpass query will be processed as a model.
+
+Ensure query will return only one entity per object (building, road, ...). The provider takes care of retrieving the full geometries.
+
+Example:
+```yaml
+  provider:
+    type: overpass
+    url: https://overpass-api.de/api/interpreter
+    query: nwr[building]
+```
+
+This will fetch all entities with a `building` tag and create corresponding models. Nodes and ways defining the geometry of `building` entities will automatically be fetched by the provider, and should not be included in query (it would otherwise result in them being fetched twice, possibly causing rendering glitches later on).
+
+**Default processor**: `osm`
 
 ### `wfs` (Web Feature Service)
 Provider of type `wfs` fetches vector data from a [Web Feature Service](https://en.wikipedia.org/wiki/Web_Feature_Service) source. Source must support WFS 1.1 and GML 3.1 versions.
@@ -108,6 +133,13 @@ Provider of type `geotiff` reads **float** (for now) raster data from a [GeoTiff
 ## Processors
 
 A processor converts data from a provider into models. Processor type is identified by `type` field.
+
+### `osm` (Open Street Map)
+Processor of type `osm` takes vector OSM data from `overpass` provider and turns them into models.
+
+**Extra parameters**: None
+
+**Suitable providers**: `overpass`
 
 ### `geoToolsVector` (GeoTools vector processor)
 Processor of type `geoToolsVector` takes vector features and turns them into models, using GeoTools library.

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <geotools.version>31.0</geotools.version>
+        <osm4j.version>1.4.1</osm4j.version>
     </properties>
 
     <repositories>
@@ -30,6 +31,16 @@
         <repository>
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
+        </repository>
+        <!-- OSM4J repository -->
+        <repository>
+            <id>topobyte</id>
+            <url>https://mvn.topobyte.de/</url>
+        </repository>
+        <!-- Required by OSM4J -->
+        <repository>
+            <id>slimjars</id>
+            <url>https://mvn.slimjars.com</url>
         </repository>
     </repositories>
 
@@ -164,6 +175,22 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-pool2</artifactId>
             <version>2.12.1</version>
+        </dependency>
+        <!-- OSM4J -->
+        <dependency>
+            <groupId>de.topobyte</groupId>
+            <artifactId>osm4j-core</artifactId>
+            <version>${osm4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>de.topobyte</groupId>
+            <artifactId>osm4j-xml</artifactId>
+            <version>${osm4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>de.topobyte</groupId>
+            <artifactId>osm4j-geometry</artifactId>
+            <version>${osm4j.version}</version>
         </dependency>
 
         <!--

--- a/src/main/java/com/ignfab/minalac/generator/MinalacGenerator.java
+++ b/src/main/java/com/ignfab/minalac/generator/MinalacGenerator.java
@@ -22,6 +22,7 @@ import com.ignfab.minalac.generator.parameters.placeables.voxels.MCVoxelParams;
 import com.ignfab.minalac.generator.parameters.placeables.voxels.MTVoxelParams;
 import com.ignfab.minalac.generator.parameters.processors.FloatMatrixProcessorParams;
 import com.ignfab.minalac.generator.parameters.processors.GeoToolsVectorProcessorParams;
+import com.ignfab.minalac.generator.parameters.processors.OsmProcessorParams;
 import com.ignfab.minalac.generator.parameters.processors.post.ConditionalPostProcessorParams;
 import com.ignfab.minalac.generator.parameters.processors.post.DiscardPostProcessorParams;
 import com.ignfab.minalac.generator.parameters.processors.post.IdentityPostProcessorParams;
@@ -33,6 +34,7 @@ import com.ignfab.minalac.generator.parameters.processors.post.MetadataTruncateP
 import com.ignfab.minalac.generator.parameters.processors.post.MetadataValueMappingPostProcessorParams;
 import com.ignfab.minalac.generator.parameters.providers.GeoPackageProviderParams;
 import com.ignfab.minalac.generator.parameters.providers.GeoTiffProviderParams;
+import com.ignfab.minalac.generator.parameters.providers.OverpassProviderParams;
 import com.ignfab.minalac.generator.parameters.providers.ShapefileProviderParams;
 import com.ignfab.minalac.generator.parameters.providers.WFSProviderParams;
 import com.ignfab.minalac.generator.parameters.providers.WMSFloatBilProviderParams;
@@ -125,9 +127,11 @@ public final class MinalacGenerator {
         parser.registerParams("shapefile", ShapefileProviderParams.class);
         parser.registerParams("wmsFloat", WMSFloatBilProviderParams.class);
         parser.registerParams("geotiff", GeoTiffProviderParams.class);
+        parser.registerParams("overpass", OverpassProviderParams.class);
 
         parser.registerParams("floatMatrix", FloatMatrixProcessorParams.class);
         parser.registerParams("geoToolsVector", GeoToolsVectorProcessorParams.class);
+        parser.registerParams("osm", OsmProcessorParams.class);
 
         parser.registerParams("identity", IdentityPostProcessorParams.class);
         parser.registerParams("discard", DiscardPostProcessorParams.class);

--- a/src/main/java/com/ignfab/minalac/generator/MinalacGenerator.java
+++ b/src/main/java/com/ignfab/minalac/generator/MinalacGenerator.java
@@ -44,6 +44,7 @@ import com.ignfab.minalac.generator.parameters.tasks.NoOperationTaskParams;
 import com.ignfab.minalac.generator.parameters.tasks.PopulateHeightmapTaskParams;
 import com.ignfab.minalac.generator.parameters.tasks.RenderBuildingsTaskParams;
 import com.ignfab.minalac.generator.parameters.tasks.RenderHeightmapTaskParams;
+import com.ignfab.minalac.generator.parameters.tasks.RenderLines2dTaskParams;
 import com.ignfab.minalac.generator.parameters.tasks.RenderLinesTaskParams;
 import com.ignfab.minalac.generator.parameters.tasks.RenderSurfacesTaskParams;
 import com.ignfab.minalac.generator.parameters.tasks.ScheduleTaskParams;
@@ -116,6 +117,7 @@ public final class MinalacGenerator {
         parser.registerParams("renderHeightmap", RenderHeightmapTaskParams.class);
         parser.registerParams("renderSurfaces", RenderSurfacesTaskParams.class);
         parser.registerParams("renderLines", RenderLinesTaskParams.class);
+        parser.registerParams("renderLines2d", RenderLines2dTaskParams.class);
         parser.registerParams("setSpawn", SetSpawnTaskParams.class);
 
         parser.registerParams("wfs", WFSProviderParams.class);

--- a/src/main/java/com/ignfab/minalac/generator/inputs/OsmData.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/OsmData.java
@@ -1,0 +1,28 @@
+package com.ignfab.minalac.generator.inputs;
+
+import de.topobyte.osm4j.core.model.iface.OsmEntity;
+import de.topobyte.osm4j.core.resolve.OsmEntityProvider;
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+
+/**
+ * OSM entity with a fully resolvable geometry.
+ *
+ * @param resolver the resolver to use to resolve references to other elements
+ * @param entity the element whose geometry might contain references to other elements
+ */
+public record OsmData(OsmEntityProvider resolver, OsmEntity entity) {
+    /**
+     * Coordinate Reference System for OSM Data (EPSG:4326 / WGS-84).
+     */
+    public static final CoordinateReferenceSystem CRS;
+
+    static {
+        String code = "EPSG:4326";
+        try {
+            CRS = org.geotools.referencing.CRS.decode(code);
+        } catch (FactoryException e) {
+            throw new RuntimeException("Could not initialize OSM CRS to %s!".formatted(code), e);
+        }
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/inputs/OverpassProvider.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/OverpassProvider.java
@@ -1,0 +1,160 @@
+package com.ignfab.minalac.generator.inputs;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
+import com.slimjars.dist.gnu.trove.iterator.TLongObjectIterator;
+import com.slimjars.dist.gnu.trove.map.TLongObjectMap;
+import de.topobyte.osm4j.core.access.OsmInputException;
+import de.topobyte.osm4j.core.dataset.InMemoryMapDataSet;
+import de.topobyte.osm4j.core.dataset.MapDataSetLoader;
+import de.topobyte.osm4j.core.model.iface.OsmEntity;
+import de.topobyte.osm4j.xml.dynsax.OsmXmlReader;
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+
+import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
+import com.ignfab.minalac.generator.exceptions.RetryableException;
+import com.ignfab.minalac.generator.exceptions.TransformException;
+import com.ignfab.minalac.generator.utils.coordinates.EnvelopeProvider;
+import com.ignfab.minalac.generator.utils.iterator.Iterators;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+
+/**
+ * Data provider for Overpass.
+ */
+public class OverpassProvider implements Provider<OsmData> {
+    private final URI url;
+    private final EnvelopeProvider envelopeProvider;
+    private final String query;
+
+    /**
+     * Creates a new {@code OverpassProvider}.
+     *
+     * @param url Overpass URL
+     * @param query Overpass query. Each element will be processed as a separate model.
+     * @param envelopeProvider the envelope provider to filter elements.
+     */
+    public OverpassProvider(URI url, String query, EnvelopeProvider envelopeProvider) {
+        this.url = url;
+        this.query = query;
+        this.envelopeProvider = envelopeProvider;
+    }
+
+    @Override
+    public Class<OsmData> providedType() {
+        return OsmData.class;
+    }
+
+    @Override
+    public SimpleResult<OsmData> provide(WorldBBox3d bbox) throws GenerationFailedException, RetryableException {
+        ReferencedEnvelope envelope;
+        try {
+            envelope = envelopeProvider.computeForCRS(OsmData.CRS, bbox);
+        } catch (FactoryException | TransformException e) {
+            throw new GenerationFailedException(e);
+        }
+
+        // Fetch data from query, within bbox, including sub-ways and nodes but getting rid of eventual tags.
+        // (we will rely on tags to distinguish wanted data from constituting ways and nodes)
+        String data = String.format(Locale.US, "[bbox:%f,%f,%f,%f];%s;out;>;out skel;",
+            envelope.getMinX(), envelope.getMinY(), envelope.getMaxX(), envelope.getMaxY(), query);
+
+        String body = "data=" + URLEncoder.encode(data, StandardCharsets.UTF_8);
+
+        HttpClient client = HttpClient.newHttpClient();
+
+        HttpRequest request = HttpRequest.newBuilder()
+            .uri(url)
+            .POST(HttpRequest.BodyPublishers.ofString(body))
+            .build();
+
+        HttpResponse<InputStream> response;
+
+        try {
+            response = client.send(request, HttpResponse.BodyHandlers.ofInputStream());
+        } catch (IOException | InterruptedException e) {
+            throw new RetryableException("Error opening connection", e);
+        }
+
+        int status = response.statusCode();
+
+        if (status >= 400) {
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(response.body()))) {
+                System.err.printf("%d status code from Overpass%n", status);
+                System.err.println(reader.lines().collect(Collectors.joining("\n")));
+            } catch (IOException ignored) {}
+
+            throw new RetryableException("%d status code from Overpass".formatted(status));
+        }
+
+        InMemoryMapDataSet dataset;
+        try (InputStream stream = response.body()) {
+            dataset = MapDataSetLoader.read(new OsmXmlReader(stream, false), true, true, true);
+        } catch (OsmInputException e) {
+            throw new GenerationFailedException(e);
+        } catch (IOException e) {
+            throw new RetryableException(e);
+        }
+
+        return new SimpleResult<>(OsmData.CRS,
+            Iterators.remap(
+                Iterators.union(
+                    new OsmEntityIterator(dataset.getNodes()),
+                    new OsmEntityIterator(dataset.getWays()),
+                    new OsmEntityIterator(dataset.getRelations())
+                ),
+                (entity) -> new OsmData(dataset, entity)
+            )
+        );
+    }
+
+    /**
+     * An iterator for a {@code TLongObjectMap} of {@code OsmEntity} objects.
+     * <p>
+     * This iterator wraps a {@code TLongObjectIterator} over {@code OsmEntity} subtypes.
+     * It casts back results into {@code OsmEntity} type and skips entities with no tags
+     * (the provider query strips tags from entities that are only component of features geometries).
+     */
+    private static class OsmEntityIterator implements Iterator<OsmEntity> {
+        private final TLongObjectIterator<? extends OsmEntity> iterator;
+        private OsmEntity next;
+
+        OsmEntityIterator(TLongObjectMap<? extends OsmEntity> map) {
+            iterator = map.iterator();
+            moveOn();
+        }
+
+        public void moveOn() {
+            next = null;
+            while (next == null && iterator.hasNext()) {
+                iterator.advance();
+                if (iterator.value().getNumberOfTags() > 0)
+                    next = iterator.value();
+            }
+        }
+
+        @Override
+        public boolean hasNext() {
+            return next != null;
+        }
+
+        @Override
+        public OsmEntity next() {
+            OsmEntity result = next;
+            moveOn();
+            return result;
+        }
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/parameters/processors/OsmProcessorParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/processors/OsmProcessorParams.java
@@ -1,0 +1,23 @@
+package com.ignfab.minalac.generator.parameters.processors;
+
+import org.geotools.api.referencing.FactoryException;
+
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.inputs.OsmData;
+import com.ignfab.minalac.generator.models.JTSGeometryModel;
+import com.ignfab.minalac.generator.processors.OsmProcessor;
+import com.ignfab.minalac.generator.processors.Processor;
+
+/**
+ * Parameters for OSM processor.
+ */
+public class OsmProcessorParams extends ProcessorParams {
+    @Override
+    public Processor<OsmData, JTSGeometryModel> create(Generation generation) {
+        try {
+            return new OsmProcessor(generation.makeCoordsConverter(OsmData.CRS));
+        } catch (FactoryException e) {
+            throw new RuntimeException("Cannot convert OSM CRS to target CRS", e);
+        }
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/parameters/providers/OverpassProviderParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/providers/OverpassProviderParams.java
@@ -1,0 +1,54 @@
+package com.ignfab.minalac.generator.parameters.providers;
+
+import java.beans.ConstructorProperties;
+import java.net.URI;
+
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.inputs.OsmData;
+import com.ignfab.minalac.generator.inputs.OverpassProvider;
+import com.ignfab.minalac.generator.inputs.Provider;
+import com.ignfab.minalac.generator.parameters.processors.OsmProcessorParams;
+import com.ignfab.minalac.generator.parameters.processors.ProcessorParams;
+
+/**
+ * Parameters for Overpass provider.
+ */
+public class OverpassProviderParams extends ProviderParams {
+    /**
+     * URL of Overpass API to use (required).
+     */
+    @JsonSetter(nulls = Nulls.FAIL)
+    public String url;
+
+    /**
+     * Overpass query (required).
+     */
+    @JsonSetter(nulls = Nulls.FAIL)
+    public String query;
+
+    /**
+     * Creates a new OverpassProviderParams with mandatory fields.
+     *
+     * @param url URL of Overpass API to use.
+     * @param query Overpass query
+     */
+    @ConstructorProperties({"url", "query"})
+    public OverpassProviderParams(String url, String query) {
+        this.url = url;
+        this.query = query;
+    }
+
+    @Override
+    public Provider<OsmData> create(Generation generation) {
+        // (Trailing ";" are removed from query)
+        return new OverpassProvider(URI.create(url), query.replaceAll(";+$", ""), generation::getEnvelopeForCRS);
+    }
+
+    @Override
+    public ProcessorParams defaultProcessor() {
+        return new OsmProcessorParams();
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/parameters/tasks/RenderLines2dTaskParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/tasks/RenderLines2dTaskParams.java
@@ -1,0 +1,58 @@
+package com.ignfab.minalac.generator.parameters.tasks;
+
+import java.beans.ConstructorProperties;
+
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.parameters.heightmaps.ReadableHeightmapParams;
+import com.ignfab.minalac.generator.parameters.placeables.structures.PlaceableStructureParams;
+import com.ignfab.minalac.generator.tasks.RenderLines2dTask;
+import com.ignfab.minalac.generator.tasks.TileTask;
+
+/**
+ * Parameters for {@link RenderLines2dTask}.
+ */
+public class RenderLines2dTaskParams extends ModelTaskParams {
+    /**
+     * Structure to place and repeat along lines (required).
+     */
+    @JsonSetter(nulls = Nulls.FAIL)
+    public PlaceableStructureParams structure;
+
+    /**
+     * Heightmap on which draw lines (from which Z is taken according to X and Y).
+     */
+    @JsonSetter(nulls = Nulls.FAIL)
+    public ReadableHeightmapParams heightmap;
+
+    /**
+     * Constructor used to ensure that the required fields are present during deserialization.
+     *
+     * @param structure structure to place along lines
+     * @param heightmap heightmap on which draw lines (from which Z is taken according to X and Y)
+     */
+    @ConstructorProperties({"structure", "heightmap"})
+    public RenderLines2dTaskParams(PlaceableStructureParams structure, ReadableHeightmapParams heightmap) {
+        this.structure = structure;
+        this.heightmap = heightmap;
+    }
+
+    @Override
+    public void validate() throws IllegalArgumentException {
+        structure.validate();
+        models.validate();
+        heightmap.validate();
+    }
+
+    @Override
+    public TileTask create(Generation generation) {
+        return new RenderLines2dTask(
+            models.create(),
+            structure.create(generation.seed()),
+            heightmap.create(generation.heightmaps())
+        );
+    }
+}
+

--- a/src/main/java/com/ignfab/minalac/generator/processors/GeoToolsVectorProcessor.java
+++ b/src/main/java/com/ignfab/minalac/generator/processors/GeoToolsVectorProcessor.java
@@ -18,7 +18,7 @@ import com.ignfab.minalac.generator.utils.coordinates.CoordsConverterProvider;
  */
 public class GeoToolsVectorProcessor extends ConvertingProcessor<SimpleFeature, JTSGeometryModel> {
     /**
-     * Creates a new processor using the given converter to for the {@link JTSGeometryModel}.
+     * Creates a new processor using the given converter for the {@link JTSGeometryModel}.
      * @param converterProvider the converter provider to transform coordinates from map to world
      */
     public GeoToolsVectorProcessor(CoordsConverterProvider converterProvider) {

--- a/src/main/java/com/ignfab/minalac/generator/processors/OsmProcessor.java
+++ b/src/main/java/com/ignfab/minalac/generator/processors/OsmProcessor.java
@@ -1,0 +1,95 @@
+package com.ignfab.minalac.generator.processors;
+
+import de.topobyte.osm4j.core.model.iface.OsmEntity;
+import de.topobyte.osm4j.core.model.iface.OsmNode;
+import de.topobyte.osm4j.core.model.iface.OsmRelation;
+import de.topobyte.osm4j.core.model.iface.OsmTag;
+import de.topobyte.osm4j.core.model.iface.OsmWay;
+import de.topobyte.osm4j.core.resolve.EntityNotFoundException;
+import de.topobyte.osm4j.geometry.GeometryBuilder;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+
+import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
+import com.ignfab.minalac.generator.exceptions.TransformException;
+import com.ignfab.minalac.generator.inputs.OsmData;
+import com.ignfab.minalac.generator.models.JTSGeometryModel;
+import com.ignfab.minalac.generator.utils.coordinates.MapToWorldConverter;
+
+/**
+ * Processor transforming {@code OsmData} into {@link JTSGeometryModel}.
+ * It also copies OSM element tags into model's metadata.
+ * <p>
+ * This processor pairs well with {@link com.ignfab.minalac.generator.inputs.OverpassProvider}.
+ */
+public class OsmProcessor implements Processor<OsmData, JTSGeometryModel> {
+    private final MapToWorldConverter converter;
+    private static final GeometryBuilder GEOMETRY_BUILDER = new GeometryBuilder();
+
+    /**
+     * Creates a new {@code OsmProcessor} using the given converter.
+     * @param converter the converter to transform coordinates from map to world (should use {@link OsmData#CRS} as source CRS)
+     */
+    public OsmProcessor(MapToWorldConverter converter) {
+        this.converter = converter;
+    }
+
+    @Override
+    public Class<OsmData> acceptedType() {
+        return OsmData.class;
+    }
+
+    @Override
+    public Class<JTSGeometryModel> modelType() {
+        return JTSGeometryModel.class;
+    }
+
+    @Override
+    public JTSGeometryModel process(OsmData data) throws GenerationFailedException {
+        OsmEntity entity = data.entity();
+
+        // Try to convert OSM geometry to JTS geometry
+        Geometry geometry;
+
+        try {
+            geometry = switch (entity.getType()) {
+                case Node -> GEOMETRY_BUILDER.build((OsmNode) entity);
+                case Way -> GEOMETRY_BUILDER.build((OsmWay) entity, data.resolver());
+                case Relation -> GEOMETRY_BUILDER.build((OsmRelation) entity, data.resolver());
+            };
+        } catch (EntityNotFoundException e) {
+            throw new GenerationFailedException(e);
+        }
+
+        // Coordinates are inverted between OSM and EPSG-4326
+        geometry.apply((Coordinate coordinate) -> {
+            double buffer = coordinate.x;
+            coordinate.x = coordinate.y;
+            coordinate.y = buffer;
+        });
+
+        JTSGeometryModel model;
+
+        try {
+            model = new JTSGeometryModel(geometry, converter);
+        } catch (TransformException e) {
+            throw new GenerationFailedException(e);
+        }
+
+        // Copy OSM tags to model metadata
+        for (int index = 0; index < entity.getNumberOfTags(); index++) {
+            OsmTag tag = entity.getTag(index);
+
+            model.setMetadata(tag.getKey(), tag.getValue());
+        }
+        return model;
+    }
+
+    @Override
+    public void initialize(CoordinateReferenceSystem layerCrs) throws GenerationFailedException {
+        if (!layerCrs.equals(OsmData.CRS))
+            throw new GenerationFailedException("OSM layers should always use %s CRS, got %s.".formatted(OsmData.CRS.getName(), layerCrs.getName()));
+    }
+
+}

--- a/src/main/java/com/ignfab/minalac/generator/tasks/RenderLines2dTask.java
+++ b/src/main/java/com/ignfab/minalac/generator/tasks/RenderLines2dTask.java
@@ -1,0 +1,64 @@
+package com.ignfab.minalac.generator.tasks;
+
+import com.ignfab.minalac.generator.generation.GenerationTile;
+import com.ignfab.minalac.generator.generation.heightmaps.ReadableHeightmap;
+import com.ignfab.minalac.generator.generation.heightmaps.ReadableHeightmapSpec;
+import com.ignfab.minalac.generator.models.ModelSelection;
+import com.ignfab.minalac.generator.models.Shape2dConvertibleModel;
+import com.ignfab.minalac.generator.placeables.PlaceableStructure;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+import com.ignfab.minalac.generator.voxelization.shape2d.iterator.IndexedPosition2d;
+import com.ignfab.minalac.generator.voxelization.shape2d.voxelizer.ThickLinearIndexedVoxelizer2d;
+
+/**
+ * A task rendering lines by placing structure along them.
+ */
+public class RenderLines2dTask extends ModelTask<Shape2dConvertibleModel> {
+    // In structure, X is for linear direction (starting at 0, looping over bbox max x), Y for both orthogonal directions (0 is central axis).
+    private final PlaceableStructure structure;
+    private final ReadableHeightmapSpec heightmapSpec;
+    private final ThickLinearIndexedVoxelizer2d voxelizer;
+
+    /**
+     * Creates a new {@code RenderLinesTask}.
+     * <p>
+     * Structure will be used as template and will be repeated along lines.
+     * <p>
+     * In structure x-axis will be along lines. Y-axis will be on sides, and z-axis will be used for height.
+     *
+     * @param selection selection of models to render
+     * @param structure structure placed along the lines
+     * @param heightmapSpec if not null, only parts of the lines over that heightmap are rendered
+     */
+    public RenderLines2dTask(
+        ModelSelection selection,
+        PlaceableStructure structure,
+        ReadableHeightmapSpec heightmapSpec
+    ) {
+        super(Shape2dConvertibleModel.class, selection);
+
+        this.structure = structure;
+        this.heightmapSpec = heightmapSpec;
+        voxelizer = new ThickLinearIndexedVoxelizer2d(structure.limits().sizeY());
+    }
+
+    @Override
+    protected void run(Shape2dConvertibleModel model, GenerationTile tile) {
+        ReadableHeightmap heightmap = tile.heightmap(heightmapSpec);
+        WorldBBox3d limits = structure.limits();
+
+        // Always align structure center to the line axis.
+        double yOffset = 0.5 * limits.sizeY() + limits.minY();
+
+        for (IndexedPosition2d pos : tile.limits().to2d().filterInside(voxelizer.voxelize(model))) {
+
+            // Get voxel in structure along x-axis, using eventual structure offset as a repeat offset
+            int x = Math.floorMod((int) Math.round(pos.index()) - limits.minX(), limits.sizeX()) + limits.minX();
+            // Much simpler for y-axis
+            int y = (int) Math.floor(pos.distance() + yOffset);
+
+            for (int z = limits.minZ(); z <= limits.maxZ(); z++)
+                structure.get(x, y, z).place(tile.voxels(), pos.coords().x(), pos.coords().y(), heightmap.get(pos.coords()) + z);
+        }
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/tasks/RenderLines2dTask.java
+++ b/src/main/java/com/ignfab/minalac/generator/tasks/RenderLines2dTask.java
@@ -28,7 +28,7 @@ public class RenderLines2dTask extends ModelTask<Shape2dConvertibleModel> {
      *
      * @param selection selection of models to render
      * @param structure structure placed along the lines
-     * @param heightmapSpec if not null, only parts of the lines over that heightmap are rendered
+     * @param heightmapSpec heightmap on which draw lines
      */
     public RenderLines2dTask(
         ModelSelection selection,

--- a/src/main/java/com/ignfab/minalac/generator/voxelization/shape2d/LinearRing2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/voxelization/shape2d/LinearRing2d.java
@@ -2,6 +2,7 @@ package com.ignfab.minalac.generator.voxelization.shape2d;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.ListIterator;
 
@@ -110,5 +111,11 @@ public class LinearRing2d extends LineString2d {
      */
     public LinearRing2d toCounterClockwise() {
         return isClockwise() ? invert() : this;
+    }
+
+    // A linear ring could be considered as a polygon
+    @Override
+    public Iterable<Polygon2d> polygons() {
+        return List.of(new Polygon2d(this, Collections.emptyList()));
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/voxelization/shape3d/LinearRing3d.java
+++ b/src/main/java/com/ignfab/minalac/generator/voxelization/shape3d/LinearRing3d.java
@@ -2,6 +2,7 @@ package com.ignfab.minalac.generator.voxelization.shape3d;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.ListIterator;
 
@@ -110,5 +111,11 @@ public class LinearRing3d extends LineString3d {
      */
     public LinearRing3d toCounterClockwiseXY() {
         return isClockwiseXY() ? invert() : this;
+    }
+
+    // A linear ring could be considered as a polygon
+    @Override
+    public Iterable<Polygon3d> polygons() {
+        return List.of(new Polygon3d(this, Collections.emptyList()));
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/models/TestingShape2dModel.java
+++ b/src/test/java/com/ignfab/minalac/generator/models/TestingShape2dModel.java
@@ -1,0 +1,29 @@
+package com.ignfab.minalac.generator.models;
+
+import com.ignfab.minalac.generator.voxelization.shape2d.Shape2d;
+
+/**
+ * A Shape2d convertible model out of a {@link Shape2d} for testing purposes.
+ */
+public class TestingShape2dModel extends ModelImpl implements Shape2dConvertibleModel {
+    private final Shape2d shape;
+
+    /**
+     * Creates a new model with given shape.
+     *
+     * @param shape shape for this model
+     */
+    public TestingShape2dModel(Shape2d shape) {
+        this.shape = shape;
+    }
+
+    @Override
+    public Shape2d toShape2d() {
+        return shape;
+    }
+
+    @Override
+    public String salt() {
+        return "";
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/models/TestingShape3dModel.java
+++ b/src/test/java/com/ignfab/minalac/generator/models/TestingShape3dModel.java
@@ -14,7 +14,6 @@ public class TestingShape3dModel extends ModelImpl implements Shape3dConvertible
      * @param shape shape for this model
      */
     public TestingShape3dModel(Shape3d shape) {
-        super();
         this.shape = shape;
     }
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/placeables/structures/TestingPlaceableStructureParams.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/placeables/structures/TestingPlaceableStructureParams.java
@@ -1,0 +1,41 @@
+package com.ignfab.minalac.generator.parameters.placeables.structures;
+
+import java.util.List;
+
+import com.ignfab.minalac.generator.placeables.PlaceableStructure;
+import com.ignfab.minalac.generator.utils.random.Seed;
+
+/**
+ * Class providing valid and invalid {@link PlaceableStructureParams} for tests.
+ */
+public final class TestingPlaceableStructureParams {
+    /**
+     * A valid {@link PlaceableStructureParams}.
+     */
+    public static final PlaceableStructureParams VALID;
+
+    /**
+     * An invalid {@link PlaceableStructureParams}.
+     */
+    public static final PlaceableStructureParams INVALID;
+
+    static {
+        VALID = new PlaceableStructureParams();
+        VALID.params = List.of(new Valid());
+        INVALID = new PlaceableStructureParams();
+        INVALID.params = List.of(new Invalid());
+    }
+
+    private static final class Valid extends PlaceableStructureParams.Variant {
+        public void apply(Seed seed, PlaceableStructure.Builder structureBuilder) {}
+    }
+
+    private static final class Invalid extends PlaceableStructureParams.Variant {
+        public void validate() {
+            throw new IllegalArgumentException("Invalid structure");
+        }
+        public void apply(Seed seed, PlaceableStructure.Builder structureBuilder) {}
+    }
+
+    private TestingPlaceableStructureParams() {}
+}

--- a/src/test/java/com/ignfab/minalac/generator/parameters/processors/OsmVectorProcessorParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/processors/OsmVectorProcessorParamsTest.java
@@ -11,7 +11,7 @@ import com.ignfab.minalac.generator.utils.random.TestingSeed;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class GeoToolsVectorProcessorParamsTest {
+public class OsmVectorProcessorParamsTest {
     @Test
     public void testCreate() throws FactoryException {
         CoordinateReferenceSystem crs2154 = CRS.decode("EPSG:2154");
@@ -19,7 +19,7 @@ public class GeoToolsVectorProcessorParamsTest {
         Generation generation = new Generation(new TestingVoxelWorld(), TestingSeed.UNUSED, crs2154, 0, 0, 20, 20, 1, 1, 0.0, 100);
 
         // A simple OK test
-        GeoToolsVectorProcessorParams params = new GeoToolsVectorProcessorParams();
+        OsmProcessorParams params = new OsmProcessorParams();
         assertDoesNotThrow(() -> params.create(generation));
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/parameters/providers/OverpassProviderParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/providers/OverpassProviderParamsTest.java
@@ -1,6 +1,7 @@
-package com.ignfab.minalac.generator.parameters.processors;
+package com.ignfab.minalac.generator.parameters.providers;
 
 import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.NoSuchAuthorityCodeException;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.referencing.CRS;
 import org.junit.jupiter.api.Test;
@@ -11,15 +12,14 @@ import com.ignfab.minalac.generator.utils.random.TestingSeed;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class GeoToolsVectorProcessorParamsTest {
+public class OverpassProviderParamsTest {
     @Test
-    public void testCreate() throws FactoryException {
-        CoordinateReferenceSystem crs2154 = CRS.decode("EPSG:2154");
-
-        Generation generation = new Generation(new TestingVoxelWorld(), TestingSeed.UNUSED, crs2154, 0, 0, 20, 20, 1, 1, 0.0, 100);
+    public void testCreate() throws NoSuchAuthorityCodeException, FactoryException {
+        CoordinateReferenceSystem crs = CRS.decode("EPSG:2154");
+        Generation generation = new Generation(new TestingVoxelWorld(), TestingSeed.UNUSED, crs, 0, 0, 20, 20, 1, 1, 0.0, 100);
 
         // A simple OK test
-        GeoToolsVectorProcessorParams params = new GeoToolsVectorProcessorParams();
+        OverpassProviderParams params = new OverpassProviderParams("http://toto.com", "feature1");
         assertDoesNotThrow(() -> params.create(generation));
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/parameters/tasks/RenderLines2dTaskParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/tasks/RenderLines2dTaskParamsTest.java
@@ -1,0 +1,33 @@
+package com.ignfab.minalac.generator.parameters.tasks;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+
+import com.ignfab.minalac.generator.parameters.heightmaps.TestingHeightmapParams;
+import com.ignfab.minalac.generator.parameters.models.TestingModelSelectionParams;
+import com.ignfab.minalac.generator.parameters.placeables.structures.TestingPlaceableStructureParams;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class RenderLines2dTaskParamsTest {
+
+    @Test
+    public void testValidate() throws JsonProcessingException {
+        RenderLines2dTaskParams params;
+
+        // Check any invalid members makes valid throw
+        params = new RenderLines2dTaskParams(TestingPlaceableStructureParams.VALID, TestingHeightmapParams.VALID);
+        params.models = TestingModelSelectionParams.INVALID;
+        assertThrows(IllegalArgumentException.class, params::validate);
+
+        params = new RenderLines2dTaskParams(TestingPlaceableStructureParams.INVALID, TestingHeightmapParams.VALID);
+        assertThrows(IllegalArgumentException.class, params::validate);
+
+        params = new RenderLines2dTaskParams(TestingPlaceableStructureParams.VALID, TestingHeightmapParams.INVALID);
+        assertThrows(IllegalArgumentException.class, params::validate);
+
+        // All valid
+        params = new RenderLines2dTaskParams(TestingPlaceableStructureParams.VALID, TestingHeightmapParams.VALID);
+        assertDoesNotThrow(params::validate);
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/parameters/tasks/RenderLinesTaskParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/tasks/RenderLinesTaskParamsTest.java
@@ -3,9 +3,8 @@ package com.ignfab.minalac.generator.parameters.tasks;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.Test;
 
-import com.ignfab.minalac.generator.parameters.ParamsTester;
 import com.ignfab.minalac.generator.parameters.models.TestingModelSelectionParams;
-import com.ignfab.minalac.generator.parameters.placeables.structures.PlaceableStructureParams;
+import com.ignfab.minalac.generator.parameters.placeables.structures.TestingPlaceableStructureParams;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -15,21 +14,15 @@ public class RenderLinesTaskParamsTest {
     public void testValidate() throws JsonProcessingException {
         RenderLinesTaskParams params;
 
-        // Prepare invalid and valid structure params
-        PlaceableStructureParams validStruct = ParamsTester.deserialize(PlaceableStructureParams.class, "{ \"at\": [0, 0, 0], \"put\": 'A' }");
-        assertDoesNotThrow(validStruct::validate);
-        PlaceableStructureParams invalidStruct = ParamsTester.deserialize(PlaceableStructureParams.class, "{ \"axes\": [], \"with\": {}, \"blueprint\": 'A' }");
-        assertThrows(IllegalArgumentException.class, invalidStruct::validate);
-
         // Test required arguments
-        params = new RenderLinesTaskParams(validStruct);
+        params = new RenderLinesTaskParams(TestingPlaceableStructureParams.VALID);
         params.models = TestingModelSelectionParams.INVALID;
         assertThrows(IllegalArgumentException.class, params::validate);
 
-        params = new RenderLinesTaskParams(invalidStruct);
+        params = new RenderLinesTaskParams(TestingPlaceableStructureParams.INVALID);
         assertThrows(IllegalArgumentException.class, params::validate);
 
-        params = new RenderLinesTaskParams(validStruct);
+        params = new RenderLinesTaskParams(TestingPlaceableStructureParams.VALID);
         assertDoesNotThrow(params::validate);
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/processors/OsmProcessorTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/processors/OsmProcessorTest.java
@@ -1,0 +1,63 @@
+package com.ignfab.minalac.generator.processors;
+
+import java.util.List;
+
+import de.topobyte.osm4j.core.dataset.InMemoryListDataSet;
+import de.topobyte.osm4j.core.model.impl.Node;
+import de.topobyte.osm4j.core.model.impl.Tag;
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.feature.SchemaException;
+import org.geotools.referencing.CRS;
+import org.junit.jupiter.api.Test;
+
+import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
+import com.ignfab.minalac.generator.inputs.OsmData;
+import com.ignfab.minalac.generator.models.JTSGeometryModel;
+import com.ignfab.minalac.generator.utils.coordinates.TestingConverter;
+import com.ignfab.minalac.generator.voxelization.shape2d.Point2d;
+import com.ignfab.minalac.generator.voxelization.shape2d.Shape2d;
+import com.ignfab.minalac.generator.voxelization.shape3d.Point3d;
+import com.ignfab.minalac.generator.voxelization.shape3d.Shape3d;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class OsmProcessorTest {
+
+    @Test
+    public void test() throws SchemaException, FactoryException {
+        CoordinateReferenceSystem crs2154 = CRS.decode("EPSG:2154");
+        CoordinateReferenceSystem crs4326 = CRS.decode("EPSG:4326");
+        OsmProcessor processor = new OsmProcessor(TestingConverter.IDENTITY);
+
+        assertThrows(GenerationFailedException.class, () -> processor.initialize(crs2154));
+        assertDoesNotThrow(() -> processor.initialize(crs4326));
+
+        // Validate capabilities of processor
+        assertTrue(processor.acceptedType().isAssignableFrom(OsmData.class), "processor accepts OsmData");
+        assertTrue(JTSGeometryModel.class.isAssignableFrom(processor.modelType()), "processor produces JTSGeometryModel");
+
+        InMemoryListDataSet resolver = new InMemoryListDataSet();
+
+        // Construct dummy node
+        OsmData data = new OsmData(resolver, new Node(1, 2.3, 4.5, List.of(
+            new Tag("name", "toto"),
+            new Tag("job", "yes")
+        )));
+
+        // Validate processing
+        JTSGeometryModel model = assertDoesNotThrow(() -> processor.process(data));
+
+        // Validate metadata
+        assertEquals("toto", model.getMetadata("name"));
+        assertEquals("yes", model.getMetadata("job"));
+
+        // Test 2d conversion (Could be improved checking shape contains only given point)
+        Shape2d shape2d = assertDoesNotThrow(() -> model.toShape2d());
+        assertInstanceOf(Point2d.class, shape2d);
+
+        // Test 3d conversion (Could be improved checking shape contains only given point)
+        Shape3d shape3d = assertDoesNotThrow(() -> model.toShape3d());
+        assertInstanceOf(Point3d.class, shape3d);
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/tasks/RenderLines2dTaskTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/tasks/RenderLines2dTaskTest.java
@@ -1,0 +1,67 @@
+package com.ignfab.minalac.generator.tasks;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.ignfab.minalac.generator.generation.TestingGenerationTile;
+import com.ignfab.minalac.generator.generation.heightmaps.computed.ConstantHeightmap;
+import com.ignfab.minalac.generator.models.ModelSelection;
+import com.ignfab.minalac.generator.models.TestingShape2dModel;
+import com.ignfab.minalac.generator.outputs.testing.TestingVoxel;
+import com.ignfab.minalac.generator.placeables.PlaceableStructure;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
+import com.ignfab.minalac.generator.voxelization.shape2d.LineString2d;
+
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/*
+ Here we try not to test voxelization but only rendering.
+ This means that we won't test correct voxelization results but only that rendering is ok according to parameters.
+*/
+class RenderLines2dTaskTest {
+    private WorldBBox3d bbox;
+    private TestingGenerationTile tile;
+    private ModelSelection modelSelection;
+
+    @BeforeEach
+    public void setUp() {
+        // bbox must be larger than a single voxel in each dimension for tests to work
+        bbox = new WorldBBox3d(-1, -2, -3, 4, 5, 6);
+        tile = new TestingGenerationTile(bbox);
+        modelSelection = new ModelSelection("testing", null);
+    }
+
+    @Test
+    public void testConstructor() {
+        assertDoesNotThrow(() -> new RenderLines2dTask(modelSelection, PlaceableStructure.EMPTY, new ConstantHeightmap(0)));
+    }
+
+    @Test
+    public void testRender() {
+
+        tile.models().add("testing", List.of(new TestingShape2dModel(LineString2d.fromPoints(bbox.min().to2d(), bbox.max().to2d()))));
+        PlaceableStructure structure = PlaceableStructure.builder()
+            .set(new WorldCoords3d(0, 0, 0), new TestingVoxel("TEST"))
+            .build();
+
+        // Test rendering works
+        assertDoesNotThrow(() -> new RenderLines2dTask(modelSelection, structure, new ConstantHeightmap(-1)).run(tile), "Render should not throw");
+
+        // Test some voxels are rendered
+        assertDoesNotThrow(() -> {
+            for (WorldCoords3d pos : bbox)
+                if (tile.voxels().get(pos) != null)
+                    return; // Test is ok, we found a voxel!
+            throw new Exception("No voxel rendered");
+        }, "Voxel expected to be rendered");
+
+        // Test all rendered voxels are on heightmap
+        for (WorldCoords3d pos : bbox)
+            if (tile.voxels().get(pos) != null)
+                assertEquals(-1, pos.z(), "Voxel at %s expected to be on heightmap".formatted(pos));
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/voxelization/shape2d/LinearRing2dTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/voxelization/shape2d/LinearRing2dTest.java
@@ -120,7 +120,11 @@ public class LinearRing2dTest {
 
     @Test
     public void testPolygons() {
-        assertFalse(assertDoesNotThrow(ring::polygons).iterator().hasNext());
+        // Ring can be seen as a polygon, so it has only one polygon.
+        // Polygon unique line string may be inverted so we cannot compare it.
+        Iterator<Polygon2d> iter = assertDoesNotThrow(ring::polygons).iterator();
+        assertDoesNotThrow(iter::next);
+        assertFalse(iter.hasNext());
     }
 
     @Test

--- a/src/test/java/com/ignfab/minalac/generator/voxelization/shape3d/LinearRing3dTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/voxelization/shape3d/LinearRing3dTest.java
@@ -111,6 +111,10 @@ public class LinearRing3dTest {
 
     @Test
     public void testPolygons() {
-        assertFalse(assertDoesNotThrow(ring::polygons).iterator().hasNext());
+        // Ring can be seen as a polygon, so it has only one polygon.
+        // Polygon unique line string may be inverted so we cannot compare it.
+        Iterator<Polygon3d> iter = assertDoesNotThrow(ring::polygons).iterator();
+        assertDoesNotThrow(iter::next);
+        assertFalse(iter.hasNext());
     }
 }


### PR DESCRIPTION
### Changes

Adds new Overpass provider and processor.

#### Feature description

It uses OSM4J library to transform Overpass data into geometries.

This PR also adds a simple 2d line drawing task (we only add 3d line drawing task).

### Reason

That feature was in former generator version.

### Self-checks

- [x] The code has unit tests associated
- [x] The code has Javadoc Comments associated
- [x] Complex / Unexpected code is explained / justified with a small comment
- [x] Relevant documentation inside the `/docs` folder has been updated
- [x] All examples in `examples/` work the same (or have been adapted if subject to changes in this PR)
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [x] The texts have been proofread (documentation, error messages, logs, comments...)
