### PR TITLE
fix(model-store): Synchronize "add" method to prevent concurrent modification exception

### DIFF
--- a/src/main/java/com/ignfab/minalac/generator/models/ModelStore.java
+++ b/src/main/java/com/ignfab/minalac/generator/models/ModelStore.java
@@ -19,9 +19,12 @@ public class ModelStore {
      * @param type Type to associate with stored models
      * @param models Models to be stored
      */
-    public void add(String type, List<Model> models) {
+    // The method is synchronized to prevent concurrent modification exception
+    public synchronized void add(String type, List<Model> models) {
         if (type == null || type.isEmpty())
             throw new IllegalArgumentException("Type must be a non empty string");
+        if (models.isEmpty())
+            return;
 
         byType.computeIfAbsent(type, k -> new ArrayList<>()).addAll(models);
     }


### PR DESCRIPTION
### Changes

This PR fixes a race condition that can cause the `ModelStore#add` method to throw a `ConcurrentModificationException`.

#### Feature description

When multiple `fetchData` tasks finishes simultaneously (which is unlikely but when they have no dependency and their provider returns no data it increases the chances of it to occur), they calls the `ModelStore#add` method simultaneously, which will modify the store concurrently and cause the exception to be thrown. Synchronizing the method resolves the issue.

In addition, when an empty list of models is added to the store, is it unnecessary to register it. An early-return has been added to cover this scenario.

### Reason

The exception could cause random generation failure.

This method is called only once per `fetchData` task, so synchronizing it completely is rather insignificant related to performances impact.

### Self-checks

- ~~The code has unit tests associated~~
- [x] The code has Javadoc Comments associated
- [x] Complex / Unexpected code is explained / justified with a small comment
- ~~Relevant documentation inside the `/docs` folder has been updated~~
- [x] All examples in `examples/` work the same (or have been adapted if subject to changes in this PR)
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [x] The texts have been proofread (documentation, error messages, logs, comments...)
