### PR TITLE
fix(geotiff): Enable GeoTools hint to force longitude-first axis order

### DIFF
--- a/src/main/java/com/ignfab/minalac/generator/inputs/GeoTiffDataProvider.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/GeoTiffDataProvider.java
@@ -50,7 +50,11 @@ public class GeoTiffDataProvider implements Provider<FloatGeographicDataMatrix2d
     public Provider.Result<FloatGeographicDataMatrix2d> provide(WorldBBox3d bbox) throws GenerationFailedException, RetryableException {
         GridCoverage2D grid;
         try {
-            grid = new GeoTiffReader(file, crsOverride == null ? null : new Hints(Hints.DEFAULT_COORDINATE_REFERENCE_SYSTEM, crsOverride)).read();
+            // This hint must remain enabled
+            Hints hints = new Hints(Hints.FORCE_LONGITUDE_FIRST_AXIS_ORDER, true);
+            if (crsOverride != null)
+                hints.put(Hints.DEFAULT_COORDINATE_REFERENCE_SYSTEM, crsOverride);
+            grid = new GeoTiffReader(file, hints).read();
         } catch (IOException e) {
             throw new RetryableException(e);
         }


### PR DESCRIPTION
### Type of modification


- Code
  - Inputs

### Issue

Closes #187

### Changes

This PR fixes an issue when loading GeoTiff files in EPSG:4326.

#### Feature description

The `FORCE_LONGITUDE_FIRST_AXIS_ORDER` hint from GeoTools was missing on the `GeoTiffReader`, causing issue with EPSG:4326 data (and maybe other CRS based on longitude/latitude coordinates).

It was initially enabled, but got disabled by mistake when the `crsOverride` option was added. See details about how it happened in the related issue.

#### Showcase

Find the MRE in the related issue. With this fix, no exception occurs.

### Reason

This was a mistake.

### TODOs

We could try to add unit tests for all providers with sample data (at least for local data providers).

### Self-checks

- [ ] The code has unit tests associated
- [x] The code has Javadoc Comments associated
- [x] Complex / Unexpected code is explained / justified with a small comment
- ~~Relevant documentation inside the `/docs` folder has been updated~~
- ~~All examples in `examples/` work the same (or have been adapted if subject to changes in this PR)~~
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [x] The texts have been proofread (documentation, error messages, logs, comments...)
