### PR TITLE
Fix WMS shift and margins

### DIFF
--- a/src/main/java/com/ignfab/minalac/generator/generation/Generation.java
+++ b/src/main/java/com/ignfab/minalac/generator/generation/Generation.java
@@ -159,16 +159,13 @@ public class Generation {
     public ReferencedEnvelope getEnvelopeForCRS(CoordinateReferenceSystem crs, WorldBBox3d bbox) throws FactoryException, TransformException {
         WorldToMapConverter converter = makeCoordsConverter(crs).inverse();
 
-        int minX = bbox.minX();
-        int minY = bbox.minY();
-        int maxX = bbox.maxX() + 1;
-        int maxY = bbox.maxY() + 1;
+        // We include whole voxels surface (so +/- 0.5 around centers)
         Geometry geom = new GeometryFactory().createLinearRing(new Coordinate[] {
-            new Coordinate(minX, minY),
-            new Coordinate(maxX, minY),
-            new Coordinate(maxX, maxY),
-            new Coordinate(minX, maxY),
-            new Coordinate(minX, minY)
+            new Coordinate(bbox.minX() - 0.5, bbox.minY() - 0.5),
+            new Coordinate(bbox.maxX() + 0.5, bbox.minY() - 0.5),
+            new Coordinate(bbox.maxX() + 0.5, bbox.maxY() + 0.5),
+            new Coordinate(bbox.minX() - 0.5, bbox.maxY() + 0.5),
+            new Coordinate(bbox.minX() - 0.5, bbox.minY() - 0.5)
         });
 
         return new ReferencedEnvelope(converter.convert(geom).getEnvelopeInternal(), crs);

--- a/src/main/java/com/ignfab/minalac/generator/inputs/GeographicDataMatrix2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/GeographicDataMatrix2d.java
@@ -31,11 +31,15 @@ public interface GeographicDataMatrix2d<T> {
 
     /**
      * {@return x-axis component of geographical offset}
+     *
+     * Beware, the offset should be relative to cells (pixels) centers, not corners.
      */
     double offsetX();
 
     /**
      * {@return y-axis component of geographical offset}
+     *
+     * Beware, the offset should be relative to cells (pixels) centers, not corners.
      */
     double offsetY();
 

--- a/src/main/java/com/ignfab/minalac/generator/inputs/WMSFloatBilDataProvider.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/WMSFloatBilDataProvider.java
@@ -14,6 +14,7 @@ import org.geotools.referencing.CRS;
 import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
 import com.ignfab.minalac.generator.exceptions.RetryableException;
 import com.ignfab.minalac.generator.exceptions.TransformException;
+import com.ignfab.minalac.generator.utils.Rounding;
 import com.ignfab.minalac.generator.utils.coordinates.EnvelopeProvider;
 import com.ignfab.minalac.generator.utils.iterator.Iterators;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
@@ -71,23 +72,35 @@ public class WMSFloatBilDataProvider implements Provider<FloatGeographicDataMatr
             throw new GenerationFailedException(e);
         }
 
-        // Let's say we want heightmap with 1 map unit precision.
-        // TODO: Should computed from capabilities and voxel size in realworld
+        // Pixel size in map units
+        // TODO: Should be computed from capabilities and voxel size in realworld
         // (we don't need information more accurate than voxel size neither information more
         // accurate than capabilities)
-        int width  = (int) Math.round(envelope.getMaxX() - envelope.getMinX());
-        int height = (int) Math.round(envelope.getMaxY() - envelope.getMinY());
+        double pixelSize = 1;
 
+        // This is the WMS bbox expressed in map coordinates.
+        // It is used below to deduce matrix offset and cell size.
+        // WMS matrix is aligned in the same way in all tiles (use of floor/ceil).
+        // This prevents glitches between tiles.
+
+        // We need margin for interpolation (-1/+1 expressed in pixelSize)
+        // TODO: Margin size should come from processor (may be with PR#123?)
+        double minX = Rounding.floor(envelope.getMinX(), pixelSize, -1);
+        double minY = Rounding.floor(envelope.getMinY(), pixelSize, -1);
+        double maxX = Rounding.ceil(envelope.getMaxX(), pixelSize, 1);
+        double maxY = Rounding.ceil(envelope.getMaxY(), pixelSize, 1);
+
+        // Formulas give integer numbers, we round them to avoid surprises with floating points
+        int width  = (int) Math.round((maxX - minX) / pixelSize);
+        int height = (int) Math.round((maxY - minY) / pixelSize);
+
+        // Perform WMS query
         ParameterizedURL url = baseURL.builder()
             .parameter("CRS", srsName)
-            .parameter("BBOX", envelope.getMinX()
-                + "," + envelope.getMinY()
-                + "," + envelope.getMaxX()
-                + "," + envelope.getMaxY())
+            .parameter("BBOX", minX + "," + minY + "," + maxX + "," + maxY)
             .parameter("WIDTH", width)
             .parameter("HEIGHT", height)
             .build();
-
         InputStream inputStream;
         try {
             inputStream = url.toURL().openStream();
@@ -97,6 +110,7 @@ public class WMSFloatBilDataProvider implements Provider<FloatGeographicDataMatr
             throw new RetryableException("Error opening connection", e);
         }
 
+        // Read resulting binary data
         int size = 4 * width * height;
         int total = 0;
 
@@ -116,15 +130,9 @@ public class WMSFloatBilDataProvider implements Provider<FloatGeographicDataMatr
         if (total != size)
             throw new RetryableException("Incomplete data read from stream");
 
-        FloatArrayGeographicDataMatrix2d result = new FloatArrayGeographicDataMatrix2d(
-            width,
-            height,
-            envelope.getMinX(),
-            envelope.getMinY(),
-            envelope.getWidth() / width,
-            envelope.getHeight() / height
-        );
+        FloatArrayGeographicDataMatrix2d result = new FloatArrayGeographicDataMatrix2d(width, height, minX, minY, pixelSize, pixelSize);
 
+        // Decode binary data into float matrix
         ByteBuffer.wrap(data).order(ByteOrder.LITTLE_ENDIAN).asFloatBuffer().get(result.data());
 
         return new SimpleResult<>(crs, Iterators.iterator(result));

--- a/src/main/java/com/ignfab/minalac/generator/models/FloatMatrixModel.java
+++ b/src/main/java/com/ignfab/minalac/generator/models/FloatMatrixModel.java
@@ -62,8 +62,9 @@ public class FloatMatrixModel extends ModelImpl implements Matrix2d<Float> {
             return null;
         }
 
-        float x = (float) ((coordinates.x() - data.offsetX()) / data.cellSizeX());
-        float y = (float) ((coordinates.y() - data.offsetY()) / data.cellSizeY());
+        // We interpolate between cell centers (not cell upper left corner)
+        float x = (float) ((coordinates.x() + 0.5 - data.offsetX()) / data.cellSizeX() - 0.5);
+        float y = (float) ((coordinates.y() + 0.5 - data.offsetY()) / data.cellSizeY() - 0.5);
 
         // Using separate ceil & floor allows a good management of integer coordinates
         int xf = (int) Math.floor(x);

--- a/src/main/java/com/ignfab/minalac/generator/parameters/tasks/PopulateHeightmapTaskParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/tasks/PopulateHeightmapTaskParams.java
@@ -40,7 +40,8 @@ public class PopulateHeightmapTaskParams extends ModelTaskParams {
     public TileTask create(Generation generation) {
         return new PopulateHeightmapTask(
             models.create(),
-            heightmap.create(generation.heightmaps())
+            heightmap.create(generation.heightmaps()),
+            generation.getVerticalScale()
         );
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/tasks/PopulateHeightmapTask.java
+++ b/src/main/java/com/ignfab/minalac/generator/tasks/PopulateHeightmapTask.java
@@ -15,16 +15,20 @@ import com.ignfab.minalac.generator.voxelization.Matrix2d;
  */
 public class PopulateHeightmapTask extends ModelTask<FloatMatrixModel> {
     private final WritableHeightmapSpec heightmapSpec;
+    private final double verticalScale;
 
     /**
      * Creates a new {@code PopulateHeightmapTask}.
      *
      * @param selection the model selection containing the wanted models
      * @param heightmapSpec Spec of writable heightmap where heights will be written
+     * @param verticalScale Vertical factor to apply on heights
      */
-    public PopulateHeightmapTask(ModelSelection selection, WritableHeightmapSpec heightmapSpec) {
+    // TODO: verticalScale maybe better applyed by model processor?
+    public PopulateHeightmapTask(ModelSelection selection, WritableHeightmapSpec heightmapSpec, double verticalScale) {
         super(FloatMatrixModel.class, selection);
         this.heightmapSpec = heightmapSpec;
+        this.verticalScale = verticalScale;
     }
 
     @Override
@@ -35,7 +39,7 @@ public class PopulateHeightmapTask extends ModelTask<FloatMatrixModel> {
         for (Matrix2d.Value<Float> value : model) {
             WorldCoords2d c = value.coords();
             if (intersection.contains(c))
-                heightmap.set(c, Math.round(value.value()));
+                heightmap.set(c, (int) Math.round(value.value() / verticalScale));
         }
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/utils/Rounding.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/Rounding.java
@@ -1,0 +1,77 @@
+package com.ignfab.minalac.generator.utils;
+
+/**
+ * Some advanced rounding helpers.
+ * <p>
+ * This class provides helpers for rounding not only to integers but to larger or smaller gaps.
+ * For example, a gap of 2 rounds to even numbers.
+ * A gap of 1 makes these function identical to those in Math class.
+ */
+public final class Rounding {
+    private Rounding() {}
+
+    /**
+     * {@return closest number to {@code number} divisible by {@code gap}}
+     *
+     * @param number number to round
+     * @param gap rounding gap
+     */
+    public static double round(double number, double gap) {
+        return round(number, gap, 0);
+    }
+
+    /**
+     * {@return closest number to {@code number} divisible by {@code gap} with {@code offset} gaps added}
+     *
+     * @param number number to round
+     * @param gap rounding gap
+     * @param offset number of gaps to add to result
+     */
+    public static double round(double number, double gap, int offset) {
+        return (Math.round(number / gap) + offset) * gap;
+    }
+
+    /**
+     * {@return largest number less than or equals to {@code number} and divisible by {@code gap}}
+     *
+     * @param number number to round
+     * @param gap rounding gap
+     */
+    public static double floor(double number, double gap) {
+        return floor(number, gap, 0);
+    }
+
+    /**
+     * {@return largest number less than or equals to {@code number} and divisible by {@code gap} with {@code offset} gaps added}
+     *
+     * @param number number to round
+     * @param gap rounding gap
+     * @param offset number of gaps to add to result
+     */
+    public static double floor(double number, double gap, int offset) {
+        return (Math.floor(number / gap) + offset) * gap;
+    }
+
+    /**
+     * {@return smallest number greater than or equals to {@code number} and divisible by {@code gap}}
+     *
+     * @param number number to round
+     * @param gap rounding gap
+     */
+
+    public static double ceil(double number, double gap) {
+        return ceil(number, gap, 0);
+    }
+
+    /**
+     * {@return smallest number greater than or equals to {@code number} and divisible by {@code gap} with {@code offset} gaps added}
+     *
+     * @param number number to round
+     * @param gap rounding gap
+     * @param offset number of gaps to add to result
+     */
+
+    public static double ceil(double number, double gap, int offset) {
+        return (Math.ceil(number / gap) + offset) * gap;
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/generation/TestGeneration.java
+++ b/src/test/java/com/ignfab/minalac/generator/generation/TestGeneration.java
@@ -50,18 +50,18 @@ public class TestGeneration {
         Generation generation = new Generation(world, seed, crs2154, x2154, y2154, 500, 500, 2.0, 3.0, 0.5 * Math.PI, 500);
 
         assertEquals(seed, generation.seed());
+
+        // Size of the world expected to be given extents
         WorldBBox3d box = generation.world().limits();
-        assertEquals(-250, box.minX());
-        assertEquals(-250, box.minY());
-        assertEquals(249, box.maxX());
-        assertEquals(249, box.maxY());
+        assertEquals(500, box.sizeX());
+        assertEquals(500, box.sizeY());
 
         // We should have an envelope +/- 500 around center (250 voxel * 2.0 meters/voxels = 500m)
         Envelope envelope = generation.getEnvelopeForCRS(crs2154, box);
-        assertEquals(657_280.0, envelope.getMinX(), 2);
-        assertEquals(6_860_230.0, envelope.getMinY(), 2);
-        assertEquals(658_280.0, envelope.getMaxX(), 2);
-        assertEquals(6_861_230.0, envelope.getMaxY(), 2);
+        assertEquals(x2154 - 500.0, envelope.getMinX(), 2);
+        assertEquals(y2154 - 500.0, envelope.getMinY(), 2);
+        assertEquals(x2154 + 500.0, envelope.getMaxX(), 2);
+        assertEquals(y2154 + 500.0, envelope.getMaxY(), 2);
 
         // Try another CRS
         envelope = generation.getEnvelopeForCRS(crs4326, box);

--- a/src/test/java/com/ignfab/minalac/generator/models/FloatMatrixModelTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/models/FloatMatrixModelTest.java
@@ -62,7 +62,11 @@ public class FloatMatrixModelTest {
             -1.0f, 1.0f,
             -3.0f, 5.0f,
         };
-        FloatGeographicDataMatrix2d data = new FloatArrayGeographicDataMatrix2d(values, 2, 2, 0.0, 0.0, 10.0, 10.0);
+
+        // Beware, interpolation is between cells centers, not cells upper left corner, at voxel center, not voxel upper left corner
+        // So we have an offset of -5/-5 for a cell size of 10
+        // and 0.5/0.5 for voxel size in order to have valid interpolable values between [0-10],[0-10].
+        FloatGeographicDataMatrix2d data = new FloatArrayGeographicDataMatrix2d(values, 2, 2, -4.5, -4.5, 10.0, 10.0);
 
         FloatMatrixModel model = new FloatMatrixModel(data, converter);
         // Borders

--- a/src/test/java/com/ignfab/minalac/generator/tasks/PopulateHeightmapTaskTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/tasks/PopulateHeightmapTaskTest.java
@@ -40,17 +40,17 @@ public class PopulateHeightmapTaskTest {
         tile.models().add("matrix", List.of(model));
         ModelSelection selection = new ModelSelection("matrix", null);
 
-        new PopulateHeightmapTask(selection, heightmap.spec()).run(tile);
+        new PopulateHeightmapTask(selection, heightmap.spec(), 0.5).run(tile);
 
         assertValue(0, heightmap, -1, -2);
         assertValue(0, heightmap, 0, -2);
         assertValue(0, heightmap, 1, -2);
         assertValue(0, heightmap, -1, -1);
-        assertValue(1, heightmap, 0, -1);
-        assertValue(2, heightmap, 1, -1);
+        assertValue(2, heightmap, 0, -1);
+        assertValue(4, heightmap, 1, -1);
         assertValue(0, heightmap, -1, 0);
-        assertValue(4, heightmap, 0, 0);
-        assertValue(5, heightmap, 1, 0);
+        assertValue(8, heightmap, 0, 0);
+        assertValue(10, heightmap, 1, 0);
     }
 
     private void assertValue(int expected, ReadableHeightmap heightmap, int x, int y) {


### PR DESCRIPTION
### Changes

Fix a bug in WMS processing when angle was not 0/90/180/270. In corners 

#### Technical changes

* Fixes a 0.5 voxel shift in FloatMatrixes
* Adds a 1 map unit margin around FloatMatrixes necessary for interpolation

### TODOs

(later) : Makes processor tell provider which margin it needs for interpolation (hardcoded for now)

### Self-checks

- ~~The code has unit tests associated~~
- ~~The code has Javadoc Comments associated~~
- ~~Complex / Unexpected code is explained / justified with a small comment~~
- ~~Relevant documentation inside the `/docs` folder has been updated~~
- ~~All examples in `examples/` work the same (or have been adapted if subject to changes in this PR)~~
- [X] Git history is clean (each commit accomplish a single task and describe it accordingly)
- ~~The texts have been proofread (documentation, error messages, logs, comments...)~~
