### PR TITLE
Add `renderPoints` and `renderPoints2d`

### DIFF
--- a/docs/usage/parameters/TileTasks.md
+++ b/docs/usage/parameters/TileTasks.md
@@ -15,6 +15,7 @@ Each task has a `type`, optional dependencies to other tasks (in `after`), and o
 * [Tasks operating on world](#tasks-operating-on-world)
   * [`renderHeightmap`](#renderheightmap)
   * [`renderLines`](#renderlines)
+  * [`renderPoints`](#renderpoints)
   * [`renderSurfaces`](#rendersurfaces)
   * [`fillBetweenHeightmapAndMetadata`](#fillbetweenheightmapandmetadata)
   * [`renderBuildings`](#renderbuildings)
@@ -158,6 +159,24 @@ Three-dimensional structures can be used and same rules apply. X-axis is repeate
 The blueprint shows five successive vertical slices of the structure. This will form a sort of long building with windows:
 
 ![Several long building-like structures with glass window, stone top and bottom, floating in the air](img/render-line-zyx.png)
+
+### `renderPoints`
+
+Renders 3d points as a placeable. 
+
+#### Extra parameters
+
+- `models`: [Selection of models](ModelSelection.md) to render (required, models must be convertible to 3d shapes)
+- `place`: [Placeable](Placeables.md) to use (required)
+
+#### Example
+
+```yaml
+type: renderPoints
+models:
+  type: points
+place: default:stone
+```
 
 ### `renderSurfaces`
 

--- a/src/main/java/com/ignfab/minalac/generator/MinalacGenerator.java
+++ b/src/main/java/com/ignfab/minalac/generator/MinalacGenerator.java
@@ -48,6 +48,8 @@ import com.ignfab.minalac.generator.parameters.tasks.RenderBuildingsTaskParams;
 import com.ignfab.minalac.generator.parameters.tasks.RenderHeightmapTaskParams;
 import com.ignfab.minalac.generator.parameters.tasks.RenderLines2dTaskParams;
 import com.ignfab.minalac.generator.parameters.tasks.RenderLinesTaskParams;
+import com.ignfab.minalac.generator.parameters.tasks.RenderPoints2dTaskParams;
+import com.ignfab.minalac.generator.parameters.tasks.RenderPointsTaskParams;
 import com.ignfab.minalac.generator.parameters.tasks.RenderSurfacesTaskParams;
 import com.ignfab.minalac.generator.parameters.tasks.ScheduleTaskParams;
 import com.ignfab.minalac.generator.parameters.tasks.SequenceTaskParams;
@@ -120,6 +122,8 @@ public final class MinalacGenerator {
         parser.registerParams("renderSurfaces", RenderSurfacesTaskParams.class);
         parser.registerParams("renderLines", RenderLinesTaskParams.class);
         parser.registerParams("renderLines2d", RenderLines2dTaskParams.class);
+        parser.registerParams("renderPoints", RenderPointsTaskParams.class);
+        parser.registerParams("renderPoints2d", RenderPoints2dTaskParams.class);
         parser.registerParams("setSpawn", SetSpawnTaskParams.class);
 
         parser.registerParams("wfs", WFSProviderParams.class);

--- a/src/main/java/com/ignfab/minalac/generator/parameters/tasks/RenderPoints2dTaskParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/tasks/RenderPoints2dTaskParams.java
@@ -1,0 +1,58 @@
+package com.ignfab.minalac.generator.parameters.tasks;
+
+import java.beans.ConstructorProperties;
+
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.parameters.heightmaps.ReadableHeightmapParams;
+import com.ignfab.minalac.generator.parameters.placeables.PlaceableParams;
+import com.ignfab.minalac.generator.tasks.RenderPoints2dTask;
+import com.ignfab.minalac.generator.utils.execution.Task;
+
+/**
+ * Parameters for {@link RenderPoints2dTask}.
+ */
+public class RenderPoints2dTaskParams extends ModelTaskParams {
+
+    /**
+     * Placeable to place at points (required).
+     */
+    @JsonSetter(nulls = Nulls.FAIL)
+    private PlaceableParams place;
+
+    /**
+     * Heightmap on which to draw points (required).
+     */
+    @JsonSetter(nulls = Nulls.FAIL)
+    private ReadableHeightmapParams heightmap;
+
+    /**
+     * Constructor used to ensure that the required fields are present during deserialization.
+     *
+     * @param place placeable to place at points
+     * @param heightmap heightmap on which to draw points
+     */
+    @ConstructorProperties({"place", "heightmap"})
+    public RenderPoints2dTaskParams(PlaceableParams place, ReadableHeightmapParams heightmap) {
+        this.place = place;
+        this.heightmap = heightmap;
+    }
+
+    @Override
+    public void validate() throws IllegalArgumentException {
+        super.validate();
+        place.validate();
+        heightmap.validate();
+    }
+
+    @Override
+    public Task create(Generation generation) {
+        return new RenderPoints2dTask(
+            models.create(),
+            place.create(generation.seed()),
+            heightmap.create(generation.heightmaps())
+        );
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/parameters/tasks/RenderPointsTaskParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/tasks/RenderPointsTaskParams.java
@@ -1,0 +1,47 @@
+package com.ignfab.minalac.generator.parameters.tasks;
+
+import java.beans.ConstructorProperties;
+
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.parameters.placeables.PlaceableParams;
+import com.ignfab.minalac.generator.tasks.RenderPointsTask;
+import com.ignfab.minalac.generator.utils.execution.Task;
+
+/**
+ * Parameters for {@link RenderPointsTask}.
+ */
+public class RenderPointsTaskParams extends ModelTaskParams {
+
+    /**
+     * Placeable to place at points (required).
+     */
+    @JsonSetter(nulls = Nulls.FAIL)
+    private PlaceableParams place;
+
+    /**
+     * Constructor used to ensure that the required fields are present during deserialization.
+     *
+     * @param place placeable to place at points
+     */
+    @ConstructorProperties({"place"})
+    public RenderPointsTaskParams(PlaceableParams place) {
+        this.place = place;
+    }
+
+    @Override
+    public void validate() throws IllegalArgumentException {
+        super.validate();
+        place.validate();
+    }
+
+    @Override
+    public Task create(Generation generation) {
+        return new RenderPointsTask(
+            models.create(),
+            place.create(generation.seed())
+        );
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/tasks/RenderPoints2dTask.java
+++ b/src/main/java/com/ignfab/minalac/generator/tasks/RenderPoints2dTask.java
@@ -1,0 +1,47 @@
+package com.ignfab.minalac.generator.tasks;
+
+import com.ignfab.minalac.generator.generation.GenerationTile;
+import com.ignfab.minalac.generator.generation.heightmaps.ReadableHeightmap;
+import com.ignfab.minalac.generator.generation.heightmaps.ReadableHeightmapSpec;
+import com.ignfab.minalac.generator.models.ModelSelection;
+import com.ignfab.minalac.generator.models.Shape2dConvertibleModel;
+import com.ignfab.minalac.generator.placeables.Placeable;
+import com.ignfab.minalac.generator.utils.world2d.Positioned2d;
+import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
+import com.ignfab.minalac.generator.voxelization.shape2d.voxelizer.Point2dVoxelizer;
+
+/**
+ * A task rendering points by placing placeables at them.
+ */
+public class RenderPoints2dTask extends ModelTask<Shape2dConvertibleModel> {
+    private final Placeable placeable;
+    private final ReadableHeightmapSpec heightmapSpec;
+    private final Point2dVoxelizer voxelizer;
+
+    /**
+     * Creates a new {@code RenderPoints2dTask}.
+     *
+     * @param selection selection of models to render
+     * @param placeable placeable placed at the points
+     * @param heightmapSpec heightmap on which draw points
+     */
+    public RenderPoints2dTask(
+        ModelSelection selection,
+        Placeable placeable,
+        ReadableHeightmapSpec heightmapSpec
+    ) {
+        super(Shape2dConvertibleModel.class, selection);
+        this.placeable = placeable;
+        this.heightmapSpec = heightmapSpec;
+        voxelizer = new Point2dVoxelizer();
+    }
+
+    @Override
+    protected void run(Shape2dConvertibleModel model, GenerationTile tile) {
+        ReadableHeightmap heightmap = tile.heightmap(heightmapSpec);
+        for (Positioned2d point : voxelizer.voxelize(model)) {
+            WorldCoords2d pos = point.coords();
+            placeable.place(tile.voxels(), pos.x(), pos.y(), heightmap.get(pos));
+        }
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/tasks/RenderPointsTask.java
+++ b/src/main/java/com/ignfab/minalac/generator/tasks/RenderPointsTask.java
@@ -1,0 +1,37 @@
+package com.ignfab.minalac.generator.tasks;
+
+import com.ignfab.minalac.generator.generation.GenerationTile;
+import com.ignfab.minalac.generator.models.ModelSelection;
+import com.ignfab.minalac.generator.models.Shape3dConvertibleModel;
+import com.ignfab.minalac.generator.placeables.Placeable;
+import com.ignfab.minalac.generator.utils.world3d.Positioned3d;
+import com.ignfab.minalac.generator.voxelization.shape3d.voxelizer.Point3dVoxelizer;
+
+/**
+ * A task rendering points by placing placeables at them.
+ */
+public class RenderPointsTask extends ModelTask<Shape3dConvertibleModel> {
+    private final Placeable placeable;
+    private final Point3dVoxelizer voxelizer;
+
+    /**
+     * Creates a new {@code RenderPointsTask}.
+     *
+     * @param selection selection of models to render
+     * @param placeable placeable placed at the points
+     */
+    public RenderPointsTask(
+        ModelSelection selection,
+        Placeable placeable
+    ) {
+        super(Shape3dConvertibleModel.class, selection);
+        this.placeable = placeable;
+        voxelizer = new Point3dVoxelizer();
+    }
+
+    @Override
+    protected void run(Shape3dConvertibleModel model, GenerationTile tile) {
+        for (Positioned3d point : voxelizer.voxelize(model))
+            placeable.place(tile.voxels(), point.coords());
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/voxelization/shape2d/voxelizer/Point2dVoxelizer.java
+++ b/src/main/java/com/ignfab/minalac/generator/voxelization/shape2d/voxelizer/Point2dVoxelizer.java
@@ -1,0 +1,14 @@
+package com.ignfab.minalac.generator.voxelization.shape2d.voxelizer;
+
+import com.ignfab.minalac.generator.utils.world2d.Positioned2d;
+import com.ignfab.minalac.generator.voxelization.shape2d.Shape2dConvertible;
+
+/**
+ * A voxelizer that returns the points of a 2D shape.
+ */
+public class Point2dVoxelizer implements Shape2dVoxelizer {
+    @Override
+    public Iterable<? extends Positioned2d> voxelize(Shape2dConvertible convertible) {
+        return convertible.toShape2d().points();
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/voxelization/shape3d/voxelizer/Point3dVoxelizer.java
+++ b/src/main/java/com/ignfab/minalac/generator/voxelization/shape3d/voxelizer/Point3dVoxelizer.java
@@ -1,0 +1,14 @@
+package com.ignfab.minalac.generator.voxelization.shape3d.voxelizer;
+
+import com.ignfab.minalac.generator.utils.world3d.Positioned3d;
+import com.ignfab.minalac.generator.voxelization.shape3d.Shape3dConvertible;
+
+/**
+ * A voxelizer that returns the points of a 3D shape.
+ */
+public class Point3dVoxelizer implements Shape3dVoxelizer {
+    @Override
+    public Iterable<? extends Positioned3d> voxelize(Shape3dConvertible convertible) {
+        return convertible.toShape3d().points();
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/parameters/tasks/RenderPoints2dTaskParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/tasks/RenderPoints2dTaskParamsTest.java
@@ -1,0 +1,32 @@
+package com.ignfab.minalac.generator.parameters.tasks;
+
+import org.junit.jupiter.api.Test;
+
+import com.ignfab.minalac.generator.parameters.heightmaps.TestingHeightmapParams;
+import com.ignfab.minalac.generator.parameters.models.TestingModelSelectionParams;
+import com.ignfab.minalac.generator.parameters.placeables.structures.TestingPlaceableStructureParams;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class RenderPoints2dTaskParamsTest {
+
+    @Test
+    public void testValidate() {
+        RenderPoints2dTaskParams params;
+
+        // Check any invalid member makes validation throw
+        params = new RenderPoints2dTaskParams(TestingPlaceableStructureParams.VALID, TestingHeightmapParams.VALID);
+        params.models = TestingModelSelectionParams.INVALID;
+        assertThrows(IllegalArgumentException.class, params::validate);
+
+        params = new RenderPoints2dTaskParams(TestingPlaceableStructureParams.INVALID, TestingHeightmapParams.VALID);
+        assertThrows(IllegalArgumentException.class, params::validate);
+
+        params = new RenderPoints2dTaskParams(TestingPlaceableStructureParams.VALID, TestingHeightmapParams.INVALID);
+        assertThrows(IllegalArgumentException.class, params::validate);
+
+        // All valid
+        params = new RenderPoints2dTaskParams(TestingPlaceableStructureParams.VALID, TestingHeightmapParams.VALID);
+        assertDoesNotThrow(params::validate);
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/parameters/tasks/RenderPointsTaskParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/tasks/RenderPointsTaskParamsTest.java
@@ -1,0 +1,28 @@
+package com.ignfab.minalac.generator.parameters.tasks;
+
+import org.junit.jupiter.api.Test;
+
+import com.ignfab.minalac.generator.parameters.models.TestingModelSelectionParams;
+import com.ignfab.minalac.generator.parameters.placeables.structures.TestingPlaceableStructureParams;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class RenderPointsTaskParamsTest {
+
+    @Test
+    public void testValidate() {
+        RenderPointsTaskParams params;
+
+        // Check any invalid member makes validation throw
+        params = new RenderPointsTaskParams(TestingPlaceableStructureParams.VALID);
+        params.models = TestingModelSelectionParams.INVALID;
+        assertThrows(IllegalArgumentException.class, params::validate);
+
+        params = new RenderPointsTaskParams(TestingPlaceableStructureParams.INVALID);
+        assertThrows(IllegalArgumentException.class, params::validate);
+
+        // All valid
+        params = new RenderPointsTaskParams(TestingPlaceableStructureParams.VALID);
+        assertDoesNotThrow(params::validate);
+    }
+}


### PR DESCRIPTION
### Issue

#192 

### Changes

Add two renderers which rendering points as a structure.

#### Showcase

Example with trees renderer:
<img width="2560" height="1505" alt="image" src="https://github.com/user-attachments/assets/6165ca71-ffc0-4f89-aed7-71c81abac577" />
<img width="2560" height="1506" alt="image" src="https://github.com/user-attachments/assets/28771efd-12e4-44a4-ad20-62e654964fce" />
<img width="1055" height="920" alt="image" src="https://github.com/user-attachments/assets/514ad557-27bb-4e27-9132-3925792bd5cc" />

### Reason

OSM data give some data like a point (e.g: tree, public sit, ...)

### Self-checks

- [x] The code has unit tests associated
- [x] The code has Javadoc Comments associated
- [x] Complex / Unexpected code is explained / justified with a small comment
- [x] Relevant documentation inside the `/docs` folder has been updated
- [x] All examples in `examples/` work the same (or have been adapted if subject to changes in this PR)
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [ ] The texts have been proofread (documentation, error messages, logs, comments...)
