### PR TITLE
Add Layouts and `renderFacade` task

### DIFF
--- a/docs/usage/parameters/Layout.md
+++ b/docs/usage/parameters/Layout.md
@@ -1,0 +1,90 @@
+
+# Layout
+
+Layout is a kind of structure that can resize itself to fit a requested space. 
+
+## Table of contents
+
+* [Stretchable Layout](#stretchable-layout)
+* [Repeat Layout](#repeat-layout)
+* [Concatenate Layout](#concatenate-layout)
+
+## Stretchable Layout
+
+Makes a structure stretchable by having one band per axis (row, column or layer) that gets repeated or ommited to fit the requested size.
+
+```yaml
+structure:
+  axes: x
+  blueprint: "rvb"
+  with:
+    "r": wool:red
+    "v": wool:green
+    "b": wool:blue
+stretchableAlongX:
+  at: 2
+  atLeast: 2
+  atMost: 5
+stretchableAlongY:
+  at: 1
+```
+
+Fields:
+  - `structure` (required) : The structure to make stretchable
+  - `stretchableAlongX` (optional): Strech parameters along x-axis. Leaving it out keeps that axis fixed.
+  - `stretchableAlongY` (optional): Strech parameters along y-axis. Leaving it out keeps that axis fixed.
+  - `stretchableAlongZ` (optional): Strech parameters along z-axis. Leaving it out keeps that axis fixed.
+
+Each `stretchableAlong` have:
+  - `at` (required): coordinate of the band to stretch
+  - `atLeast` (optional, default `1`): Minimum repetition of the band. `0` allows squeezing.
+  - `atMost` (optional, default `infinite`): Maximum repetition of the band.
+
+## Repeat Layout
+
+Repeats a layout along a given axis. If the repeated layout is resizable on that axis, 
+the repeated may be stretched to fill the requested size.
+
+```yaml
+repeat: otherLayout
+along: x
+atLeast: 1
+atMost: 2
+```
+
+Fields:
+  - `repeat` (required): The layout to repeat. 
+  - `along` (required): Axis which the layout is repeated (`x`, `y` or `z`)
+  - `atLeast` (optional, default `1`): Minimum repetition of repetition. `0` allows the layout to be empty.
+  - `atMost` (optional, default `infinite`): Maximum repetition of the layout.
+
+## Concatenate Layout
+
+Places several layout side by side on a given axis. 
+Available space is distributed by priority.
+Layout having the same priority get space distributed as evenly as possibly.
+If layouts of same priority can not use all the space, the rest is passed to next priority.
+
+```yaml
+concatenate:
+  - priority: 1 # Défaut: 0
+    otherLayout
+  - priority: 2 # Défaut: 0
+    anotherLayout
+along: y
+zPolicy: KEEP
+```
+Policies are used to control how non concatenate axes are sized.
+
+Fields:
+- `concatenate` (required): List of layouts to place side by side.
+  - `priority` (optional, default `1`): Priority level. Layout with higher values get space first.  
+- `along` (required): Axis which the layouts are placed (`x`, `y` or `z`)
+- `xPolicy` (optional, default `INHERIT`): Policy for the x-axis.
+- `yPolicy` (optional, default `INHERIT`): Policy for the y-axis.
+- `zPolicy` (optional, default `INHERIT`): Policy for the z-axis.
+
+Policies values:
+- `INHERIT`: Uses the policy set by the parent (Parent layout or parent task).
+- `KEEP`: Each layout keep its own size on that axis. Layout may have different sizes on that axis.
+- `ADJUST`: All layout are forced to have the same size.

--- a/docs/usage/parameters/TileTasks.md
+++ b/docs/usage/parameters/TileTasks.md
@@ -20,6 +20,7 @@ Each task has a `type`, optional dependencies to other tasks (in `after`), and o
   * [`fillBetweenHeightmapAndMetadata`](#fillbetweenheightmapandmetadata)
   * [`renderBuildings`](#renderbuildings)
   * [`setSpawn`](#setspawn)
+  * [`renderFacade`](#renderfacade)
 * [Tasks operating on heightmaps](#tasks-operating-on-heightmaps)
   * [`populateHeightmap`](#populateheightmap)
   * [`copyHeightmap`](#copyheightmap)
@@ -275,6 +276,34 @@ type: setSpawn
 heightmap: ground
 x: 2
 y: -1
+```
+
+### `renderFacade`
+
+Renders facades using layouts from 2D shapes. 
+Layouts are tried in order, the first one that can fit the requested space is used.
+
+#### Extra parameters
+
+- `models`: [Selection of models](ModelSelection.md) to render (required, models must be convertible to 2d shapes)
+- `height` (string): Name of the metadata containing the desired height. (required)
+- `altitude` (string): Name of the metadata containing the altitude. (required)
+- `build`: List of layouts to try. Default axis policies are `ADJUST` on `X` and `Z`, `KEEP` on `Y`.
+
+#### Example
+
+```yaml
+models: buildings
+height: height
+altitude: ground-floor-altitude
+build:
+  - structure:
+      at: [ 0, -1..0, 0 ]
+      put: stone
+      stretchableAlongX:
+        at: 0
+      stretchableAlongZ:
+        at: 0
 ```
 
 ## Tasks operating on heightmaps

--- a/examples/formats/minecraft.yaml
+++ b/examples/formats/minecraft.yaml
@@ -3,7 +3,6 @@ references:
   - &voxel-stone minecraft:stone
   - &voxel-dirt minecraft:dirt
   - &voxel-cobble minecraft:cobblestone
-  - &voxel-empty minecraft:air
   - &voxel-building-ground minecraft:stone_bricks
   - &voxel-grass minecraft:grass_block
   - &voxel-glass minecraft:glass
@@ -38,3 +37,21 @@ references:
         at: [ 0, 0, 0..5 ]
   - &voxel-water minecraft:water
   - &voxel-air minecraft:air
+  - &corner-material minecraft:smooth_red_sandstone
+  - &base-material minecraft:sandstone
+  - &other-material minecraft:red_sandstone
+  - &borders-material minecraft:smooth_red_sandstone
+  - &cornice-material minecraft:smooth_red_sandstone
+  - &lintel-material minecraft:cut_sandstone
+  - &facade-residential-materials
+    "-": *base-material
+    "+": *other-material
+    "O": *borders-material
+    "*": minecraft:tinted_glass
+    "=": *lintel-material
+    "|": minecraft:jungle_fence
+  - &modern-wall minecraft:clay
+  - &modern-glass minecraft:tinted_glass
+  - &modern-materials
+    "O": *modern-wall
+    "*": *modern-glass

--- a/examples/formats/minetest.yaml
+++ b/examples/formats/minetest.yaml
@@ -3,7 +3,7 @@ references:
   - &voxel-stone default:stone
   - &voxel-dirt default:dirt
   - &voxel-cobble default:cobble
-  - &voxel-empty default:air
+  - &voxel-empty air
   - &voxel-building-ground default:stonebrick
   - &voxel-grass default:dirt_with_grass
   - &voxel-glass default:glass
@@ -32,3 +32,21 @@ references:
         at: [ 0, 0, 0..5 ]
   - &voxel-water default:water_source
   - &voxel-air air
+  - &corner-material default:desert_sandstone_block
+  - &base-material default:sandstone
+  - &other-material default:desert_stone
+  - &borders-material default:desert_sandstone_block
+  - &cornice-material default:desert_sandstone_block
+  - &lintel-material default:sandstonebrick
+  - &facade-residential-materials
+    "-": *base-material
+    "+": *other-material
+    "O": *borders-material
+    "*": default:obsidian_glass
+    "=": *lintel-material
+    "|": default:fence_junglewood
+  - &modern-wall default:clay
+  - &modern-glass default:obsidian_glass
+  - &modern-materials
+    "O": *modern-wall
+    "*": *modern-glass

--- a/examples/processes/full.yaml
+++ b/examples/processes/full.yaml
@@ -114,10 +114,12 @@ forEachTile:
       type: buildings
     heightmap: ground
     altitudeMetadata: ground-floor-altitude
-    placeAbove: *voxel-empty
+    placeAbove: *voxel-air
     placeBelow: *voxel-building-ground
 
-  renderBuildings:
+  # Hacky way to render roofs. Should be removed.
+  # Would have been nice to have a fillBetweenMetadatas
+  renderRoofs:
     after: flattenGroundBuildings
     type: renderBuildings
     models:
@@ -126,8 +128,8 @@ forEachTile:
         metadata: height
         greaterThan: 0
     roof: *voxel-cobble
-    wall: *voxel-stone
-    window: *voxel-glass
+    wall: *voxel-air
+    window: *voxel-air
 
   forest:
     type: sequence
@@ -298,3 +300,197 @@ forEachTile:
       with:
         "█": *road-paint
         "░": *road-tar
+
+  renderResidentialBuildings:
+    after:
+      - flattenGroundBuildings
+      - renderRoofs
+    type: renderFacade
+    models:
+      type: buildings
+      filter:
+        metadata: usage_1
+        equals: Résidentiel
+    height: height
+    altitude: ground-floor-altitude
+    # TODO: Layout should probably be defined on a common.yaml file in format.
+    build:
+     - along: x
+       concatenate:
+         # Left corner
+         - &corner
+           structure:
+             at: [ 0, -1..0, 0 ]
+             put: *corner-material
+           stretchableAlongX:
+             at: 0
+           stretchableAlongZ:
+             at: 0
+           priority: -1
+         - along: z
+           concatenate:
+             # Ground floor
+             - priority: 1
+               along: x
+               concatenate:
+                 - atLeast: 0
+                   along: x
+                   repeat:
+                     structure:
+                       axes: [ z, x ]
+                       blueprint: [ "-O==O", "-O**O", "-O**O", "-O**O", "-O==O", "-O--O" ]
+                       with: *facade-residential-materials
+                     stretchableAlongZ:
+                       at: 0
+                 # Door
+                 - structure:
+                     axes: [ z, x ]
+                     blueprint: [ "-O==O-", "-O  O-", "-O  O-", "-O  O-", "-O  O-", "-O  O-" ]
+                     with: *facade-residential-materials
+                   stretchableAlongZ:
+                     at: 0
+                 # Right ground windows
+                 - along: x
+                   atLeast: 0
+                   repeat:
+                     structure:
+                       axes: [ z, x ]
+                       blueprint: [ "O==O-", "O**O-", "O**O-", "O**O-", "O==O-", "O--O-" ]
+                       with: *facade-residential-materials
+                     stretchableAlongZ:
+                       at: 0
+             # Cornice
+             - structure:
+                 at: [ 0, 0, 0 ]
+                 put: *cornice-material
+               stretchableAlongX:
+                 at: 0
+             # Upper floors
+             - priority: 2
+               along: z
+               atLeast: 0
+               repeat:
+                 along: x
+                 concatenate:
+                   - structure:
+                       at: [ 0, 0, 0..5 ]
+                       put: *other-material
+                   - along: x
+                     repeat:
+                       structure:
+                         axes: [ y, z, x ]
+                         blueprint:
+                           - [ "O==O+", "O**O+", "O**O+", "O**O+", "O==O+", "O--O+" ]
+                           - [ "     ", "     ", "     ", "|||| ", "==== ", "O  O " ]
+                         with: *facade-residential-materials
+                         yOffset: -1
+             # Upper cornice
+             - structure:
+                 at: [ 0, 0, 0 ]
+                 put: *cornice-material
+               stretchableAlongX:
+                 at: 0
+               stretchableAlongZ:
+                 at: 0
+         # Right corner
+         - *corner
+     - structure:
+         at: [ 0, 0, 0 ]
+         put: *corner-material
+       stretchableAlongX:
+         at: 0
+       stretchableAlongZ:
+         at: 0
+
+  renderOfficeBuildings:
+    after:
+      - flattenGroundBuildings
+      - renderRoofs
+    type: renderFacade
+    models:
+      type: buildings
+      filter:
+        not:
+          metadata: usage_1
+          equals: Résidentiel
+    height: height
+    altitude: ground-floor-altitude
+    # TODO: Layout should probably be defined on a common.yaml file in format.
+    build:
+      - along: x
+        concatenate:
+          # Left corner
+          - structure:
+              put: *modern-wall
+              at: [0, 0, 0]
+            stretchableAlongX:
+              at: 0
+            stretchableAlongZ:
+              at: 0
+          # Facade
+          - priority: 1
+            along: z
+            concatenate:
+              # Ground floor
+              - along: x
+                concatenate:
+                  # Left
+                  - along: x
+                    repeat:
+                      structure:
+                        with: *modern-materials
+                        axes: [z, x]
+                        blueprint: [ "O**", "O**", "O**", "OOO", "OOO"]
+                  # Door
+                  - structure:
+                      with: *modern-materials
+                      axes: [z, x]
+                      blueprint: [ "OOOO", "O  O", "O  O", "O  O", "O  O" ]
+                  # Right
+                  - along: x
+                    repeat:
+                      structure:
+                        with: *modern-materials
+                        axes: [z, x]
+                        blueprint: [ "**O", "**O", "**O", "OOO", "OOO" ]
+              # Upper floors
+              - priority: 1
+                along: x
+                concatenate:
+                  - structure:
+                      put: *modern-wall
+                      at: [0, 0, 0 ]
+                    stretchableAlongZ:
+                      at: 0
+                  - along: x
+                    repeat:
+                      structure:
+                        with: *modern-materials
+                        axes: x
+                        blueprint: "**O"
+                      stretchableAlongZ:
+                        at: 0
+              # Top
+              - structure:
+                  put: *modern-wall
+                  at: [0, 0, 0 ]
+                stretchableAlongX:
+                  at: 0
+                stretchableAlongZ:
+                  at: 0
+          # Left corner
+          - structure:
+              put: *modern-wall
+              at: [0, 0, 0]
+            stretchableAlongX:
+              at: 0
+            stretchableAlongZ:
+              at: 0
+      # Default
+      - structure:
+          at: [ 0, 0, 0 ]
+          put: *modern-wall
+        stretchableAlongX:
+          at: 0
+        stretchableAlongZ:
+          at: 0

--- a/generate.sh
+++ b/generate.sh
@@ -127,9 +127,9 @@ if [ $output_dir_needed ]; then
     output_dir=$(realpath "$output_dir")
 fi
 
-params=$({
-  cat "$format"; echo; cat "$process"; echo; cat "$place"
-})
+params=$(
+ ( cat "$format"; printf "\n---\n"; cat "$process"; printf "\n---\n"; cat "$place"; printf "\n---\n" ) | yq ea 'select(di == 0) *+ select(di == 1) *+ select(di == 2)' | yq 'explode(.)'
+)
 
 if [ "$display_only" ]; then
     echo "$params"

--- a/src/main/java/com/ignfab/minalac/generator/MinalacGenerator.java
+++ b/src/main/java/com/ignfab/minalac/generator/MinalacGenerator.java
@@ -36,12 +36,14 @@ import com.ignfab.minalac.generator.parameters.providers.ShapefileProviderParams
 import com.ignfab.minalac.generator.parameters.providers.WFSProviderParams;
 import com.ignfab.minalac.generator.parameters.providers.WMSFloatBilProviderParams;
 import com.ignfab.minalac.generator.parameters.tasks.CopyHeightmapTaskParams;
+import com.ignfab.minalac.generator.parameters.tasks.DebugLayoutTaskParams;
 import com.ignfab.minalac.generator.parameters.tasks.FetchDataTaskParams;
 import com.ignfab.minalac.generator.parameters.tasks.FillBetweenHeightmapAndMetadataTaskParams;
 import com.ignfab.minalac.generator.parameters.tasks.HeightmapStatsTaskParams;
 import com.ignfab.minalac.generator.parameters.tasks.NoOperationTaskParams;
 import com.ignfab.minalac.generator.parameters.tasks.PopulateHeightmapTaskParams;
 import com.ignfab.minalac.generator.parameters.tasks.RenderBuildingsTaskParams;
+import com.ignfab.minalac.generator.parameters.tasks.RenderFacadeTaskParams;
 import com.ignfab.minalac.generator.parameters.tasks.RenderHeightmapTaskParams;
 import com.ignfab.minalac.generator.parameters.tasks.RenderLines2dTaskParams;
 import com.ignfab.minalac.generator.parameters.tasks.RenderLinesTaskParams;
@@ -133,6 +135,8 @@ public final class MinalacGenerator {
         parser.registerParams("renderPoints", RenderPointsTaskParams.class);
         parser.registerParams("renderPoints2d", RenderPoints2dTaskParams.class);
         parser.registerParams("setSpawn", SetSpawnTaskParams.class);
+        parser.registerParams("renderFacade", RenderFacadeTaskParams.class);
+        parser.registerParams("debugLayout", DebugLayoutTaskParams.class);
 
         parser.registerParams("wfs", WFSProviderParams.class);
         parser.registerParams("gpkg", GeoPackageProviderParams.class);

--- a/src/main/java/com/ignfab/minalac/generator/exceptions/UnbuildableException.java
+++ b/src/main/java/com/ignfab/minalac/generator/exceptions/UnbuildableException.java
@@ -1,0 +1,35 @@
+package com.ignfab.minalac.generator.exceptions;
+
+/**
+ * An exception thrown when a builder cannot build.
+ * <p>
+ * This may happen when building or as soon as the impossibility is detected.
+ */
+public class UnbuildableException extends Exception {
+
+    /**
+     * Creates a new unbuildable exception.
+     * @param message the error message
+     */
+    public UnbuildableException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new unbuildable exception.
+     * @param cause the cause of this error
+     */
+    public UnbuildableException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Creates a new unbuildable exception.
+     * @param message the error message
+     * @param cause the cause of this error
+     */
+    public UnbuildableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}
+

--- a/src/main/java/com/ignfab/minalac/generator/parameters/placeables/layouts/ConcatenateLayoutBuilderParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/placeables/layouts/ConcatenateLayoutBuilderParams.java
@@ -1,0 +1,155 @@
+package com.ignfab.minalac.generator.parameters.placeables.layouts;
+
+import java.beans.ConstructorProperties;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.exc.InputCoercionException;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.node.ObjectNode;
+
+import com.ignfab.minalac.generator.exceptions.UnbuildableException;
+import com.ignfab.minalac.generator.parameters.utils.AxisParams;
+import com.ignfab.minalac.generator.placeables.layouts.DefaultLayoutBuilder;
+import com.ignfab.minalac.generator.placeables.layouts.LayoutBuilder;
+import com.ignfab.minalac.generator.utils.random.Seed;
+
+/**
+ * Parameters for a {@link LayoutBuilder} concatenates different layouts along an axis
+ * <p>
+ * Usage example:
+ * <pre>
+ *   place:
+ *     - ... first layout description ...
+ *     - priority: 2
+ *       ... second layout description ...
+ *   along: x | y | z
+ * </pre>
+ */
+public class ConcatenateLayoutBuilderParams implements LayoutBuilderParams {
+    /**
+     * List of layouts to concatenate.
+     */
+    @JsonSetter(nulls = Nulls.FAIL)
+    public List<ConcatenateParams> concatenate;
+
+    /**
+     * Axis along which layouts are concatenated.
+     */
+    @JsonSetter(nulls = Nulls.FAIL)
+    AxisParams along;
+
+    /**
+     * Adjust policy along X-axis (default: inherit).
+     */
+    @JsonSetter(nulls = Nulls.SKIP)
+    AxisPolicy xPolicy = AxisPolicy.INHERIT;
+
+    /**
+     * Adjust policy along Y-axis (default: inherit).
+     */
+    @JsonSetter(nulls = Nulls.SKIP)
+    AxisPolicy yPolicy = AxisPolicy.INHERIT;
+
+    /**
+     * Adjust policy along Z-axis (default: inherit).
+     */
+    @JsonSetter(nulls = Nulls.SKIP)
+    AxisPolicy zPolicy = AxisPolicy.INHERIT;
+
+    /**
+     * Creates a new {@code ConcatenateLayoutBuilderParams} out of mandatory parameters.
+     * @param concatenate list of layouts to concatenate
+     * @param along axis along which concatenate layouts
+     */
+    @ConstructorProperties({ "concatenate", "along" })
+    public ConcatenateLayoutBuilderParams(List<ConcatenateParams> concatenate, AxisParams along) {
+        this.concatenate = concatenate;
+        this.along = along;
+    }
+
+    @Override
+    public void validate() {
+        if (concatenate.isEmpty())
+            throw new IllegalArgumentException("Cannot be empty");
+        concatenate.forEach(ConcatenateParams::validate);
+    }
+
+    @Override
+    public LayoutBuilder createBuilder(Seed seed, AxesPolicies policies) throws UnbuildableException {
+        LayoutBuilder[] builders = new LayoutBuilder[concatenate.size()];
+        int[] priorities = new int[concatenate.size()];
+        for (int i = 0; i < concatenate.size(); i++)  {
+            builders[i] = concatenate.get(i).layout.createBuilder(seed, policies);
+            priorities[i] = concatenate.get(i).priority;
+        }
+
+        return DefaultLayoutBuilder.concat(builders, along.create(), priorities,
+            (xPolicy == AxisPolicy.INHERIT ? policies.x() : xPolicy) == AxisPolicy.ADJUST,
+            (yPolicy == AxisPolicy.INHERIT ? policies.y() : yPolicy) == AxisPolicy.ADJUST,
+            (zPolicy == AxisPolicy.INHERIT ? policies.z() : zPolicy) == AxisPolicy.ADJUST
+        );
+    }
+
+    /**
+     * Parameters for each concatenated layout.
+     * <p>
+     * This is basically a {@link LayoutBuilderParams} with an eventual extra {@code priority} field.
+     */
+    @JsonDeserialize(using = ConcatenateParams.Deserializer.class)
+    public static final class ConcatenateParams {
+        /**
+         * Concatenated {@link LayoutBuilderParams}.
+         */
+        @JsonSetter(nulls = Nulls.FAIL)
+        public LayoutBuilderParams layout;
+
+        /**
+         * Priority for space repartition.
+         */
+        @JsonSetter(nulls = Nulls.SKIP)
+        public int priority = 0;
+
+        /**
+         * Validates parameters.
+         */
+        public void validate() {
+            layout.validate();
+        }
+
+        /**
+         * Custom deserializer for {@code ConcatenateParams}.
+         * <p>
+         * This deserializer will take care of {@code priority} field and use all other fields to deserialize into {@code layout}.
+         */
+        public static class Deserializer extends ValueDeserializer<ConcatenateParams> {
+
+            @Override
+            public ConcatenateParams deserialize(JsonParser parser, DeserializationContext context) throws JacksonException {
+                JsonNode node = parser.readValueAsTree();
+
+                if (node instanceof ObjectNode objectNode) {
+                    ConcatenateParams params = new ConcatenateParams();
+
+                    JsonNode priorityNode = objectNode.get("priority");
+                    if (priorityNode != null) {
+                        if (!priorityNode.isIntegralNumber())
+                            throw new InputCoercionException(parser, "Priority should be a integer number", node.asToken(), Integer.class);
+                        params.priority = priorityNode.asInt();
+                        objectNode.remove("priority");
+                    }
+                    params.layout = context.readTreeAsValue(objectNode, LayoutBuilderParams.class);
+
+                    return params;
+                } else
+                    throw new InputCoercionException(parser, "Placed layouts should be layouts", node.asToken(), LayoutBuilderParams.class);
+            }
+        }
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/parameters/placeables/layouts/LayoutBuilderParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/placeables/layouts/LayoutBuilderParams.java
@@ -1,0 +1,67 @@
+package com.ignfab.minalac.generator.parameters.placeables.layouts;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import com.ignfab.minalac.generator.exceptions.UnbuildableException;
+import com.ignfab.minalac.generator.placeables.layouts.LayoutBuilder;
+import com.ignfab.minalac.generator.utils.random.Seed;
+
+/**
+ * Interface for {@link LayoutBuilder} params.
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION, defaultImpl = StructureLayoutBuilderParams.class)
+@JsonSubTypes({
+    @JsonSubTypes.Type(ConcatenateLayoutBuilderParams.class),
+    @JsonSubTypes.Type(RepeatLayoutBuilderParams.class),
+    @JsonSubTypes.Type(StructureLayoutBuilderParams.class),
+})
+public interface LayoutBuilderParams {
+
+    /**
+     * Validates layout builder or throws runtime exception.
+     */
+    default void validate() {}
+
+    /**
+     * Creates {@link LayoutBuilder} from parameters.
+     *
+     * @param seed The random seed
+     * @param policies Default axis adjustment policies
+     * @return created layout builder
+     * @throws UnbuildableException
+     */
+    LayoutBuilder createBuilder(Seed seed, AxesPolicies policies) throws UnbuildableException;
+
+    /**
+     * Axis adjustment policeis.
+     */
+    enum AxisPolicy {
+        /**
+         * Inherit policy: use default value.
+         */
+        @JsonProperty("inherit")
+        INHERIT,
+
+        /**
+         * Keep policy: keep axis as is with no modification.
+         */
+        @JsonProperty("keep")
+        KEEP,
+
+        /**
+         * Adjust policy: Adjust axis so it starts at 0 and has the desired size.
+         */
+        @JsonProperty("adjust")
+        ADJUST
+    };
+
+    /**
+     * Ajust policies for the three axes.
+     * @param x x-axis adjustment policy
+     * @param y y-axis adjustment policy
+     * @param z z-axis adjustment policy
+     */
+    record AxesPolicies(AxisPolicy x, AxisPolicy y, AxisPolicy z) {};
+}

--- a/src/main/java/com/ignfab/minalac/generator/parameters/placeables/layouts/RepeatLayoutBuilderParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/placeables/layouts/RepeatLayoutBuilderParams.java
@@ -1,0 +1,80 @@
+package com.ignfab.minalac.generator.parameters.placeables.layouts;
+
+import java.beans.ConstructorProperties;
+
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+
+import com.ignfab.minalac.generator.exceptions.UnbuildableException;
+import com.ignfab.minalac.generator.parameters.utils.AxisParams;
+import com.ignfab.minalac.generator.placeables.layouts.DefaultLayoutBuilder;
+import com.ignfab.minalac.generator.placeables.layouts.LayoutBuilder;
+import com.ignfab.minalac.generator.utils.random.Seed;
+
+/**
+ * Parameters for a {@link LayoutBuilder} that repeats a layout along an axis.
+ * <p>
+ * Usage example:
+ * <pre>
+ *   repeat:
+ *     ... layout description ...
+ *   along: x | y | z
+ *   atLeast: 1
+ * </pre>
+ */
+public class RepeatLayoutBuilderParams implements LayoutBuilderParams {
+    /**
+     * {@link LayoutBuilderParams} to repeat.
+     */
+    @JsonSetter(nulls = Nulls.FAIL)
+    public LayoutBuilderParams repeat;
+
+    /**
+     * Axis along which layout is repeated.
+     */
+    @JsonSetter(nulls = Nulls.FAIL)
+    public AxisParams along;
+
+    /**
+     * Minimum number of repetitions (default 1).
+     */
+    @JsonSetter(nulls = Nulls.SKIP)
+    public int atLeast = 1;
+
+    /**
+     * Maxiumum number of repetitions (default infinite).
+     */
+    @JsonSetter(nulls = Nulls.SKIP)
+    public int atMost = Integer.MAX_VALUE;
+
+    /**
+     * Creates a new {@code RepeatLayoutBuilderParams} out of mandatory parameters.
+     * @param repeat layout to repeat
+     * @param along axis along which layout is repeated
+     */
+
+    @ConstructorProperties({ "repeat", "along" })
+    public RepeatLayoutBuilderParams(LayoutBuilderParams repeat, AxisParams along) {
+        this.repeat = repeat;
+        this.along = along;
+    }
+
+    @Override
+    public void validate() {
+        if (atLeast < 0)
+            throw new IllegalArgumentException("atLeast field must be a positive integer");
+        if (atMost < atLeast)
+            throw new IllegalArgumentException("atMost must be greater than atLeast");
+        repeat.validate();
+    }
+
+    @Override
+    public LayoutBuilder createBuilder(Seed seed, AxesPolicies policies) throws UnbuildableException {
+        return DefaultLayoutBuilder.repeat(
+            repeat.createBuilder(seed, policies),
+            along.create(),
+            atLeast,
+            atMost
+        );
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/parameters/placeables/layouts/StructureLayoutBuilderParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/placeables/layouts/StructureLayoutBuilderParams.java
@@ -1,0 +1,119 @@
+package com.ignfab.minalac.generator.parameters.placeables.layouts;
+
+import java.beans.ConstructorProperties;
+
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+
+import com.ignfab.minalac.generator.exceptions.UnbuildableException;
+import com.ignfab.minalac.generator.parameters.placeables.structures.PlaceableStructureParams;
+import com.ignfab.minalac.generator.placeables.PlaceableStructure;
+import com.ignfab.minalac.generator.placeables.layouts.LayoutBuilder;
+import com.ignfab.minalac.generator.placeables.layouts.StretchableStructureBuilder;
+import com.ignfab.minalac.generator.utils.axis.Axis;
+import com.ignfab.minalac.generator.utils.random.Seed;
+
+/**
+ * <p>
+ * Parameters for making a {@link PlaceableStructure} resizable by allowing at most one stretchable band of the structure per axis (e.g. a column at x = 2 and a row at z = 1), effectively making it a Layout Builder.
+ * <p>
+ * Usage example:
+ * <pre>
+ *   structure:
+ *     ...
+ *   stretchableAlongX:
+ *     at: 3
+ *   stretchableAlongZ:
+ *     at: 2
+ *     atLeast: 0
+ * </pre>
+ */
+public class StructureLayoutBuilderParams implements LayoutBuilderParams {
+    /**
+     * The {@link PlaceableStructure} to transform into a LayoutBuilder.
+     */
+    public PlaceableStructureParams structure;
+    /**
+     * Parameters for defining the band along x-axis stretchable. (Optional)
+     */
+    public StretchAxisParams stretchableAlongX;
+    /**
+     * Parameters for defining the band along y-axis stretchable. (Optional)
+     */
+    public StretchAxisParams stretchableAlongY;
+    /**
+     * Parameters for defining the band along z-axis  stretchable. (Optional)
+     */
+    public StretchAxisParams stretchableAlongZ;
+
+    /**
+     * Creates a new {@code StructureLayoutBuilderParams} out of mandatory parameters.
+     *
+     * @param structure the {@link PlaceableStructureParams} to transform.
+     */
+    @ConstructorProperties({ "structure" })
+    public StructureLayoutBuilderParams(PlaceableStructureParams structure) {
+        this.structure = structure;
+    }
+
+    @Override
+    public void validate() {
+        structure.validate();
+        if (stretchableAlongX != null)
+            stretchableAlongX.validate();
+        if (stretchableAlongY != null)
+            stretchableAlongY.validate();
+        if (stretchableAlongZ != null)
+            stretchableAlongZ.validate();
+    }
+
+    @Override
+    public LayoutBuilder createBuilder(Seed seed, AxesPolicies policies) throws UnbuildableException {
+        PlaceableStructure structure = this.structure.create(seed);
+
+        StretchableStructureBuilder.StretchAxis x = null;
+        StretchableStructureBuilder.StretchAxis y = null;
+        StretchableStructureBuilder.StretchAxis z = null;
+        if (stretchableAlongX != null)
+            x = new StretchableStructureBuilder.StretchAxis(Axis.X, stretchableAlongX.at, stretchableAlongX.atLeast, stretchableAlongX.atMost);
+        if (stretchableAlongY != null)
+            y = new StretchableStructureBuilder.StretchAxis(Axis.Y, stretchableAlongY.at, stretchableAlongY.atLeast, stretchableAlongY.atMost);
+        if (stretchableAlongZ != null)
+            z = new StretchableStructureBuilder.StretchAxis(Axis.Z, stretchableAlongZ.at, stretchableAlongZ.atLeast, stretchableAlongZ.atMost);
+
+        return new StretchableStructureBuilder(structure, x, y, z);
+    }
+
+    /**
+     * Stretch params along a given axis.
+     */
+    public static class StretchAxisParams {
+        /**
+         * Position to use for stretching. This position will be repeated (or omitted) according to wanted size.
+         */
+        @JsonSetter(nulls = Nulls.FAIL)
+        public int at;
+        /**
+         * Minimum number of repetitions (default 1).
+         */
+        @JsonSetter(nulls = Nulls.SKIP)
+        public int atLeast = 1;
+        /**
+         * Maximum number of repetitions (default infinite).
+         */
+        @JsonSetter(nulls = Nulls.SKIP)
+        public int atMost = Integer.MAX_VALUE;
+
+        /**
+         * Validates contents.
+         */
+        public void validate() {
+        if (at < 0)
+            throw new IllegalArgumentException("Stretch position must be positive");
+        if (atLeast < 0)
+            throw new IllegalArgumentException("Stretch at least must be positive");
+        if (atMost < atLeast)
+            throw new IllegalArgumentException("Stretch at most must be greater or equals to stretch at least");
+        }
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/parameters/tasks/DebugLayoutTaskParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/tasks/DebugLayoutTaskParams.java
@@ -1,0 +1,101 @@
+    package com.ignfab.minalac.generator.parameters.tasks;
+
+import java.beans.ConstructorProperties;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+
+import com.ignfab.minalac.generator.exceptions.UnbuildableException;
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.parameters.placeables.layouts.LayoutBuilderParams;
+import com.ignfab.minalac.generator.tasks.DebugLayoutTask;
+import com.ignfab.minalac.generator.tasks.TileTask;
+import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
+
+/**
+ * Parameters for a {@code DebugStructureBuilderTask}.
+ * <p>
+ * This task is a helper for working out facade parameters.
+ */
+public class DebugLayoutTaskParams extends TaskParams {
+    /**
+     * List of builders to use to construct structure.
+     * Builders will be tried in list order. First succeeding will be used.
+     */
+    @JsonProperty("build")
+    @JsonSetter(nulls = Nulls.FAIL)
+    @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+    public List<LayoutBuilderParams> builders;
+
+    /**
+     * Where to place resulting structure.
+     */
+    @JsonSetter(nulls = Nulls.FAIL)
+    public WorldCoords3d at;
+
+    /**
+     * Desired resulting size.
+     */
+    @JsonSetter(nulls = Nulls.SKIP)
+    public DebugSizeParams size =  new DebugSizeParams();
+
+    /**
+     * Creates a new {@code DebugStructureBuilderTaskParams} out of mandatory parameters.
+     * @param builders list of builders to use
+     * @param at position where to place resulting structure
+     */
+    @ConstructorProperties({"builders", "at"})
+    public DebugLayoutTaskParams(List<LayoutBuilderParams> builders, WorldCoords3d at) {
+        this.builders = builders;
+        this.at = at;
+    }
+
+    @Override
+    public TileTask create(Generation generation) {
+        try {
+            return new DebugLayoutTask(
+                builders.stream().map(builder -> {
+                    try {
+                        return builder.createBuilder(generation.seed(), new LayoutBuilderParams.AxesPolicies(
+                            LayoutBuilderParams.AxisPolicy.ADJUST,
+                            LayoutBuilderParams.AxisPolicy.KEEP,
+                            LayoutBuilderParams.AxisPolicy.ADJUST
+                        ));
+                    } catch (UnbuildableException e) {
+                        throw new IllegalArgumentException(e);
+                    }
+                }).collect(Collectors.toList()),
+                at, size.x, size.y, size.z
+            );
+        } catch (UnbuildableException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    /**
+     * Params for placed structure wanted size.
+     * <p>
+     * Size component may be omited. Omiting a component means leaving the builder decide size on corresponding axis.
+     */
+    public static class DebugSizeParams {
+        /**
+         * X-axis component of the size.
+         */
+        @JsonSetter(nulls = Nulls.SKIP)
+        public Integer x;
+        /**
+         * Y-axis component of the size.
+         */
+        @JsonSetter(nulls = Nulls.SKIP)
+        public Integer y;
+        /**
+         * Z-axis component of the size.
+         */
+        @JsonSetter(nulls = Nulls.SKIP)
+        public Integer z;
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/parameters/tasks/RenderFacadeTaskParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/tasks/RenderFacadeTaskParams.java
@@ -1,0 +1,104 @@
+package com.ignfab.minalac.generator.parameters.tasks;
+
+import java.beans.ConstructorProperties;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+
+import com.ignfab.minalac.generator.exceptions.UnbuildableException;
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.parameters.models.ModelSelectionParams;
+import com.ignfab.minalac.generator.parameters.placeables.layouts.LayoutBuilderParams;
+import com.ignfab.minalac.generator.tasks.RenderFacadeTask;
+import com.ignfab.minalac.generator.tasks.TileTask;
+
+/**
+ * Parameters for a {@link RenderFacadeTask}.
+ */
+public class RenderFacadeTaskParams extends ModelTaskParams {
+    /**
+     * Type of models to render (required).
+     */
+    @JsonSetter(nulls = Nulls.FAIL)
+    public ModelSelectionParams models;
+
+    /**
+     * List of builders to try out.
+     * <p>
+     * Builders will be tried in list order.
+     * If a builder fails, next one is tried.
+     * If it succeeds, facade is built and next builders won't be used.
+     * If all builders fail, nothing will be built.
+     */
+    @JsonProperty("build")
+    @JsonSetter(nulls = Nulls.FAIL)
+    @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+    public List<LayoutBuilderParams> builders;
+
+    /**
+     * Name of metadata containing building height (from wall bottom to wall top).
+     */
+    @JsonSetter(nulls = Nulls.FAIL)
+    public String height;
+
+    /**
+     * Name of metadata containing building altitude (altitude of wall bottom).
+     */
+    @JsonSetter(nulls = Nulls.FAIL)
+    public String altitude;
+
+    /**
+     * Creates a new {@code RenderFacadeTaskParams} out of mandatory parameters.
+     * @param models model selection for facades
+     * @param builders builders to try, in order
+     * @param height name of metadata containing building height
+     * @param altitude name of metadata containing building altitude
+     */
+    @ConstructorProperties({ "models", "builders", "height", "altitude"})
+    public RenderFacadeTaskParams(
+        ModelSelectionParams models,
+        List<LayoutBuilderParams> builders,
+        String height,
+        String altitude
+    ) {
+        this.models = models;
+        this.builders = builders;
+        this.height = height;
+        this.altitude = altitude;
+    }
+
+
+    @Override
+    public void validate() {
+        if (height.isBlank())
+            throw new IllegalArgumentException("Height metadata cannot be blank");
+        if (altitude.isBlank())
+            throw new IllegalArgumentException("Altitude metadata cannot be blank");
+        models.validate();
+        builders.forEach(LayoutBuilderParams::validate);
+    }
+
+    @Override
+    public TileTask create(Generation generation) {
+        return new RenderFacadeTask(
+            models.create(),
+            builders.stream().map(builder -> {
+                try {
+                    return builder.createBuilder(generation.seed(), new LayoutBuilderParams.AxesPolicies(
+                        LayoutBuilderParams.AxisPolicy.ADJUST,
+                        LayoutBuilderParams.AxisPolicy.KEEP,
+                        LayoutBuilderParams.AxisPolicy.ADJUST
+                    ));
+                } catch (UnbuildableException e) {
+                    throw new IllegalArgumentException(e);
+                }
+            }).collect(Collectors.toList()),
+            height,
+            altitude
+        );
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/parameters/utils/AxisParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/utils/AxisParams.java
@@ -1,0 +1,47 @@
+package com.ignfab.minalac.generator.parameters.utils;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.ignfab.minalac.generator.utils.axis.Axis;
+
+/**
+ * Parameters for a three dimensional axis.
+ */
+public enum AxisParams {
+    /**
+     * X-axis.
+     */
+    @JsonProperty("x")
+    X(Axis.X),
+    /**
+     * Y-axis.
+     */
+    @JsonProperty("y")
+    Y(Axis.Y),
+    /**
+     * Z-axis.
+     */
+    @JsonProperty("z")
+    Z(Axis.Z);
+
+    /**
+     * Actual {@link Axis} associated to parameter.
+     */
+    public final Axis axis;
+
+    /**
+     * Creates a new axis.
+     *
+     * @param axis Axis associated to parameter
+     */
+    AxisParams(Axis axis) {
+        this.axis = axis;
+    }
+
+    /**
+     * {@return the corresponding {@link Axis}}
+     */
+    public Axis create() {
+        return axis;
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/placeables/EmptyStructure.java
+++ b/src/main/java/com/ignfab/minalac/generator/placeables/EmptyStructure.java
@@ -1,0 +1,33 @@
+package com.ignfab.minalac.generator.placeables;
+
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+import com.ignfab.minalac.generator.world.VoxelTile;
+
+/**
+ * A structure containing nothing.
+ * <p>
+ * This is a singleton class, always use {@code EmptyStructure.INSTANCE}.
+ */
+public final class EmptyStructure implements Structure {
+
+    /**
+     * Singleton instance.
+     */
+    public static final EmptyStructure INSTANCE = new EmptyStructure();
+
+    private EmptyStructure() {};
+
+    @Override
+    public void place(VoxelTile tile, int x, int y, int z) {}
+
+    @Override
+    public Placeable get(int x, int y, int z) {
+        return Nothing.INSTANCE;
+    }
+
+    @Override
+    public WorldBBox3d limits() {
+        return WorldBBox3d.EMPTY;
+    }
+
+}

--- a/src/main/java/com/ignfab/minalac/generator/placeables/LayoutStructure.java
+++ b/src/main/java/com/ignfab/minalac/generator/placeables/LayoutStructure.java
@@ -1,0 +1,110 @@
+package com.ignfab.minalac.generator.placeables;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.ignfab.minalac.generator.utils.axis.Axis;
+import com.ignfab.minalac.generator.utils.axis.mappers.AxisMapper;
+import com.ignfab.minalac.generator.utils.axis.mappers.IdentityAxisMapper;
+import com.ignfab.minalac.generator.utils.axis.mappers.SizesAxisMapper;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
+import com.ignfab.minalac.generator.utils.world3d.WorldSize3d;
+import com.ignfab.minalac.generator.world.VoxelTile;
+
+/**
+ * A placeable structure made of several structures.
+ * <p>
+ * {@link AxisMapper}s are used to map structure coordinate to substructures and in-substructures coordinates.
+ */
+public class LayoutStructure implements Structure {
+    private final Structure[][][] structures;
+    private final AxisMapper axisX;
+    private final AxisMapper axisY;
+    private final AxisMapper axisZ;
+    private final WorldBBox3d limits;
+
+    /**
+     * Creates a new {@code LayoutStructure}.
+     *
+     * @param structures Three dimensional array of structures. Array dimentions must correspond to AxisMappers sizes.
+     * @param axisX axis mapper for X-axis
+     * @param axisY axis mapper for Y-axis
+     * @param axisZ axis mapper for Z-axis
+     */
+    public LayoutStructure(Structure[][][] structures, AxisMapper axisX, AxisMapper axisY, AxisMapper axisZ) {
+        this.structures = structures;
+        this.axisX = axisX;
+        this.axisY = axisY;
+        this.axisZ = axisZ;
+
+        this.limits = new WorldBBox3d(
+            new WorldCoords3d(axisX.minimum(), axisY.minimum(), axisZ.minimum()),
+            new WorldSize3d(axisX.size(), axisY.size(), axisZ.size())
+        );
+    }
+
+    @Override
+    public Placeable get(int x, int y, int z) {
+        if (axisX.contains(x) && axisY.contains(y) && axisZ.contains(z)) {
+            AxisMapper.Mapped aX = axisX.map(x);
+            AxisMapper.Mapped aY = axisY.map(y);
+            AxisMapper.Mapped aZ = axisZ.map(z);
+            return structures[aX.index()][aY.index()][aZ.index()]
+                .get(aX.position(), aY.position(), aZ.position());
+        }
+
+        // Return Nothing instead of raising an exception to be able to render unadjusted stuff
+        return Nothing.INSTANCE;
+    }
+
+    @Override
+    public WorldBBox3d limits() {
+        return limits;
+    }
+
+    @Override
+    public void place(VoxelTile tile, int x, int y, int z) {
+        for (WorldCoords3d c : limits.bbox())
+            get(c.x(), c.y(), c.z()).place(tile, c.x() + x, c.y() + y, c.z() + z);
+    }
+
+    /**
+     * Creates a layout concatenating structures along given axis.
+     *
+     * @param structures list of structures to concatenate
+     * @param axis axis along which structures will be placed
+     * @return a {@link LayoutStructure} concatenating structures
+     */
+    public static LayoutStructure concatenate(List<Structure> structures, Axis axis) {
+        WorldBBox3d limits = WorldBBox3d.surrounding(structures.stream().map(Structure::limits).collect(Collectors.toList()));
+
+        AxisMapper axisX = axis == Axis.X
+            ? new SizesAxisMapper(structures.stream().mapToInt(s -> s.limits().sizeX()).toArray())
+            : new IdentityAxisMapper(limits.minX(), limits.sizeX());
+
+        AxisMapper axisY = axis == Axis.Y
+            ? new SizesAxisMapper(structures.stream().mapToInt(s -> s.limits().sizeY()).toArray())
+            : new IdentityAxisMapper(limits.minY(), limits.sizeY());
+
+        AxisMapper axisZ = axis == Axis.Z
+            ? new SizesAxisMapper(structures.stream().mapToInt(s -> s.limits().sizeZ()).toArray())
+            : new IdentityAxisMapper(limits.minZ(), limits.sizeZ());
+
+        Structure[][][] structArray = new Structure
+            [axis == Axis.X ? structures.size() : 1]
+            [axis == Axis.Y ? structures.size() : 1]
+            [axis == Axis.Z ? structures.size() : 1];
+
+        int index = 0;
+        for (Structure structure : structures) {
+            structArray
+                [axis == Axis.X ? index : 0]
+                [axis == Axis.Y ? index : 0]
+                [axis == Axis.Z ? index : 0] = structure;
+            index++;
+        }
+
+        return new LayoutStructure(structArray, axisX, axisY, axisZ);
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/placeables/PlaceableStructure.java
+++ b/src/main/java/com/ignfab/minalac/generator/placeables/PlaceableStructure.java
@@ -11,7 +11,7 @@ import com.ignfab.minalac.generator.world.VoxelTile;
  * {@code PlaceableStructure} is a {@link Placeable} consisting of placeables at given coordinate offsets.
  * The structure itself is immutable, but can be defined by using the {@link #builder()}.
  */
-public final class PlaceableStructure implements Placeable {
+public final class PlaceableStructure implements Structure {
     private final Map<WorldCoords3d, Placeable> placeables;
     private final WorldBBox3d limits;
 

--- a/src/main/java/com/ignfab/minalac/generator/placeables/Structure.java
+++ b/src/main/java/com/ignfab/minalac/generator/placeables/Structure.java
@@ -1,0 +1,36 @@
+package com.ignfab.minalac.generator.placeables;
+
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+
+/**
+ * A placeable made of other placeables.
+ * <p>
+ * Each underlying placeable has a unique position.
+ * There is a finite number of underlying placeables.
+ */
+public interface Structure extends Placeable {
+    /**
+     * Gets placeables at the given position in the structure.
+     * <p>
+     * (0, 0, 0) is the point that will be placed in the world at {@link Placeable#place(com.ignfab.minalac.generator.world.VoxelTile, int, int, int)} position.
+     *
+     * @param x x-component of position
+     * @param y y-component of position
+     * @param z z-component of position
+     *
+     * @return placeable at that position or null if none.
+     */
+    Placeable get(int x, int y, int z);
+
+    /**
+     * Limits of this structure.
+     * <p>
+     * Outside this limit, {@link Structure#get(int, int, int)} will always return null.
+     * <p>
+     * Limits are distinct from bounding box as limits only includes direct underlying placeables.
+     * A hierarchy of structure could place voxel out limits.
+     *
+     * @return limits of the placeable
+     */
+    WorldBBox3d limits();
+}

--- a/src/main/java/com/ignfab/minalac/generator/placeables/layouts/DefaultLayoutBuilder.java
+++ b/src/main/java/com/ignfab/minalac/generator/placeables/layouts/DefaultLayoutBuilder.java
@@ -1,0 +1,160 @@
+package com.ignfab.minalac.generator.placeables.layouts;
+
+import java.util.Arrays;
+
+import com.ignfab.minalac.generator.exceptions.UnbuildableException;
+import com.ignfab.minalac.generator.placeables.EmptyStructure;
+import com.ignfab.minalac.generator.placeables.LayoutStructure;
+import com.ignfab.minalac.generator.placeables.Structure;
+import com.ignfab.minalac.generator.utils.axis.Axis;
+import com.ignfab.minalac.generator.utils.axis.mappers.AxisMapper;
+import com.ignfab.minalac.generator.utils.axis.mappers.builders.AdjustAxisMapperBuilder;
+import com.ignfab.minalac.generator.utils.axis.mappers.builders.AxisMapperBuilder;
+import com.ignfab.minalac.generator.utils.axis.mappers.builders.DelegateAxisMapperBuilder;
+import com.ignfab.minalac.generator.utils.axis.mappers.builders.KeepAxisMapperBuilder;
+import com.ignfab.minalac.generator.utils.axis.mappers.builders.PriorityRepartitionAxisMapperBuilder;
+import com.ignfab.minalac.generator.utils.axis.mappers.builders.RepeatAxisMapperBuilder;
+
+/**
+ * A versatile implementation of {@link LayoutBuilder} based on a layout builder provider.
+ */
+public class DefaultLayoutBuilder implements LayoutBuilder {
+    private final LayoutBuilderProvider provider;
+    private final AxisMapperBuilder xAxisBuilder;
+    private final AxisMapperBuilder yAxisBuilder;
+    private final AxisMapperBuilder zAxisBuilder;
+
+    /**
+     * Creates a new {@code DefaultAxisStructureBuilder} with only one, eventually repeated, structure builder.
+     *
+     * @param builder underlying unique builder
+     * @param xAxisBuilder axis builder for x-axis
+     * @param yAxisBuilder axis builder for y-axis
+     * @param zAxisBuilder axis builder for z-axis
+     */
+    public DefaultLayoutBuilder(LayoutBuilder builder, AxisMapperBuilder xAxisBuilder, AxisMapperBuilder yAxisBuilder, AxisMapperBuilder zAxisBuilder) {
+        // Could be optimized if builder is a DefaultLayoutBuilder, we could simply do:
+        // this.provider = builder.provider
+        // this.axis*Builder = combine axis*Builder over builder.axis*Builder (need a new method)
+        this((x, y, z) -> builder, xAxisBuilder, yAxisBuilder, zAxisBuilder);
+    }
+
+    private DefaultLayoutBuilder(LayoutBuilderProvider provider, AxisMapperBuilder xAxisBuilder, AxisMapperBuilder yAxisBuilder, AxisMapperBuilder zAxisBuilder) {
+        this.provider = provider;
+        this.xAxisBuilder = xAxisBuilder;
+        this.yAxisBuilder = yAxisBuilder;
+        this.zAxisBuilder = zAxisBuilder;
+    }
+
+    @Override
+    public Structure build(int sizeX, int sizeY, int sizeZ) throws UnbuildableException {
+        AxisMapper axisX = xAxisBuilder.build(sizeX);
+        AxisMapper axisY = yAxisBuilder.build(sizeY);
+        AxisMapper axisZ = zAxisBuilder.build(sizeZ);
+
+        if (axisX.intervals().length == 0 || axisY.intervals().length == 0 || axisZ.intervals().length == 0)
+            return EmptyStructure.INSTANCE;
+
+        Structure[][][] structures = new Structure
+            [axisX.intervals().length]
+            [axisY.intervals().length]
+            [axisZ.intervals().length];
+
+        for (int iX = 0; iX < axisX.intervals().length; iX++) {
+            for (int iY = 0; iY < axisY.intervals().length; iY++) {
+                for (int iZ = 0; iZ < axisZ.intervals().length; iZ++) {
+                    LayoutBuilder b = provider.get(iX, iY, iZ);
+                    structures[iX][iY][iZ] = b.build(axisX.intervals()[iX], axisY.intervals()[iY], axisZ.intervals()[iZ]);
+                }
+            }
+        }
+
+        return new LayoutStructure(structures, axisX, axisY, axisZ);
+    }
+
+    @Override
+    public AxisMapperBuilder xAxis() {
+        return xAxisBuilder;
+    }
+
+    @Override
+    public AxisMapperBuilder yAxis() {
+        return yAxisBuilder;
+    }
+
+    @Override
+    public AxisMapperBuilder zAxis() {
+        return zAxisBuilder;
+    }
+
+    /**
+     * Creates a new {@code AxisStructureBuilder} repeating an {@link LayoutBuilder} along an axis.
+     *
+     * @param builder builder to repeat
+     * @param axis axis of repetition
+     * @param minimum minimal number of repetitions (could be 0)
+     * @param maximum maximal number of repetitions
+     * @return created {@link LayoutBuilder}
+     * @throws UnbuildableException if layout builder cannot be created
+     */
+    public static LayoutBuilder repeat(LayoutBuilder builder, Axis axis, int minimum, int maximum) throws UnbuildableException {
+        if (minimum < 0)
+            throw new IllegalArgumentException("minimum must be positive or zero");
+        if (minimum > maximum)
+            throw new IllegalArgumentException("minimum must be less than maximum");
+
+        return new DefaultLayoutBuilder(
+            builder,
+            // RepeatAxisMapperBuilder for chosen axis, DelegateAxisMapperBuilder for others
+            axis == Axis.X ? new RepeatAxisMapperBuilder(builder.xAxis(), minimum, maximum) : new DelegateAxisMapperBuilder(builder.xAxis()),
+            axis == Axis.Y ? new RepeatAxisMapperBuilder(builder.yAxis(), minimum, maximum) : new DelegateAxisMapperBuilder(builder.yAxis()),
+            axis == Axis.Z ? new RepeatAxisMapperBuilder(builder.zAxis(), minimum, maximum) : new DelegateAxisMapperBuilder(builder.zAxis())
+        );
+    }
+
+    /**
+     * Creates a new {@code AxisStructureBuilder} concatenating {@link LayoutBuilder}s along an axis, with priorities for repartition.
+     *
+     * @param builders builders to concatenate
+     * @param axis axis of concatenation
+     * @param priorities priorities for each builders (must have same length as {@code builders})
+     * @param adjustX whether X-axis should be adjusted or not.
+     * @param adjustY whether Y-axis should be adjusted or not.
+     * @param adjustZ whether Z-axis should be adjusted or not.
+     * @return created {@link LayoutBuilder}
+     * @throws UnbuildableException if layout builder cannot be created
+     */
+    public static LayoutBuilder concat(LayoutBuilder[] builders, Axis axis, int[] priorities, boolean adjustX, boolean adjustY, boolean adjustZ) throws UnbuildableException {
+        if (builders.length == 0 || builders.length != priorities.length)
+            throw new RuntimeException("tab length do not match");
+
+        // Separate in three axis arrays the axes from each builder.
+        AxisMapperBuilder[] tabX = Arrays.stream(builders).map(LayoutBuilder::xAxis).toArray(AxisMapperBuilder[]::new);
+        AxisMapperBuilder[] tabY = Arrays.stream(builders).map(LayoutBuilder::yAxis).toArray(AxisMapperBuilder[]::new);
+        AxisMapperBuilder[] tabZ = Arrays.stream(builders).map(LayoutBuilder::zAxis).toArray(AxisMapperBuilder[]::new);
+
+        LayoutBuilderProvider provider = switch (axis) {
+            case X -> (x, y, z) -> builders[x];
+            case Y -> (x, y, z) -> builders[y];
+            case Z -> (x, y, z) -> builders[z];
+        };
+
+        return new DefaultLayoutBuilder(
+            // A LayoutBuilderProvider that maps `builders` argument array to the chosen axis:
+            provider,
+            // PriorityRepartitionAxisMapperBuilder for chosen axis, KeepAxisMapperBuilder or AdjustAxisMapperBuilder for others
+            axis == Axis.X ? new PriorityRepartitionAxisMapperBuilder(tabX, priorities)
+                : adjustX ? new AdjustAxisMapperBuilder(tabX) : new KeepAxisMapperBuilder(tabX),
+            axis == Axis.Y ? new PriorityRepartitionAxisMapperBuilder(tabY, priorities)
+                : adjustY ? new AdjustAxisMapperBuilder(tabY) : new KeepAxisMapperBuilder(tabY),
+            axis == Axis.Z ? new PriorityRepartitionAxisMapperBuilder(tabZ, priorities)
+                : adjustZ ? new AdjustAxisMapperBuilder(tabZ) : new KeepAxisMapperBuilder(tabZ)
+        );
+    }
+
+
+    @FunctionalInterface
+    private interface LayoutBuilderProvider {
+        LayoutBuilder get(int ix, int iy, int iz);
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/placeables/layouts/LayoutBuilder.java
+++ b/src/main/java/com/ignfab/minalac/generator/placeables/layouts/LayoutBuilder.java
@@ -1,0 +1,38 @@
+package com.ignfab.minalac.generator.placeables.layouts;
+
+import com.ignfab.minalac.generator.exceptions.UnbuildableException;
+import com.ignfab.minalac.generator.placeables.Structure;
+import com.ignfab.minalac.generator.utils.axis.mappers.builders.AxisMapperBuilder;
+
+/**
+ * A structure layout builder based on axis mappers.
+ */
+public interface LayoutBuilder {
+    /**
+     * Builds a structure of given size.
+     *
+     * @param sizeX Size along x-axis
+     * @param sizeY Size along y-axis
+     * @param sizeZ Size along z-axis
+     *
+     * @return built structure
+     *
+     * @throws UnbuildableException if structure cannot be built
+     */
+    Structure build(int sizeX, int sizeY, int sizeZ) throws UnbuildableException;
+
+    /**
+     * @return X-axis mapper builder.
+     */
+    AxisMapperBuilder xAxis();
+
+    /**
+     * @return Y-axis mapper builder.
+     */
+    AxisMapperBuilder yAxis();
+
+    /**
+     * @return Z-axis mapper builder.
+     */
+    AxisMapperBuilder zAxis();
+}

--- a/src/main/java/com/ignfab/minalac/generator/placeables/layouts/StretchableStructureBuilder.java
+++ b/src/main/java/com/ignfab/minalac/generator/placeables/layouts/StretchableStructureBuilder.java
@@ -1,0 +1,96 @@
+package com.ignfab.minalac.generator.placeables.layouts;
+
+import com.ignfab.minalac.generator.exceptions.UnbuildableException;
+import com.ignfab.minalac.generator.placeables.EmptyStructure;
+import com.ignfab.minalac.generator.placeables.LayoutStructure;
+import com.ignfab.minalac.generator.placeables.PlaceableStructure;
+import com.ignfab.minalac.generator.placeables.Structure;
+import com.ignfab.minalac.generator.utils.axis.Axis;
+import com.ignfab.minalac.generator.utils.axis.mappers.AxisMapper;
+import com.ignfab.minalac.generator.utils.axis.mappers.builders.AxisMapperBuilder;
+import com.ignfab.minalac.generator.utils.axis.mappers.builders.ConstantAxisMapperBuilder;
+import com.ignfab.minalac.generator.utils.axis.mappers.builders.DelegateAxisMapperBuilder;
+import com.ignfab.minalac.generator.utils.axis.mappers.builders.StretcherAxisMapperBuilder;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+
+/**
+ * This makes a {@link PlaceableStructure} resizable by allowing at most one stretchable band of the structure per axis (e.g. a column at x = 2 and a row at z = 1), effectively making it a Layout Builder.
+ */
+public class StretchableStructureBuilder implements LayoutBuilder {
+    private final Structure structure;
+    private final AxisMapperBuilder xAxisBuilder;
+    private final AxisMapperBuilder yAxisBuilder;
+    private final AxisMapperBuilder zAxisBuilder;
+
+    /**
+     * Creates a new {@link StretchableStructureBuilder}.
+     *
+     * @param structure the {@link PlaceableStructure} to make resizable.
+     * @param axisX the band along x-axis to make stretchable. A {@code null} value make it not stretchable along x-axis.
+     * @param axisY the band along y-axis to make stretchable. A {@code null} value make it not stretchable along y-axis.
+     * @param axisZ the band along z-axis to make stretchable. A {@code null} value make it not stretchable along z-axis.
+     * @throws UnbuildableException if unable to create with provided arguments.
+     */
+    public StretchableStructureBuilder(PlaceableStructure structure, StretchAxis axisX, StretchAxis axisY, StretchAxis axisZ) throws UnbuildableException {
+        this.structure = structure;
+        ConstantAxisMapperBuilder xBase = new ConstantAxisMapperBuilder(structure.limits().sizeX(), structure.limits().minX());
+        ConstantAxisMapperBuilder yBase = new ConstantAxisMapperBuilder(structure.limits().sizeY(), structure.limits().minY());
+        ConstantAxisMapperBuilder zBase = new ConstantAxisMapperBuilder(structure.limits().sizeZ(), structure.limits().minZ());
+
+        xAxisBuilder = axisX == null ? new DelegateAxisMapperBuilder(xBase) : createAndCheck(structure.limits(), xBase, axisX);
+        yAxisBuilder = axisY == null ? new DelegateAxisMapperBuilder(yBase) : createAndCheck(structure.limits(), yBase, axisY);
+        zAxisBuilder = axisZ == null ? new DelegateAxisMapperBuilder(zBase) : createAndCheck(structure.limits(), zBase, axisZ);
+    }
+
+    private AxisMapperBuilder createAndCheck(WorldBBox3d limits, ConstantAxisMapperBuilder base, StretchAxis axis) throws UnbuildableException {
+        if (axis.stretchPosition > limits.max().coord(axis.axis) || axis.stretchPosition < limits.min().coord(axis.axis))
+            throw new UnbuildableException("\"at\" value (%d) is outside structure (%d to %d) for axis %s"
+                .formatted(axis.stretchPosition, limits.min().coord(axis.axis), limits.max().coord(axis.axis), axis.axis));
+
+        return new StretcherAxisMapperBuilder(base, axis.stretchPosition, axis.minStretch, axis.maxStretch);
+    }
+
+    @Override
+    public Structure build(int sizeX, int sizeY, int sizeZ) throws UnbuildableException {
+        // There is redundancy with DefaultLayoutStructure.
+        // Fow now, it is accepted as DefaultLayoutStructure is builder to builder and this class structure to builder
+        AxisMapper axisX = xAxisBuilder.build(sizeX);
+        AxisMapper axisY = yAxisBuilder.build(sizeY);
+        AxisMapper axisZ = zAxisBuilder.build(sizeZ);
+
+
+        // StretcherAxisMapperBuilder can have a size of zero. (Stretchable, length of 1, asked 0)
+        if (axisX.intervals().length == 0 || axisY.intervals().length == 0 || axisZ.intervals().length == 0)
+            return EmptyStructure.INSTANCE;
+
+        Structure[][][] structures = new Structure[1][1][1];
+        structures[0][0][0] = structure;
+
+        return new LayoutStructure(structures, axisX, axisY, axisZ);
+    }
+
+    @Override
+    public AxisMapperBuilder xAxis() {
+        return xAxisBuilder;
+    }
+
+    @Override
+    public AxisMapperBuilder yAxis() {
+        return yAxisBuilder;
+    }
+
+    @Override
+    public AxisMapperBuilder zAxis() {
+        return zAxisBuilder;
+    }
+
+    /**
+     * Defines a stretchable band along a given axis.
+     *
+     * @param axis the axis which the band is defined.
+     * @param stretchPosition the coordinate of the band to stretch. Must be within structure limits.
+     * @param minStretch minimum repetitions. May be 0 if the structure size along the given axis is greater than 0. On that particular case, the structure may be squeezed.
+     * @param maxStretch maximum repetitions.
+     */
+    public record StretchAxis(Axis axis, int stretchPosition, int minStretch, int maxStretch) { }
+}

--- a/src/main/java/com/ignfab/minalac/generator/tasks/DebugLayoutTask.java
+++ b/src/main/java/com/ignfab/minalac/generator/tasks/DebugLayoutTask.java
@@ -1,0 +1,70 @@
+package com.ignfab.minalac.generator.tasks;
+
+import java.util.List;
+
+import com.ignfab.minalac.generator.exceptions.UnbuildableException;
+import com.ignfab.minalac.generator.generation.GenerationTile;
+import com.ignfab.minalac.generator.placeables.Structure;
+import com.ignfab.minalac.generator.placeables.layouts.LayoutBuilder;
+import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
+
+/**
+ * A task helping working out layout builders.
+ * <p>
+ * This task places a structure resulting from builders with a desired size.
+ * It is not intended to be used to create worlds from geographical data but rather to visualize how layout builders behave.
+ */
+public class DebugLayoutTask implements TileTask {
+    private final List<LayoutBuilder> builders;
+    private final WorldCoords3d position;
+    private final Integer sizeX;
+    private final Integer sizeY;
+    private final Integer sizeZ;
+
+    /**
+     * Creates an new {@code DebugStructureBuilderTask}.
+     * @param builders list of builders to use for construction (first succeeding will be used)
+     * @param position where to place built structure in world
+     * @param sizeX x-axis component of wanted resulting size or null
+     * @param sizeY y-axis component of wanted resulting size or null
+     * @param sizeZ z-axis component of wanted resulting size or null
+     */
+    public DebugLayoutTask(List<LayoutBuilder> builders, WorldCoords3d position, Integer sizeX, Integer sizeY, Integer sizeZ) throws UnbuildableException {
+        this.builders = builders;
+        this.position = position;
+        this.sizeX = sizeX;
+        this.sizeY = sizeY;
+        this.sizeZ = sizeZ;
+    }
+
+    @Override
+    public void run(GenerationTile tile) {
+        Structure structure = null;
+        int number = 0;
+
+        for (LayoutBuilder builder : builders) {
+            number++;
+            int x = this.sizeX != null ? this.sizeX : builder.xAxis().minimumSize();
+            int y = this.sizeY != null ? this.sizeY : builder.yAxis().minimumSize();
+            int z = this.sizeZ != null ? this.sizeZ : builder.zAxis().minimumSize();
+            System.out.println(builder.xAxis() + ", " + builder.xAxis().minimumSize() + ", " + builder.xAxis().maxSizeUnder(x));
+            System.out.println(builder.yAxis() + ", " + builder.yAxis().minimumSize() + ", " + builder.yAxis().maxSizeUnder(y));
+            System.out.println(builder.zAxis() + ", " + builder.zAxis().minimumSize() + ", " + builder.zAxis().maxSizeUnder(z));
+            System.out.println("Builder #%d buid(%d, %d, %d)".formatted(number, x, y, z));
+            try {
+                structure = builder.build(x, y, z);
+                break;
+            } catch (UnbuildableException e) {
+                System.out.println("Failed:");
+                e.printStackTrace();
+            }
+        }
+
+        if (structure == null) {
+            System.out.println("Could not build facade structure");
+            return;
+        }
+        System.out.println(structure.limits());
+        structure.place(tile.voxels(), position.x(), position.y(), position.z());
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/tasks/RenderFacadeTask.java
+++ b/src/main/java/com/ignfab/minalac/generator/tasks/RenderFacadeTask.java
@@ -1,0 +1,128 @@
+package com.ignfab.minalac.generator.tasks;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import com.ignfab.minalac.generator.exceptions.UnbuildableException;
+import com.ignfab.minalac.generator.generation.GenerationTile;
+import com.ignfab.minalac.generator.models.ModelSelection;
+import com.ignfab.minalac.generator.models.Shape2dConvertibleModel;
+import com.ignfab.minalac.generator.placeables.LayoutStructure;
+import com.ignfab.minalac.generator.placeables.Structure;
+import com.ignfab.minalac.generator.placeables.layouts.LayoutBuilder;
+import com.ignfab.minalac.generator.utils.axis.Axis;
+import com.ignfab.minalac.generator.voxelization.shape2d.LineString2d;
+import com.ignfab.minalac.generator.voxelization.shape2d.Segment2d;
+import com.ignfab.minalac.generator.voxelization.shape2d.iterator.IndexedPosition2d;
+import com.ignfab.minalac.generator.voxelization.shape2d.voxelizer.ThickLinearIndexedVoxelizer2d;
+
+/**
+ * A {@link ModelTask} rendering facades from 2d shapes, using {@link LayoutBuilder}s.
+ */
+public class RenderFacadeTask  extends ModelTask<Shape2dConvertibleModel> {
+
+    private final List<LayoutBuilder> builders;
+    private final String heightMetadata;
+    private final String baseAltitudeMetadata;
+    private final ThickLinearIndexedVoxelizer2d voxelizer;
+
+    /**
+     * Creates a new {@code RenderFacadeTask}.
+     *
+     * @param selection Selection of models to render
+     * @param builders Layout builder to use to render facades
+     * @param heightMetadata Name of metadata holding building height
+     * @param baseAltitudeMetadata Name of metadata holding building base altitude (altitude of walls bottom)
+     */
+    public RenderFacadeTask(
+        ModelSelection selection,
+        List<LayoutBuilder> builders,
+        String heightMetadata,
+        String baseAltitudeMetadata
+    ) {
+        super(Shape2dConvertibleModel.class, selection);
+        this.builders = builders;
+        this.heightMetadata = heightMetadata;
+        this.baseAltitudeMetadata = baseAltitudeMetadata;
+
+        int thickness = 0;
+        for (LayoutBuilder builder : builders)
+            thickness = Math.max(thickness, builder.yAxis().minimumSize());
+
+        voxelizer = new ThickLinearIndexedVoxelizer2d(thickness);
+    }
+
+    @Override
+    protected void run(Shape2dConvertibleModel model, GenerationTile tile) {
+
+        // Process metadata
+        Integer height = model.getMetadata(heightMetadata);
+        Integer baseAltitude = model.getMetadata(baseAltitudeMetadata);
+        if (height == null || baseAltitude == null || height < 0)
+            return;
+
+        height = (int) Math.round(height / tile.generation().getVerticalScale());
+
+        // Process each lineString (actually linearRing) separately
+        for (LineString2d lineString : model.toShape2d().lineStrings()) {
+
+            // Determine facade parts lengths
+            List<Integer> lengths = new LinkedList<>();
+            double remain = 0.0;
+
+            Segment2d previousSegment = null;
+            for (Segment2d segment : lineString.segments()) {
+
+                if (segment.length() > 2.0 && previousSegment != null
+                    && previousSegment.direction().dot(segment.direction()) < 0.5
+                ) {
+                    int length = (int) Math.ceil(remain);
+                    remain -= length;
+                    lengths.add(length);
+                }
+                remain += segment.length();
+                previousSegment = segment;
+            }
+
+            // Add last remaining part
+            if (remain > 0.0)
+                lengths.add((int) Math.ceil(remain));
+
+            // Prepare final structure
+            List<Structure> structures = new LinkedList<>();
+            for (int length : lengths) {
+                Structure structure = null;
+
+                for (LayoutBuilder builder : builders) {
+                    try {
+                        structure = builder.build(
+                            (int) Math.ceil(length),
+                            builder.yAxis().minimumSize(),
+                            height);
+                        break;
+                    } catch (UnbuildableException e) {}
+                }
+
+                if (structure == null) {
+                    System.out.println("Could not build facade structure");
+                    return;
+                }
+                structures.add(structure);
+            }
+
+            Structure structure = LayoutStructure.concatenate(structures, Axis.X);
+
+            // Draw structure along linestring
+            int x;
+            int y;
+
+            for (IndexedPosition2d index : voxelizer.voxelize(lineString)) {
+                x = (int) Math.round(index.index());
+                y = (int) Math.round(index.distance());
+                for (int z = 0; z < height; z++)
+                    if (structure.limits().contains(x, y, z))
+                        structure.get(x, y, z).place(tile.voxels(), index.coords().x(), index.coords().y(), z + baseAltitude);
+            }
+        }
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/utils/axis/Axis.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/axis/Axis.java
@@ -1,0 +1,21 @@
+package com.ignfab.minalac.generator.utils.axis;
+
+/**
+ * Existing axes in 3 dimensions.
+ */
+public enum Axis {
+    /**
+     * X axis.
+     */
+    X,
+
+    /**
+     * Y axis.
+     */
+    Y,
+
+    /**
+     * Z axis (vertical axis in generator).
+     */
+    Z;
+}

--- a/src/main/java/com/ignfab/minalac/generator/utils/axis/mappers/AxisMapper.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/axis/mappers/AxisMapper.java
@@ -1,0 +1,57 @@
+package com.ignfab.minalac.generator.utils.axis.mappers;
+
+/**
+ * An axis mapper maps a mono dimensional position in a composite structure into a substructure index and position in substructure.
+ * <p>
+ * It also provides a list of intervals with their sizes. This could represent a list of dimension, on the given axis, of repeated or placed structures.
+ */
+public interface AxisMapper {
+    /**
+     * Maps given position on axis to an underlying interval.
+     *
+     * @param position position to map
+     * @return {@link Mapped} combining the interval index and in interval position.
+     */
+    Mapped map(int position);
+
+    /**
+     *{@return list of underlying intervals sizes}
+     */
+    int[] intervals();
+
+
+    /**
+     * {@return minimum valid position for this axis mapper}
+     */
+    int minimum();
+
+    /**
+     * {@return maximum valid position for this axis mapper}
+     */
+    default int maximum() {
+        return minimum() + size() - 1;
+    };
+
+    /**
+     * {@return size of the axis mapper}
+     */
+    int size();
+
+    /**
+     * Tells if position could be mapped.
+     *
+     * @param position position to test
+     * @return true if position could be mapped
+     */
+    default boolean contains(int position) {
+        return position >= minimum() && position <= maximum();
+    }
+
+    /**
+     * A mapped index.
+     *
+     * @param index Structure index (which structure index is mapped to)
+     * @param position In structure position
+     */
+    record Mapped(int index, int position){};
+}

--- a/src/main/java/com/ignfab/minalac/generator/utils/axis/mappers/IdentityAxisMapper.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/axis/mappers/IdentityAxisMapper.java
@@ -1,0 +1,48 @@
+package com.ignfab.minalac.generator.utils.axis.mappers;
+
+/**
+ * An {@link AxisMapper} that does an identity mapping.
+ * <p>
+ * It maps any position into interval number 0, at the same position (it keeps same origin as underlying interval)
+ */
+public class IdentityAxisMapper implements AxisMapper {
+    private final int minimum;
+    private final int size;
+    private final int[] intervals;
+
+    /**
+     * Creates a new {@code IdentityIndexMapper}.
+     *
+     * @param minimum Start position of the underlying interval
+     * @param size Size of the underlying (and so mapper) interval
+     */
+    public IdentityAxisMapper(int minimum, int size) {
+        if (size < 0)
+            throw new IllegalArgumentException("length can not be negative");
+        this.size = size;
+        this.minimum = minimum;
+        intervals = (size == 0) ? new int[0] : new int[] { size };
+    }
+
+    @Override
+    public Mapped map(int position) {
+        if (minimum > position || position >= minimum + size)
+            throw new IndexOutOfBoundsException("%s Provided position is out of bounds (position %d, min %d, size %d)".formatted(this, position, minimum, size));
+        return new Mapped(0, position);
+    }
+
+    @Override
+    public int[] intervals() {
+        return intervals;
+    }
+
+    @Override
+    public int minimum() {
+        return minimum;
+    }
+
+    @Override
+    public int size() {
+        return size;
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/utils/axis/mappers/SizesAxisMapper.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/axis/mappers/SizesAxisMapper.java
@@ -1,0 +1,62 @@
+package com.ignfab.minalac.generator.utils.axis.mappers;
+
+/**
+ * An {@link AxisMapper} that maps a position into a concatenation of intervals with given sizes.
+ * <p>
+ * {@code SizesAxisMapper} does not manage origins of underlying intervals.
+ * They would be moved anyway. So origin of this {@link AxisMapper} is always 0.
+ */
+public class SizesAxisMapper implements AxisMapper {
+    private final int size;
+    private final int[] intervals;
+
+    /**
+     * Creates a new {@code SizesAxisMapper}.
+     * <p>
+     * A {@code SizesAxisMapper} maps position into a succession of intervals of various sizes.
+     *
+     * @param sizes list of sizes of intervals composing the axis.
+     */
+    public SizesAxisMapper(int... sizes) {
+        intervals = sizes;
+
+        int size = 0;
+        for (int index = 0; index < intervals.length; index++) {
+            if (intervals[index] < 0)
+                throw new IllegalArgumentException("length can not be negative");
+            size += intervals[index];
+        }
+        this.size = size;
+    }
+
+    @Override
+    public Mapped map(int position) {
+        if (0 > position || position >= size)
+            throw new IndexOutOfBoundsException("Provided position is out of bounds");
+
+        for (int index = 0; index < intervals.length; index++) {
+            int size = intervals[index];
+            if (position < size)
+                return new Mapped(index, position);
+            position -= size;
+        }
+
+        // Will never be reached
+        throw new IndexOutOfBoundsException("This is a bug");
+    }
+
+    @Override
+    public int[] intervals() {
+        return intervals;
+    }
+
+    @Override
+    public int minimum() {
+        return 0;
+    }
+
+    @Override
+    public int size() {
+        return size;
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/utils/axis/mappers/StretcherIndexMapper.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/axis/mappers/StretcherIndexMapper.java
@@ -1,0 +1,62 @@
+package com.ignfab.minalac.generator.utils.axis.mappers;
+
+/**
+ * An {@link AxisMapper} that maps position into one stretched interval.
+ */
+public class StretcherIndexMapper implements AxisMapper {
+    private final int size;
+    private final int[] intervals;
+    private final int stretchablePosition;
+    private final int stretchSize;
+    private final int minimum;
+
+    /**
+     * Creates a new {@code AxisMapper}.
+     *
+     * @param origin the origin of this mapper
+     * @param stretchablePosition Position where the underlying interval is stretched (must be in the underlying interval)
+     * @param baseSize Size of the underlying interval
+     * @param size Stretched size (size of this mapper)
+     */
+    public StretcherIndexMapper(int origin, int stretchablePosition, int baseSize, int size) {
+        if (baseSize <= 0)
+            throw new IllegalArgumentException("Base size can not be negative or zero");
+        if (size < 0)
+            throw new IllegalArgumentException("Size can not be negative");
+        if (size - baseSize < -1)
+            throw new IllegalArgumentException("Can not be squeezed more than 1");
+        if (stretchablePosition < origin || stretchablePosition >= origin + baseSize)
+            throw new IllegalArgumentException("Stretchable coordinate out of base interval");
+
+        this.stretchablePosition = stretchablePosition;
+        this.stretchSize = size - baseSize;
+        this.size = size;
+        this.minimum = origin;
+
+        intervals = new int[]{ baseSize };
+    }
+
+    @Override
+    public Mapped map(int position) {
+        if (position < minimum || position >= minimum + size)
+            throw new IndexOutOfBoundsException("Position out of index mapper size");
+        return new Mapped(0,
+           position < stretchablePosition ? position : Math.max(stretchablePosition, position - stretchSize)
+        );
+    }
+
+    @Override
+    public int[] intervals() {
+        return intervals;
+    }
+
+    @Override
+    public int minimum() {
+        return minimum;
+    }
+
+    @Override
+    public int size() {
+        return size;
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/utils/axis/mappers/builders/AdjustAxisMapperBuilder.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/axis/mappers/builders/AdjustAxisMapperBuilder.java
@@ -1,0 +1,85 @@
+package com.ignfab.minalac.generator.utils.axis.mappers.builders;
+
+import com.ignfab.minalac.generator.exceptions.UnbuildableException;
+import com.ignfab.minalac.generator.utils.axis.mappers.AxisMapper;
+import com.ignfab.minalac.generator.utils.axis.mappers.IdentityAxisMapper;
+
+/**
+ * An {@link AxisMapperBuilder} made of multiple {@link AxisMapperBuilder}s having the same dimensions.
+ * <p>
+ * Underlying builders must all have the same origin or {@code AdjustAxisMapperBuilder} will not be
+ * able to adjust them as we have no stretcher able to change origin yet.
+ */
+public class AdjustAxisMapperBuilder implements AxisMapperBuilder {
+    private final AxisMapperBuilder[] builders;
+    private final int minimumSize;
+    private final int origin;
+
+    /**
+     * Creates a new {@code OverlayAxisMapperBuilder}.
+     * @param builders underlying {@link AxisMapperBuilder} to overlay
+     * @throws UnbuildableException
+     */
+    public AdjustAxisMapperBuilder(AxisMapperBuilder... builders) throws UnbuildableException {
+        this.builders = builders;
+
+        if (builders.length == 0) {
+            origin = 0;
+            minimumSize = 0;
+            return;
+        }
+
+        int origin = builders[0].origin();
+        int minimumSize = 0;
+
+        for (AxisMapperBuilder builder : builders) {
+            if (origin != builder.origin())
+                throw new UnbuildableException("All origins must be the same");
+            minimumSize = Math.max(minimumSize, builder.minimumSize());
+        }
+
+        // Check
+        minimumSize = maxSizeUnder(minimumSize);
+
+        if (minimumSize < 0)
+            throw new UnbuildableException("Unable to adjust dimensions (builders don't agree)");
+
+        this.minimumSize = minimumSize;
+        this.origin = origin;
+    }
+
+    @Override
+    public AxisMapper build(int size) throws UnbuildableException {
+        if (size < 0)
+            throw new IllegalArgumentException("Size must be positive or zero");
+
+        int possible = maxSizeUnder(size);
+        if (size != possible)
+            throw new UnbuildableException("Impossible to build for this size (%d, possible %d)".formatted(size, possible));
+
+        return new IdentityAxisMapper(origin, size);
+    }
+
+    @Override
+    public int maxSizeUnder(int size) {
+        if (size < 0)
+            return size;
+        int minCandidate = size;
+        for (AxisMapperBuilder builder : builders)
+            minCandidate = Math.min(minCandidate, builder.maxSizeUnder(size));
+        if (minCandidate < 0 || minCandidate == size)
+            return minCandidate;
+
+        return maxSizeUnder(minCandidate);
+    }
+
+    @Override
+    public int minimumSize() {
+        return minimumSize;
+    }
+
+    @Override
+    public int origin() {
+        return origin;
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/utils/axis/mappers/builders/AxisMapperBuilder.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/axis/mappers/builders/AxisMapperBuilder.java
@@ -1,0 +1,42 @@
+package com.ignfab.minalac.generator.utils.axis.mappers.builders;
+
+import com.ignfab.minalac.generator.exceptions.UnbuildableException;
+import com.ignfab.minalac.generator.utils.axis.mappers.AxisMapper;
+
+/**
+ * A builder for {@link AxisMapper}s.
+ * <p>
+ * An {@code AxisMapperBuilder} builds {@link AxisMapper}s and gives information about their possible sizes.
+ */
+public interface AxisMapperBuilder {
+    /**
+     * Creates an {@link AxisMapper} for the given size.
+     * <p>
+     * Resulting {@link AxisMapper} will not be offsetted (it will start at position 0)
+     *
+     * @param size wanted size for {@link AxisMapper}
+     * @return built {@link AxisMapper}
+     * @throws UnbuildableException if not able to build for this size.
+     */
+    AxisMapper build(int size) throws UnbuildableException;
+
+    /**
+     * Returns the greatest buildable size under given size.
+     * <p>
+     * Not all sizes are suitable for building. This methods will provide information about what is possible.
+     * Returns -1 if no suitable size found.
+     * @param size Testing size
+     * @return Greatest buildable size under testing size.
+     */
+    int maxSizeUnder(int size);
+
+    /**
+     * {@return the minimal buildable size}
+     */
+    int minimumSize();
+
+    /**
+     * {@return the starting point (usually 0 but may be different)}
+     */
+    int origin();
+}

--- a/src/main/java/com/ignfab/minalac/generator/utils/axis/mappers/builders/ConstantAxisMapperBuilder.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/axis/mappers/builders/ConstantAxisMapperBuilder.java
@@ -1,0 +1,46 @@
+package com.ignfab.minalac.generator.utils.axis.mappers.builders;
+
+import com.ignfab.minalac.generator.exceptions.UnbuildableException;
+import com.ignfab.minalac.generator.utils.axis.mappers.AxisMapper;
+import com.ignfab.minalac.generator.utils.axis.mappers.IdentityAxisMapper;
+
+/**
+ * An {@link AxisMapperBuilder} for a constant size.
+ */
+public class ConstantAxisMapperBuilder implements AxisMapperBuilder {
+    private final int size;
+    private final int origin;
+
+    /**
+     * Creates a new {@code ConstantAxisMapperBuilder}.
+     *
+     * @param size Size of the built {@link AxisMapper}.
+     * @param origin Starting position of underlying interval.
+     */
+    public ConstantAxisMapperBuilder(int size, int origin) {
+        this.size = size;
+        this.origin = origin;
+    }
+
+    @Override
+    public AxisMapper build(int size) throws UnbuildableException {
+        if (size != this.size)
+            throw new UnbuildableException("Requested size isn't equal to the intrinsic size");
+        return new IdentityAxisMapper(origin, size);
+    }
+
+    @Override
+    public int maxSizeUnder(int size) {
+        return size < this.size ? -1 : this.size;
+    }
+
+    @Override
+    public int minimumSize() {
+        return size;
+    }
+
+    @Override
+    public int origin() {
+        return origin;
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/utils/axis/mappers/builders/DelegateAxisMapperBuilder.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/axis/mappers/builders/DelegateAxisMapperBuilder.java
@@ -1,0 +1,43 @@
+package com.ignfab.minalac.generator.utils.axis.mappers.builders;
+
+import com.ignfab.minalac.generator.exceptions.UnbuildableException;
+import com.ignfab.minalac.generator.utils.axis.mappers.AxisMapper;
+import com.ignfab.minalac.generator.utils.axis.mappers.IdentityAxisMapper;
+
+/**
+ * An {@link AxisMapperBuilder} inheriting everything from another {@link AxisMapperBuilder}.
+ */
+public class DelegateAxisMapperBuilder implements AxisMapperBuilder {
+    private final AxisMapperBuilder delegatee;
+
+    /**
+     * Creates a new {@code DelegateAxisMapperBuilder} for a given {@link AxisMapperBuilder}.
+     *
+     * @param delegatee an {@link AxisMapperBuilder} from which everything in inherited
+     */
+    public DelegateAxisMapperBuilder(AxisMapperBuilder delegatee) {
+        this.delegatee = delegatee;
+    }
+
+    @Override
+    public AxisMapper build(int size) throws UnbuildableException {
+        if (delegatee.maxSizeUnder(size) > size)
+            throw new UnbuildableException("Builder could not fit size=%d (Builder is %s)".formatted(size, delegatee));
+        return new IdentityAxisMapper(delegatee.origin(), size);
+    }
+
+    @Override
+    public int maxSizeUnder(int size) {
+        return delegatee.maxSizeUnder(size);
+    }
+
+    @Override
+    public int minimumSize() {
+        return delegatee.minimumSize();
+    }
+
+    @Override
+    public int origin() {
+        return delegatee.origin();
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/utils/axis/mappers/builders/KeepAxisMapperBuilder.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/axis/mappers/builders/KeepAxisMapperBuilder.java
@@ -1,0 +1,60 @@
+package com.ignfab.minalac.generator.utils.axis.mappers.builders;
+
+import com.ignfab.minalac.generator.exceptions.UnbuildableException;
+import com.ignfab.minalac.generator.utils.axis.mappers.AxisMapper;
+import com.ignfab.minalac.generator.utils.axis.mappers.IdentityAxisMapper;
+
+/**
+ * An {@link AxisMapperBuilder} made of multiple overlayed {@link AxisMapperBuilder}s.
+ */
+public class KeepAxisMapperBuilder implements AxisMapperBuilder {
+    private final int minimumSize;
+    private final int origin;
+
+    /**
+     * Creates a new {@code OverlayAxisMapperBuilder}.
+     * @param builders underlying {@link AxisMapperBuilder} to overlay
+     */
+    public KeepAxisMapperBuilder(AxisMapperBuilder... builders) {
+        if (builders.length == 0) {
+            origin = 0;
+            minimumSize = 0;
+        } else {
+            int minimum = Integer.MAX_VALUE;
+            int maximum = Integer.MIN_VALUE;
+
+            for (AxisMapperBuilder builder : builders) {
+                minimum = Math.min(minimum, builder.origin());
+                maximum = Math.max(maximum, builder.origin() + builder.minimumSize());
+            }
+            origin = minimum;
+            minimumSize = maximum - minimum;
+        }
+    }
+
+    @Override
+    public AxisMapper build(int size) throws UnbuildableException {
+        if (size < 0)
+            throw new IllegalArgumentException("Size must be positive or zero");
+        // Must be quite permissive or won't be able to render stuff with various sizes
+        if (size < minimumSize)
+            throw new UnbuildableException("Impossible to build for this size (%d, must be at least %d)".formatted(size, minimumSize));
+
+        return new IdentityAxisMapper(origin, size);
+    }
+
+    @Override
+    public int maxSizeUnder(int size) {
+        return size < minimumSize ? -1 : size;
+    }
+
+    @Override
+    public int minimumSize() {
+        return minimumSize;
+    }
+
+    @Override
+    public int origin() {
+        return origin;
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/utils/axis/mappers/builders/PriorityRepartitionAxisMapperBuilder.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/axis/mappers/builders/PriorityRepartitionAxisMapperBuilder.java
@@ -1,0 +1,183 @@
+package com.ignfab.minalac.generator.utils.axis.mappers.builders;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import com.ignfab.minalac.generator.exceptions.UnbuildableException;
+import com.ignfab.minalac.generator.utils.axis.mappers.AxisMapper;
+import com.ignfab.minalac.generator.utils.axis.mappers.SizesAxisMapper;
+
+/**
+ * An {@link AxisMapperBuilder} that distributes space to undelying {@link AxisMapperBuilder} with priorities.
+ * <p>
+ * Origins of {@link AxisMapperBuilder} are ignored as they are placed according to {@code PriorityRepartitionAxisMapperBuilder} computations.
+ */
+public class PriorityRepartitionAxisMapperBuilder implements AxisMapperBuilder {
+    private final AxisMapperBuilder[] builders;
+    private final TreeMap<Integer, List<Integer>> priorities = new TreeMap<>(Collections.reverseOrder());
+    private final int[] minLengths;
+    private final int minimalSize;
+
+    /**
+     * Creates a new {@code PriorityRepartitionAxisMapperBuilder}.
+     * <p>
+     * Underlying builders will be placed side by side. To fill total size, they will be resized according to priorities.
+     * Higher priority gets extra size first. If they can't fill the size, remaining will be given to lower priorities.
+     *
+     * @param builders   underlying builders, must have the same length as {@code priorities}
+     * @param priorities corresponding priorities, must have the same length as {@code builders}
+     * @throws UnbuildableException if underlying builders are not adjustable
+     */
+    public PriorityRepartitionAxisMapperBuilder(AxisMapperBuilder[] builders, int[] priorities) throws UnbuildableException {
+        if (builders.length != priorities.length)
+            throw new IllegalArgumentException("Provide array must be same length");
+
+        int sum = 0;
+        minLengths = new int[builders.length];
+        this.builders = builders;
+
+        for (int i = 0; i < builders.length; i++) {
+            // Sort builder indexes by priorities
+            this.priorities.computeIfAbsent(priorities[i], k -> new ArrayList<>()).add(i);
+
+            minLengths[i] = builders[i].minimumSize();
+            sum = sum + minLengths[i];
+        }
+        minimalSize = sum;
+    }
+
+    @Override
+    public AxisMapper build(int size) throws UnbuildableException {
+        if (size < minimalSize)
+            throw new UnbuildableException("Requested size is not enough");
+
+        DistributionResult result = compute(size);
+
+        if (result.remainder != 0)
+            throw new UnbuildableException("Could not distribute remainder");
+
+        return new SizesAxisMapper(result.lengths);
+    }
+
+    @Override
+    public int maxSizeUnder(int size) {
+        if (size < minimalSize)
+            return -1;
+        int remainder = compute(size).remainder;
+        return size - remainder;
+    }
+
+    @Override
+    public int minimumSize() {
+        return minimalSize;
+    }
+
+    private DistributionResult compute(int size) {
+        int remaining = size - minimalSize;
+        if (remaining == 0) return new DistributionResult(minLengths, 0);
+        int[] lengths = minLengths.clone();
+
+        // Distribute remaining by priority group
+        for (Map.Entry<Integer, List<Integer>> priority : priorities.entrySet()) {
+            List<Integer> candidates = new ArrayList<>(priority.getValue());
+            boolean firstIteration = true;
+
+            // There are two phases.
+            // Phase 1 : We try to feed each builder with a fairShare between the candidates
+            // Phase 2 : A starved builder a builder who hasn't eaten but can eat.  This phase give each starved successively larger share until one or more eat.
+            while (remaining > 0 && !candidates.isEmpty()) {
+                int lastRemaining = remaining;
+                int lastCount = candidates.size();
+                candidates.sort(Comparator.comparingInt(i -> lengths[i]));
+                // Ceil division
+                int fairShare = (remaining + candidates.size() - 1) / candidates.size();
+
+                List<Integer> starved = new ArrayList<>();
+
+                // This is phase 1 : Fast distribution
+                Iterator<Integer> candidateIterator = candidates.iterator();
+                while (candidateIterator.hasNext()) {
+                    int index = candidateIterator.next();
+                    // Builders with a minimumSize already ate during allocation.
+                    // First iteration is different for them to prevent potential starvation of other candidates.
+                    if (firstIteration && lengths[index] > 0) {
+                        int toEat = builders[index].maxSizeUnder(fairShare);
+                        // Should eat if its allocated minimal size is inferior to what it could have eaten with no min size.
+                        if (toEat > lengths[index]) {
+                            remaining = remaining - (toEat - lengths[index]);
+                            lengths[index] = toEat;
+                        }
+                        continue;
+                    }
+                    int toEat = builders[index].maxSizeUnder(lengths[index] + Math.min(remaining, fairShare));
+                    if (toEat > lengths[index]) {
+                        remaining = remaining - (toEat - lengths[index]);
+                        lengths[index] = toEat;
+                    // Can not eat, it is no longer a candidate
+                    } else if (builders[index].maxSizeUnder(lengths[index] + remaining) == lengths[index]) {
+                        candidateIterator.remove();
+                    // Can potentially eat, will go on phase 2
+                    } else {
+                        starved.add(index);
+                    }
+                }
+
+                // Phase 2 give each starved successively larger share until one or more eat.
+                // All candidates that end up on starved list have the possibility to eat something (Otherwise they would have been removed on phase 1).
+                // They may no all eat, but at least one starved will eat.
+                while (!starved.isEmpty() && remaining > 0) {
+                    int lastStarvedRemaining = remaining;
+                    starved.sort(Comparator.comparingInt(i -> lengths[i]));
+                    for (int count = lastCount - 1; count > 0; count--) {
+                        int share = (remaining + count - 1) / count;
+
+                        Iterator<Integer> starvedIterator = starved.iterator();
+                        while (starvedIterator.hasNext()) {
+                            int currentIndex = starvedIterator.next();
+                            int toEat = builders[currentIndex].maxSizeUnder(lengths[currentIndex] + Math.min(remaining, share));
+
+                            if (toEat > lengths[currentIndex]) {
+                                remaining = remaining - (toEat - lengths[currentIndex]);
+                                lengths[currentIndex] = toEat;
+                                starvedIterator.remove();
+                                break;
+                            }
+                        }
+                    }
+
+                    // We give up phase 2. Full candidates will be removed on phase 1.
+                    if (lastStarvedRemaining == remaining)
+                        break;
+                }
+
+                // No progress at all we give up. It should not be necessary.
+
+                // At the end of phase 1. Candidate is either : full (and removed), hasEaten or isStarved (canEat and on starvedList).
+                // Worst scenario of no progress is : all in starvedList.
+                // On phase 2, each starved candidate is given successive larger share until reaching remaining.
+                // Worst scenario is that only one among the starved eat.
+                // If others starved can't eat phase 2 will break and those starved will be eventually be removed.
+
+                // Since I can't be 100% sure on edges cases, I have put this test as a safeguard.
+                if (lastRemaining == remaining && lastCount == candidates.size() && !firstIteration)
+                    break;
+
+                firstIteration = false;
+            }
+        }
+        return new DistributionResult(lengths, remaining);
+    }
+
+    private record DistributionResult(int[] lengths, int remainder) {
+    }
+
+    @Override
+    public int origin() {
+        return 0;
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/utils/axis/mappers/builders/RepeatAxisMapperBuilder.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/axis/mappers/builders/RepeatAxisMapperBuilder.java
@@ -1,0 +1,97 @@
+package com.ignfab.minalac.generator.utils.axis.mappers.builders;
+
+import java.util.Arrays;
+
+import com.ignfab.minalac.generator.exceptions.UnbuildableException;
+import com.ignfab.minalac.generator.utils.axis.mappers.AxisMapper;
+import com.ignfab.minalac.generator.utils.axis.mappers.SizesAxisMapper;
+
+/**
+ * An {@link AxisMapperBuilder} that repeats underlying {@link AxisMapperBuilder} as many times as possible.
+ */
+public class RepeatAxisMapperBuilder implements AxisMapperBuilder {
+    private final AxisMapperBuilder underlying;
+    private final int minSize;
+    private final int maxOccur;
+
+    /**
+     * Creates a new {@code EqualizerAxisMapperBuilder}.
+     *
+     * @param underlying Undelying {@link AxisMapperBuilder} to repeat
+     * @param minOccur Minimum number of occurences
+     * @param maxOccur Maximum number of occurences
+     * @throws UnbuildableException
+     */
+    public RepeatAxisMapperBuilder(AxisMapperBuilder underlying, int minOccur, int maxOccur) throws UnbuildableException {
+        // Another way to do it to allow it is to instantiate a SizesAxisMapper with a length of 0.
+        // If changed, StretcherAxisMapperBuilder should have same behavior
+        if (underlying.minimumSize() <= 0)
+            throw new UnbuildableException("Underlying has a minimum size of zero. Can not be repeated");
+        this.maxOccur = maxOccur;
+        this.underlying = underlying;
+        minSize = underlying.minimumSize() * minOccur;
+    }
+
+    @Override
+    public AxisMapper build(int size) throws UnbuildableException {
+        if (size < minSize)
+            throw new UnbuildableException("Requested size is not enough");
+
+        DistributionResult result = compute(size, underlying.minimumSize());
+        int remainder = result.remainder;
+
+        if (remainder != 0)
+            throw new UnbuildableException("Requested size iis either not enough or too large. Failed to distribute remainder");
+
+        return new SizesAxisMapper(result.lengths);
+    }
+
+    @Override
+    public int maxSizeUnder(int size) {
+        if (size < minSize)
+            return -1;
+
+        int underlyingMin = underlying.minimumSize();
+        if (underlyingMin == 0) return 0;
+
+        DistributionResult result = compute(size, underlyingMin);
+        return size - result.remainder;
+    }
+
+
+    @Override
+    public int minimumSize() {
+        return minSize;
+    }
+
+    @Override
+    public int origin() {
+        return 0;
+    }
+
+    private DistributionResult compute(int size, int underlyingMin) {
+        if (underlyingMin <= 0)
+            throw new UnsupportedOperationException("Can not repeat a layout that has a minimal size equal or bellow zero");
+        int count = Math.min(size / underlyingMin, maxOccur);
+        // Modulo not used since maxOccur can be bellow (size / underlyingMin)
+        int remaining = size - count * underlyingMin;
+
+        int[] lengths = new int[count];
+        Arrays.fill(lengths, underlyingMin);
+
+        for (int index = 0; index < lengths.length; index++) {
+            // Math.ceilDiv not available in Java 17
+            int possible = underlying.maxSizeUnder(underlyingMin + (remaining + count - 1) / count);
+            // distributedRemaining is (lengths[index] - possible)
+            remaining =  remaining + lengths[index] - possible;
+            lengths[index] = possible;
+            count--;
+        }
+
+        return new DistributionResult(lengths, remaining);
+    }
+
+    private record DistributionResult(int[] lengths, int remainder) {
+    }
+
+}

--- a/src/main/java/com/ignfab/minalac/generator/utils/axis/mappers/builders/StretcherAxisMapperBuilder.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/axis/mappers/builders/StretcherAxisMapperBuilder.java
@@ -1,0 +1,65 @@
+package com.ignfab.minalac.generator.utils.axis.mappers.builders;
+
+import com.ignfab.minalac.generator.exceptions.UnbuildableException;
+import com.ignfab.minalac.generator.utils.axis.mappers.AxisMapper;
+import com.ignfab.minalac.generator.utils.axis.mappers.StretcherIndexMapper;
+
+/**
+ * Builder for an {@link AxisMapper} that stretches an interval at a given coordinate.
+ */
+public class StretcherAxisMapperBuilder implements AxisMapperBuilder {
+    // For now, the only AxisMapperBuilder that is passed is the ConstantAxisMapperBuilder.
+    // StretcherIndexMapper was functionally made to work with something constant.
+    // If something else is passed, the resulting mapping might be incorrect.
+    // The AxisMapperBuilder is kept for consistency.
+    private final AxisMapperBuilder underlying;
+    private final int stretchableCoord;
+    private final int minSize;
+    private final int maxSize;
+
+    /**
+     * Creates a new {@code StretcherAxisMapperBuilder}.
+     *
+     * @param underlying {@link AxisMapperBuilder} to stretch
+     * @param stretchableCoord coordinate where to stretch {@code underlying}
+     * @param minRepetition minimum possible repetitions of stretchable coordinate
+     * @param maxRepetition maximum possible repetitions of stretchable coordinate
+     * @throws UnbuildableException if underlying builder is not adjustable
+     */
+    public StretcherAxisMapperBuilder(AxisMapperBuilder underlying, int stretchableCoord, int minRepetition, int maxRepetition) throws UnbuildableException {
+        // If changed, RepeatAxisMapperBuilder should have same behavior
+        if (underlying.minimumSize() <= 0)
+            throw new UnbuildableException("Underlying has a minimum size of zero. Can not be stretched");
+        this.underlying = underlying;
+        this.stretchableCoord = stretchableCoord;
+        int underlyingMin = underlying.minimumSize();
+        minSize = underlyingMin + minRepetition - 1;
+        maxSize = (maxRepetition == Integer.MAX_VALUE) ? Integer.MAX_VALUE : underlying.minimumSize() + maxRepetition - 1;
+    }
+
+    @Override
+    public AxisMapper build(int size) throws UnbuildableException {
+        if (size < minSize)
+            throw new UnbuildableException("Not enough space");
+        if (size > maxSize)
+            throw new UnbuildableException("Requested size is too large");
+        return new StretcherIndexMapper(underlying.origin(), stretchableCoord, underlying.minimumSize(), size);
+    }
+
+    @Override
+    public int maxSizeUnder(int size) {
+        if (size < minSize)
+            return -1;
+        return Math.min(size, maxSize);
+    }
+
+    @Override
+    public int minimumSize() {
+        return minSize;
+    }
+
+    @Override
+    public int origin() {
+        return underlying.origin();
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/utils/world2d/WorldCoords2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world2d/WorldCoords2d.java
@@ -1,5 +1,6 @@
 package com.ignfab.minalac.generator.utils.world2d;
 
+import com.ignfab.minalac.generator.utils.axis.Axis;
 import com.ignfab.minalac.generator.utils.world3d.Positioned3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
 
@@ -77,6 +78,19 @@ public record WorldCoords2d(int x, int y) implements Positioned2d {
      */
     public static WorldCoords2d ceil(double x, double y) {
         return new WorldCoords2d((int) Math.ceil(x), (int) Math.ceil(y));
+    }
+
+    /**
+     * Returns one of {@code WorldCoords2d} component.
+     * @param axis component axis
+     * @return component value
+     */
+    public int coord(Axis axis) {
+        return switch (axis) {
+            case X -> x;
+            case Y -> y;
+            case Z -> throw new IllegalArgumentException("Does not exist for that axis.");
+        };
     }
 
     @Override

--- a/src/main/java/com/ignfab/minalac/generator/utils/world2d/WorldSize2d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world2d/WorldSize2d.java
@@ -1,5 +1,6 @@
 package com.ignfab.minalac.generator.utils.world2d;
 
+import com.ignfab.minalac.generator.utils.axis.Axis;
 import com.ignfab.minalac.generator.utils.world3d.WorldSize3d;
 
 /**
@@ -53,5 +54,18 @@ public record WorldSize2d(int x, int y) {
      */
     public WorldSize3d to3d(int z) {
         return new WorldSize3d(this, z);
+    }
+
+    /**
+     * Returns one of {@code WorldSize2d} component.
+     * @param axis component axis
+     * @return component value
+     */
+    public int coord(Axis axis) {
+        return switch (axis) {
+            case X -> x;
+            case Y -> y;
+            case Z -> throw new IllegalArgumentException("Does not exist for that axis.");
+        };
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/utils/world3d/WorldCoords3d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world3d/WorldCoords3d.java
@@ -1,5 +1,6 @@
 package com.ignfab.minalac.generator.utils.world3d;
 
+import com.ignfab.minalac.generator.utils.axis.Axis;
 import com.ignfab.minalac.generator.utils.world2d.Positioned2d;
 import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
 
@@ -91,6 +92,19 @@ public record WorldCoords3d(int x, int y, int z) implements Positioned3d {
      */
     public WorldCoords3d add(WorldCoords3d value) {
         return add(value.x, value.y, value.z);
+    }
+
+    /**
+     * Returns one of {@code WorldCoords3d} component.
+     * @param axis component axis
+     * @return component value
+     */
+    public int coord(Axis axis) {
+        return switch (axis) {
+            case X -> x;
+            case Y -> y;
+            case Z -> z;
+        };
     }
 
     @Override

--- a/src/main/java/com/ignfab/minalac/generator/utils/world3d/WorldSize3d.java
+++ b/src/main/java/com/ignfab/minalac/generator/utils/world3d/WorldSize3d.java
@@ -1,5 +1,6 @@
 package com.ignfab.minalac.generator.utils.world3d;
 
+import com.ignfab.minalac.generator.utils.axis.Axis;
 import com.ignfab.minalac.generator.utils.world2d.WorldSize2d;
 
 /**
@@ -55,5 +56,18 @@ public record WorldSize3d(int x, int y, int z) {
      */
     public WorldSize2d to2d() {
         return new WorldSize2d(this);
+    }
+
+    /**
+     * Returns one of {@code WorldSize3d} component.
+     * @param axis component axis
+     * @return component value
+     */
+    public int coord(Axis axis) {
+        return switch (axis) {
+            case X -> x;
+            case Y -> y;
+            case Z -> z;
+        };
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/utils/axis/mappers/IdentityAxisMapperTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/axis/mappers/IdentityAxisMapperTest.java
@@ -1,0 +1,45 @@
+package com.ignfab.minalac.generator.utils.axis.mappers;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class IdentityAxisMapperTest {
+    @Test
+    public void testConstructor() {
+        assertThrows(IllegalArgumentException.class, () -> new IdentityAxisMapper(0, -1));
+    }
+
+    @Test
+    public void testMap() {
+        AxisMapper empty = assertDoesNotThrow(() -> new IdentityAxisMapper(0, 0));
+        assertThrows(IndexOutOfBoundsException.class, () -> empty.map(0));
+
+        AxisMapper notEmpty = assertDoesNotThrow(() -> new IdentityAxisMapper(1, 3));
+        assertThrows(IndexOutOfBoundsException.class, () -> notEmpty.map(0));
+        assertThrows(IndexOutOfBoundsException.class, () -> notEmpty.map(4));
+
+        assertEquals(new AxisMapper.Mapped(0, 1), notEmpty.map(1));
+        assertEquals(new AxisMapper.Mapped(0, 2), notEmpty.map(2));
+        assertEquals(new AxisMapper.Mapped(0, 3), notEmpty.map(3));
+    }
+
+    @Test
+    public void testIntervals() {
+        int[] empty = assertDoesNotThrow(() -> (new IdentityAxisMapper(0, 0).intervals()));
+        assertEquals(0, empty.length);
+
+        int[] notEmpty = assertDoesNotThrow(() -> (new IdentityAxisMapper(2, 7).intervals()));
+        assertEquals(1, notEmpty.length);
+        assertEquals(7, notEmpty[0]);
+    }
+
+    @Test
+    public void testSize() {
+        AxisMapper empty = assertDoesNotThrow(() -> new IdentityAxisMapper(2, 0));
+        assertEquals(0, empty.size());
+
+        AxisMapper notEmpty = assertDoesNotThrow(() -> new IdentityAxisMapper(3, 37));
+        assertEquals(37, notEmpty.size());
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/utils/axis/mappers/SizesAxisMapperTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/axis/mappers/SizesAxisMapperTest.java
@@ -1,0 +1,65 @@
+package com.ignfab.minalac.generator.utils.axis.mappers;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class SizesAxisMapperTest {
+    @Test
+    public void testConstructor() {
+        assertThrows(IllegalArgumentException.class, () -> new SizesAxisMapper(2, 1, -5));
+        assertThrows(IllegalArgumentException.class, () -> new SizesAxisMapper(-2, 1, 5));
+        assertDoesNotThrow(() -> new SizesAxisMapper());
+        assertDoesNotThrow(() -> new SizesAxisMapper(1, 2, 0));
+        assertDoesNotThrow(() -> new SizesAxisMapper(1, 2, 7));
+    }
+
+    @Test
+    public void testMap() {
+        AxisMapper empty = assertDoesNotThrow(() -> new SizesAxisMapper(0));
+        assertThrows(IndexOutOfBoundsException.class, () -> empty.map(0));
+
+        AxisMapper notEmpty = assertDoesNotThrow(() -> new SizesAxisMapper(3));
+        assertThrows(IndexOutOfBoundsException.class, () -> notEmpty.map(-1));
+        assertThrows(IndexOutOfBoundsException.class, () -> notEmpty.map(3));
+
+        assertEquals(new AxisMapper.Mapped(0, 0), notEmpty.map(0));
+        assertEquals(new AxisMapper.Mapped(0, 1), notEmpty.map(1));
+        assertEquals(new AxisMapper.Mapped(0, 2), notEmpty.map(2));
+
+        AxisMapper multiple = assertDoesNotThrow(() -> new SizesAxisMapper(3, 0, 1, 2));
+        assertThrows(IndexOutOfBoundsException.class, () -> multiple.map(-1));
+        assertThrows(IndexOutOfBoundsException.class, () -> multiple.map(6));
+
+        // First interval (length 3)
+        assertEquals(new AxisMapper.Mapped(0, 0), multiple.map(0));
+        assertEquals(new AxisMapper.Mapped(0, 1), multiple.map(1));
+        assertEquals(new AxisMapper.Mapped(0, 2), multiple.map(2));
+
+        // Third interval (length 1)
+        assertEquals(new AxisMapper.Mapped(2, 0), multiple.map(3));
+
+        // Fourth interval (length 0)
+        assertEquals(new AxisMapper.Mapped(3, 0), multiple.map(4));
+        assertEquals(new AxisMapper.Mapped(3, 1), multiple.map(5));
+    }
+
+    @Test
+    public void testIntervals() {
+        assertArrayEquals(new int[] {}, new SizesAxisMapper().intervals());
+        assertArrayEquals(new int[] { 3, 1, 2 }, new SizesAxisMapper(3, 1, 2).intervals());
+        assertArrayEquals(new int[] { 0, 1, 2 }, new SizesAxisMapper(0, 1, 2).intervals());
+    }
+
+    @Test
+    public void testSize() {
+        AxisMapper empty = assertDoesNotThrow(() -> new SizesAxisMapper(0));
+        assertEquals(0, empty.size());
+
+        AxisMapper notEmpty = assertDoesNotThrow(() -> new SizesAxisMapper(3, 1, 5));
+        assertEquals(9, notEmpty.size());
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/utils/axis/mappers/StretcherAxisMapperTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/axis/mappers/StretcherAxisMapperTest.java
@@ -1,0 +1,74 @@
+package com.ignfab.minalac.generator.utils.axis.mappers;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class StretcherAxisMapperTest {
+    @Test
+    public void testConstructor() {
+        assertThrows(IllegalArgumentException.class, () -> new StretcherIndexMapper(0, 0, 2, -1), "negative length");
+        assertThrows(IllegalArgumentException.class, () -> new StretcherIndexMapper(0, 0, -1, 1), "negative base length");
+        assertThrows(IllegalArgumentException.class, () -> new StretcherIndexMapper(0, 0, 3, 1), "Squeezed more than once");
+        assertThrows(IllegalArgumentException.class, () -> new StretcherIndexMapper(0, 4, 2, 2), "stretch out of size");
+    }
+
+    @Test
+    public void testMap() {
+        AxisMapper same = assertDoesNotThrow(() -> (new StretcherIndexMapper(0, 1, 3, 3)));
+        assertEquals(new AxisMapper.Mapped(0, 0), same.map(0));
+        assertEquals(new AxisMapper.Mapped(0, 1), same.map(1));
+        assertEquals(new AxisMapper.Mapped(0, 2), same.map(2));
+
+        AxisMapper stretched = assertDoesNotThrow(() -> (new StretcherIndexMapper(0, 1, 3, 5)));
+        assertEquals(new AxisMapper.Mapped(0, 0), stretched.map(0));
+        assertEquals(new AxisMapper.Mapped(0, 1), stretched.map(1));
+        assertEquals(new AxisMapper.Mapped(0, 1), stretched.map(2));
+        assertEquals(new AxisMapper.Mapped(0, 1), stretched.map(3));
+        assertEquals(new AxisMapper.Mapped(0, 2), stretched.map(4));
+
+        AxisMapper squeezedFirst = assertDoesNotThrow(() -> (new StretcherIndexMapper(0, 0, 3, 2)));
+        assertEquals(new AxisMapper.Mapped(0, 1), squeezedFirst.map(0));
+        assertEquals(new AxisMapper.Mapped(0, 2), squeezedFirst.map(1));
+
+        AxisMapper squeezedSecond = assertDoesNotThrow(() -> (new StretcherIndexMapper(0, 1, 3, 2)));
+        assertEquals(new AxisMapper.Mapped(0, 0), squeezedSecond.map(0));
+        assertEquals(new AxisMapper.Mapped(0, 2), squeezedSecond.map(1));
+
+        AxisMapper stretchedWithOffset = assertDoesNotThrow(() -> (new StretcherIndexMapper(-2, -1, 3, 5)));
+        assertEquals(new AxisMapper.Mapped(0, -2), stretchedWithOffset.map(-2));
+        assertEquals(new AxisMapper.Mapped(0, -1), stretchedWithOffset.map(-1));
+        assertEquals(new AxisMapper.Mapped(0, -1), stretchedWithOffset.map(0));
+        assertEquals(new AxisMapper.Mapped(0, -1), stretchedWithOffset.map(1));
+        assertEquals(new AxisMapper.Mapped(0, 0), stretchedWithOffset.map(2));
+
+        AxisMapper squeezedSecondWithOffset = assertDoesNotThrow(() -> (new StretcherIndexMapper(4, 5, 3, 2)));
+        assertEquals(new AxisMapper.Mapped(0, 4), squeezedSecondWithOffset.map(4));
+        assertEquals(new AxisMapper.Mapped(0, 6), squeezedSecondWithOffset.map(5));
+
+        AxisMapper squeezedFirstWithOffset = assertDoesNotThrow(() -> (new StretcherIndexMapper(4, 4, 3, 2)));
+        assertEquals(new AxisMapper.Mapped(0, 5), squeezedFirstWithOffset.map(4));
+        assertEquals(new AxisMapper.Mapped(0, 6), squeezedFirstWithOffset.map(5));
+
+        AxisMapper zeroSize = assertDoesNotThrow(() -> (new StretcherIndexMapper(0, 0, 1, 0)));
+        assertThrows(IndexOutOfBoundsException.class, () -> zeroSize.map(0));
+    }
+
+    @Test
+    public void testIntervalsAndSize() {
+        AxisMapper same = assertDoesNotThrow(() -> (new StretcherIndexMapper(0, 0, 3, 3)));
+        assertArrayEquals(new int[] { 3 }, same.intervals());
+        assertEquals(3, same.size());
+
+        AxisMapper stretched = assertDoesNotThrow(() -> (new StretcherIndexMapper(0, 0, 3, 5)));
+        assertArrayEquals(new int[] { 3 }, stretched.intervals());
+        assertEquals(5, stretched.size());
+
+        AxisMapper squeezed = assertDoesNotThrow(() -> (new StretcherIndexMapper(0, 0, 3, 2)));
+        assertArrayEquals(new int[] { 3 }, squeezed.intervals());
+        assertEquals(2, squeezed.size());
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/utils/axis/mappers/builders/AdjustAxisMapperBuilderTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/axis/mappers/builders/AdjustAxisMapperBuilderTest.java
@@ -1,0 +1,101 @@
+package com.ignfab.minalac.generator.utils.axis.mappers.builders;
+
+import org.junit.jupiter.api.Test;
+
+import com.ignfab.minalac.generator.exceptions.UnbuildableException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class AdjustAxisMapperBuilderTest {
+    @Test
+    public void testBuild() {
+        assertThrows(
+            UnbuildableException.class,
+            () -> new AdjustAxisMapperBuilder(
+                new RangeTestingAxisMapperBuilder(1, 5, 0),
+                new RangeTestingAxisMapperBuilder(1, 5, 1)
+            ),
+            "Different origin"
+        );
+
+        assertThrows(
+            UnbuildableException.class,
+            () -> new AdjustAxisMapperBuilder(
+                new RangeTestingAxisMapperBuilder(1, 5),
+                new RangeTestingAxisMapperBuilder(6, 9)
+            ),
+            "No min sizes"
+        );
+
+        assertDoesNotThrow(
+            () -> new AdjustAxisMapperBuilder(
+                new RangeTestingAxisMapperBuilder(0),
+                new RangeTestingAxisMapperBuilder(0, 9)
+            )
+        );
+
+        assertDoesNotThrow(
+            () -> new AdjustAxisMapperBuilder(
+                new RangeTestingAxisMapperBuilder(1, 6),
+                new RangeTestingAxisMapperBuilder(4, 9)
+            )
+        );
+    }
+
+    @Test
+    public void testMaxSizeUnder() {
+        assertThrows(
+            UnbuildableException.class,
+            () -> new AdjustAxisMapperBuilder(
+                new RangeTestingAxisMapperBuilder(1, 5),
+                new RangeTestingAxisMapperBuilder(7, 8))
+        );
+
+        AxisMapperBuilder builder = assertDoesNotThrow(
+            () -> new AdjustAxisMapperBuilder(
+                new RangeTestingAxisMapperBuilder(1, 7),
+                new RangeTestingAxisMapperBuilder(5, 10))
+        );
+        assertEquals(7, builder.maxSizeUnder(10));
+        assertEquals(7, builder.maxSizeUnder(7));
+        assertEquals(6, builder.maxSizeUnder(6));
+        assertEquals(5, builder.maxSizeUnder(5));
+        assertEquals(-1, builder.maxSizeUnder(4));
+
+        AxisMapperBuilder canBeZero = assertDoesNotThrow(
+            () -> new AdjustAxisMapperBuilder(
+                new RangeTestingAxisMapperBuilder(0, 7),
+                new RangeTestingAxisMapperBuilder(0, 10))
+        );
+        assertEquals(7, canBeZero.maxSizeUnder(10));
+        assertEquals(0, canBeZero.maxSizeUnder(0));
+    }
+
+    @Test
+    public void testMinimumSize() {
+        AxisMapperBuilder nonZeroMinSize = assertDoesNotThrow(
+            () -> new AdjustAxisMapperBuilder(
+                new RangeTestingAxisMapperBuilder(1, 7),
+                new RangeTestingAxisMapperBuilder(5, 10),
+                new RangeTestingAxisMapperBuilder(4, 6))
+        );
+        assertEquals(5, nonZeroMinSize.minimumSize());
+
+        AxisMapperBuilder zeroMinSize = assertDoesNotThrow(
+            () -> new AdjustAxisMapperBuilder(
+                new RangeTestingAxisMapperBuilder(0, 7),
+                new RangeTestingAxisMapperBuilder(0, 10)
+            ));
+        assertEquals(0, zeroMinSize.minimumSize());
+    }
+
+    @Test
+    public void testOrigin() {
+        AxisMapperBuilder builder = assertDoesNotThrow(
+            () -> new AdjustAxisMapperBuilder(
+                new RangeTestingAxisMapperBuilder(1, 7, -3),
+                new RangeTestingAxisMapperBuilder(5, 10, -3))
+        );
+        assertEquals(-3, builder.origin());
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/utils/axis/mappers/builders/AllowlistTestingAxisMapperBuilder.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/axis/mappers/builders/AllowlistTestingAxisMapperBuilder.java
@@ -1,0 +1,48 @@
+package com.ignfab.minalac.generator.utils.axis.mappers.builders;
+
+import java.util.Arrays;
+
+import com.ignfab.minalac.generator.exceptions.UnbuildableException;
+import com.ignfab.minalac.generator.utils.axis.mappers.AxisMapper;
+
+public class AllowlistTestingAxisMapperBuilder implements AxisMapperBuilder {
+    private final int[] allowedLength;
+    private final int origin;
+
+    public AllowlistTestingAxisMapperBuilder(int[] allowedLength, int origin) {
+        this.allowedLength = allowedLength;
+        this.origin = origin;
+        Arrays.sort(this.allowedLength);
+        if (this.allowedLength[0] < 0)
+            throw new RuntimeException("Can not contain negative length");
+    }
+
+    public AllowlistTestingAxisMapperBuilder(int... allowedLength) {
+        this(allowedLength, 0);
+    }
+
+    @Override
+    public AxisMapper build(int size) throws UnbuildableException {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public int maxSizeUnder(int size) {
+        if (size < allowedLength[0])
+            return -1;
+        for (int i = allowedLength.length - 1; i >= 0; i--)
+            if (allowedLength[i] <= size)
+                return allowedLength[i];
+        throw new RuntimeException("It should not happen");
+    }
+
+    @Override
+    public int minimumSize() {
+        return allowedLength[0];
+    }
+
+    @Override
+    public int origin() {
+        return origin;
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/utils/axis/mappers/builders/AllowlistTestingAxisMapperBuilderTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/axis/mappers/builders/AllowlistTestingAxisMapperBuilderTest.java
@@ -1,0 +1,24 @@
+package com.ignfab.minalac.generator.utils.axis.mappers.builders;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AllowlistTestingAxisMapperBuilderTest {
+    @Test
+    public void testMaxSizeUnder() {
+        assertEquals(50, new AllowlistTestingAxisMapperBuilder(new int[]{2, 5, 50}).maxSizeUnder(50));
+        assertEquals(50, new AllowlistTestingAxisMapperBuilder(new int[]{2, 5, 50}).maxSizeUnder(60));
+        assertEquals(5, new AllowlistTestingAxisMapperBuilder(new int[]{2, 5, 50}).maxSizeUnder(49));
+        assertEquals(2, new AllowlistTestingAxisMapperBuilder(new int[]{2, 5, 50}).maxSizeUnder(3));
+        assertEquals(2, new AllowlistTestingAxisMapperBuilder(new int[]{2, 5, 50}).maxSizeUnder(2));
+        assertEquals(-1, new AllowlistTestingAxisMapperBuilder(new int[]{2, 5, 50}).maxSizeUnder(1));
+    }
+
+    @Test
+    public void testMinimumSize() {
+        assertEquals(1, new AllowlistTestingAxisMapperBuilder(new int[]{1, 5, 6}).minimumSize());
+        assertEquals(2, new AllowlistTestingAxisMapperBuilder(new int[]{7, 2, 6, 3}).minimumSize());
+        assertEquals(7, new AllowlistTestingAxisMapperBuilder(new int[]{7, 7, 7}).minimumSize());
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/utils/axis/mappers/builders/ConstantAxisMapperBuilderTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/axis/mappers/builders/ConstantAxisMapperBuilderTest.java
@@ -1,0 +1,44 @@
+package com.ignfab.minalac.generator.utils.axis.mappers.builders;
+
+import org.junit.jupiter.api.Test;
+
+import com.ignfab.minalac.generator.exceptions.UnbuildableException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ConstantAxisMapperBuilderTest {
+    @Test
+    public void testBuild() {
+        assertThrows(UnbuildableException.class, () -> new ConstantAxisMapperBuilder(7, 0).build(8));
+        assertThrows(UnbuildableException.class, () -> new ConstantAxisMapperBuilder(6, 0).build(8));
+        assertThrows(UnbuildableException.class, () -> new ConstantAxisMapperBuilder(9, 0).build(8));
+
+        assertDoesNotThrow(() -> new ConstantAxisMapperBuilder(0, 0).build(0));
+        assertDoesNotThrow(() -> new ConstantAxisMapperBuilder(6, 2).build(6));
+    }
+
+    @Test
+    public void testMaxSizeUnder() {
+        assertEquals(-1, new ConstantAxisMapperBuilder(3, 0).maxSizeUnder(-1));
+
+        assertEquals(3, new ConstantAxisMapperBuilder(3, 0).maxSizeUnder(4));
+        assertEquals(3, new ConstantAxisMapperBuilder(3, 0).maxSizeUnder(3));
+        assertEquals(-1, new ConstantAxisMapperBuilder(3, 0).maxSizeUnder(2));
+
+        assertEquals(0, new ConstantAxisMapperBuilder(0, 0).maxSizeUnder(0));
+        assertEquals(0, new ConstantAxisMapperBuilder(0, 0).maxSizeUnder(1));
+    }
+
+    @Test
+    public void testMinimumSize() {
+        assertEquals(7, new ConstantAxisMapperBuilder(7, 0).minimumSize());
+        assertEquals(0, new ConstantAxisMapperBuilder(0, 0).minimumSize());
+    }
+
+    @Test
+    public void testOrigin() {
+        assertEquals(-5, (new ConstantAxisMapperBuilder(7, -5)).origin());
+        assertEquals(0, (new ConstantAxisMapperBuilder(7, 0)).origin());
+        assertEquals(3, (new ConstantAxisMapperBuilder(7, 3)).origin());
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/utils/axis/mappers/builders/KeepAxisMapperBuilderTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/axis/mappers/builders/KeepAxisMapperBuilderTest.java
@@ -1,0 +1,55 @@
+package com.ignfab.minalac.generator.utils.axis.mappers.builders;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class KeepAxisMapperBuilderTest {
+
+    @Test
+    public void testMaxSizeUnder() {
+        AxisMapperBuilder fixed = assertDoesNotThrow(() -> new KeepAxisMapperBuilder(
+            new RangeTestingAxisMapperBuilder(2),
+            new RangeTestingAxisMapperBuilder(7),
+            new RangeTestingAxisMapperBuilder(5)
+        ));
+        // Any size greater or equal to min is fine
+        assertEquals(7, fixed.maxSizeUnder(7));
+        assertEquals(8, fixed.maxSizeUnder(8));
+        assertEquals(25, fixed.maxSizeUnder(25));
+        assertEquals(-1, fixed.maxSizeUnder(6));
+    }
+
+    @Test
+    public void testMinimumSize() {
+        AxisMapperBuilder fixed = assertDoesNotThrow(() -> new KeepAxisMapperBuilder(
+            new RangeTestingAxisMapperBuilder(2),
+            new RangeTestingAxisMapperBuilder(7),
+            new RangeTestingAxisMapperBuilder(5)
+        ));
+        assertEquals(7, fixed.minimumSize());
+
+        AxisMapperBuilder moving = assertDoesNotThrow(() -> new KeepAxisMapperBuilder(
+            new RangeTestingAxisMapperBuilder(2, 12),
+            new RangeTestingAxisMapperBuilder(7, 9),
+            new RangeTestingAxisMapperBuilder(5, 10)
+        ));
+        assertEquals(7, moving.minimumSize());
+    }
+
+    @Test
+    public void testOrigin() {
+        AxisMapperBuilder different = assertDoesNotThrow(() -> new KeepAxisMapperBuilder(
+            new RangeTestingAxisMapperBuilder(1, 2, 5),
+            new RangeTestingAxisMapperBuilder(1, 2, 2),
+            new RangeTestingAxisMapperBuilder(1, 2, -7)
+        ));
+        assertEquals(-7, different.origin());
+
+        AxisMapperBuilder same = assertDoesNotThrow(() -> new KeepAxisMapperBuilder(
+            new RangeTestingAxisMapperBuilder(1, 2, 5),
+            new RangeTestingAxisMapperBuilder(1, 2, 5)
+        ));
+        assertEquals(5, same.origin());
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/utils/axis/mappers/builders/PriorityRepartitionAxisMapperBuilderTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/axis/mappers/builders/PriorityRepartitionAxisMapperBuilderTest.java
@@ -1,0 +1,210 @@
+package com.ignfab.minalac.generator.utils.axis.mappers.builders;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.ignfab.minalac.generator.exceptions.UnbuildableException;
+import com.ignfab.minalac.generator.utils.axis.mappers.AxisMapper;
+
+import static com.ignfab.minalac.generator.utils.iterator.IteratorTester.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class PriorityRepartitionAxisMapperBuilderTest {
+
+    @Test
+    public void testMaxSizeUnderDistribution() {
+        // The tests here are not exact as finding the optimal distribution is not something easy.
+        // The exacts results are implementation dependant.
+        // However, what we want to test is that the PriorityRepartitionAxisMapperBuilder:
+        //  - Try to distribute to have an roughly equals distribution
+        //  - Try to leave no starved segments when possible
+
+        // On this case, for an asked size of 48, there is a solution with no remainder which is 20-16-12.
+        // What we want to test is that the segments are roughly equals (even if there remainder).
+        // The result is implementation dependant, so what is tested is that the results are acceptable.
+        AxisMapperBuilder fiveFourTreeBuilder = assertDoesNotThrow(
+            () -> new PriorityRepartitionAxisMapperBuilder(
+                new AxisMapperBuilder[] {new AllowlistTestingAxisMapperBuilder(0, 5, 10, 15, 20), new AllowlistTestingAxisMapperBuilder(0, 4, 8, 12, 16, 20), new AllowlistTestingAxisMapperBuilder(0, 3, 6, 9, 12, 15)},
+                new int[] {0, 0, 0}
+            )
+        );
+        assertTrue(fiveFourTreeBuilder.maxSizeUnder(48) >= 40);
+        int resultingSize = fiveFourTreeBuilder.maxSizeUnder(48);
+
+        int[] intervals = assertDoesNotThrow(() -> fiveFourTreeBuilder.build(resultingSize).intervals());
+        assertTrue(14 <= intervals[0]);
+        assertTrue(14 <= intervals[1]);
+        assertTrue(14 <= intervals[2]);
+
+
+        // The middle builder has a minimal size, there is to try that it doesn't get greedy
+        // Basically the repartition should be fair despite minimal size
+        AxisMapperBuilder noGreedTwo = assertDoesNotThrow(
+            () -> new PriorityRepartitionAxisMapperBuilder(
+                new AxisMapperBuilder[] {new AllowlistTestingAxisMapperBuilder(0, 3, 6, 9), new AllowlistTestingAxisMapperBuilder(2, 4, 6), new AllowlistTestingAxisMapperBuilder(0, 3, 6, 9)},
+                new int[] {0, 0, 0}
+            )
+        );
+
+        assertEquals(8, noGreedTwo.maxSizeUnder(8));
+        AxisMapper noGreedTwoMapper = assertDoesNotThrow(() -> noGreedTwo.build(8));
+        assertArrayEquals(new int[] {3, 2, 3}, noGreedTwoMapper.intervals());
+
+        // Tree has min size
+        AxisMapperBuilder noGreedTree = assertDoesNotThrow(
+            () -> new PriorityRepartitionAxisMapperBuilder(
+                new AxisMapperBuilder[] {new AllowlistTestingAxisMapperBuilder(3, 6, 9), new AllowlistTestingAxisMapperBuilder(0, 2, 4, 6), new AllowlistTestingAxisMapperBuilder(3, 6, 9)},
+                new int[] {0, 0, 0}
+            )
+        );
+
+        assertEquals(8, noGreedTree.maxSizeUnder(8));
+        AxisMapper noGreedTreeMapper = assertDoesNotThrow(() -> noGreedTree.build(8));
+        assertArrayEquals(new int[] {3, 2, 3}, noGreedTreeMapper.intervals());
+
+        // The tests bellow are almost the same as noGreed but with no minimal size
+        // Tested with various order
+        // 3 - 2 - 3
+        AxisMapperBuilder treeTwoTree = assertDoesNotThrow(
+            () -> new PriorityRepartitionAxisMapperBuilder(
+                new AxisMapperBuilder[] {new AllowlistTestingAxisMapperBuilder(0, 3, 6, 9), new AllowlistTestingAxisMapperBuilder(0, 2, 4, 6), new AllowlistTestingAxisMapperBuilder(0, 3, 6, 9)},
+                new int[] {0, 0, 0}
+            )
+        );
+
+        assertEquals(8, treeTwoTree.maxSizeUnder(8));
+        AxisMapper treeTwoTreeMapper = assertDoesNotThrow(() -> treeTwoTree.build(8));
+        assertArrayEquals(new int[] {3, 2, 3}, treeTwoTreeMapper.intervals());
+
+        // 3 - 3 - 2
+        AxisMapperBuilder treeTreeTwo = assertDoesNotThrow(
+            () -> new PriorityRepartitionAxisMapperBuilder(
+                new AxisMapperBuilder[] {new AllowlistTestingAxisMapperBuilder(0, 3, 6, 9), new AllowlistTestingAxisMapperBuilder(0, 3, 6, 9), new AllowlistTestingAxisMapperBuilder(0, 2, 4, 6)},
+                new int[] {0, 0, 0}
+            )
+        );
+
+        assertEquals(8, treeTreeTwo.maxSizeUnder(8));
+        AxisMapper treeTreeTwoMapper = assertDoesNotThrow(() -> treeTreeTwo.build(8));
+        assertArrayEquals(new int[] {3, 3, 2}, treeTreeTwoMapper.intervals());
+
+        // 2 - 3 - 3
+        AxisMapperBuilder twoTreeTree = assertDoesNotThrow(
+            () -> new PriorityRepartitionAxisMapperBuilder(
+                new AxisMapperBuilder[] {new AllowlistTestingAxisMapperBuilder(0, 2, 4, 6), new AllowlistTestingAxisMapperBuilder(0, 3, 6, 9), new AllowlistTestingAxisMapperBuilder(0, 3, 6, 9)},
+                new int[] {0, 0, 0}
+            )
+        );
+
+        assertEquals(8, twoTreeTree.maxSizeUnder(8));
+        AxisMapper twoTreeTreeMapper = assertDoesNotThrow(() -> twoTreeTree.build(8));
+        assertArrayEquals(new int[] {2, 3, 3}, twoTreeTreeMapper.intervals());
+    }
+
+    @Test
+    public void testMaxSizeUnderBuild() {
+        AxisMapperBuilder empty = assertDoesNotThrow(
+            () ->  new PriorityRepartitionAxisMapperBuilder(
+                new AxisMapperBuilder[] {new RangeTestingAxisMapperBuilder(0), new RangeTestingAxisMapperBuilder(0), new RangeTestingAxisMapperBuilder(0)},
+                new int[] {0, 0, 0}
+            )
+        );
+        assertEquals(0, empty.maxSizeUnder(10));
+        AxisMapper emptyMapper = assertDoesNotThrow(() -> empty.build(0));
+        assertBrowsesAllOnce(List.of(0, 0, 0), Arrays.stream(emptyMapper.intervals()).iterator());
+
+        AxisMapperBuilder minSizeError = assertDoesNotThrow(
+            () ->  new PriorityRepartitionAxisMapperBuilder(
+                new AxisMapperBuilder[] {new RangeTestingAxisMapperBuilder(2, 5), new RangeTestingAxisMapperBuilder(0), new RangeTestingAxisMapperBuilder(6, 7)},
+                new int[] {0, 0, 0}
+            )
+        );
+        assertEquals(-1, minSizeError.maxSizeUnder(7));
+        assertThrows(UnbuildableException.class, () -> minSizeError.build(7));
+
+        AxisMapperBuilder minZero = assertDoesNotThrow(
+            () ->  new PriorityRepartitionAxisMapperBuilder(
+                new AxisMapperBuilder[] {new RangeTestingAxisMapperBuilder(0, 4), new RangeTestingAxisMapperBuilder(0, 4)},
+                new int[] {0, 0}
+            )
+        );
+
+        assertEquals(5, minZero.maxSizeUnder(5));
+        AxisMapper withMinZero = assertDoesNotThrow(() -> minZero.build(5));
+        // Unordered tests as there is no control on which one will have the most
+        assertBrowsesAllOnce(List.of(2, 3), Arrays.stream(withMinZero.intervals()).iterator());
+
+        // Same priority
+        AxisMapperBuilder samePrio = assertDoesNotThrow(
+            () ->  new PriorityRepartitionAxisMapperBuilder(
+                new AxisMapperBuilder[] {new RangeTestingAxisMapperBuilder(2), new RangeTestingAxisMapperBuilder(3)},
+                new int[] {0, 0}
+            )
+        );
+        assertEquals(5, samePrio.maxSizeUnder(6));
+        AxisMapper withSamePrio = assertDoesNotThrow(() -> samePrio.build(5));
+        assertArrayEquals(new int[] {2, 3}, withSamePrio.intervals());
+
+        // Priority should take all possible after distribution of min
+        AxisMapperBuilder builderWithOnePrio = assertDoesNotThrow(
+            () ->  new PriorityRepartitionAxisMapperBuilder(
+                new AxisMapperBuilder[] {new RangeTestingAxisMapperBuilder(0, 8), new RangeTestingAxisMapperBuilder(2, 4)},
+                new int[] {1, 0}
+            )
+        );
+
+        // No remainder for first one
+        assertEquals(2, builderWithOnePrio.maxSizeUnder(2));
+        AxisMapper withSize2 = assertDoesNotThrow(() -> builderWithOnePrio.build(2));
+        assertArrayEquals(new int[] {0, 2}, withSize2.intervals());
+
+        // First takes all remainder
+        assertEquals(8, builderWithOnePrio.maxSizeUnder(8));
+        AxisMapper withSize8 = assertDoesNotThrow(() -> builderWithOnePrio.build(8));
+        assertArrayEquals(new int[] {6, 2}, withSize8.intervals());
+
+        assertEquals(10, builderWithOnePrio.maxSizeUnder(10));
+        AxisMapper withSize10 = assertDoesNotThrow(() -> builderWithOnePrio.build(10));
+        assertArrayEquals(new int[] {8, 2}, withSize10.intervals());
+
+        // First has taken all available remainder the rest goes for the second one
+        assertEquals(11, builderWithOnePrio.maxSizeUnder(11));
+        AxisMapper withSize11 = assertDoesNotThrow(() -> builderWithOnePrio.build(11));
+        assertArrayEquals(new int[] {8, 3}, withSize11.intervals());
+
+
+    }
+/*
+    public static void main(String[] args) throws UnbuildableException {
+        AxisMapperBuilder b = new PriorityRepartitionAxisMapperBuilder(
+            new AxisMapperBuilder[] {new RangeTestingAxisMapperBuilder(0, 8), new RangeTestingAxisMapperBuilder(2, 4)},
+            new int[] {1, 0});
+        AxisMapper with11 =  b.build(11);
+        System.out.println("hi");
+    }*/
+
+    @Test
+    public void testMinimumSize() {
+        assertEquals(
+            8,
+            assertDoesNotThrow(
+                () ->  new PriorityRepartitionAxisMapperBuilder(
+                    new AxisMapperBuilder[] {new RangeTestingAxisMapperBuilder(2, 5), new RangeTestingAxisMapperBuilder(0), new RangeTestingAxisMapperBuilder(6, 7)},
+                    new int[] {0, 1, 0}
+                )
+            ).minimumSize()
+        );
+
+        assertEquals(
+            0,
+            assertDoesNotThrow(
+                () ->  new PriorityRepartitionAxisMapperBuilder(
+                    new AxisMapperBuilder[] {new RangeTestingAxisMapperBuilder(0, 5), new RangeTestingAxisMapperBuilder(0), new RangeTestingAxisMapperBuilder(0, 4)},
+                    new int[] {1, 0, 0}
+                )
+            ).minimumSize()
+        );
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/utils/axis/mappers/builders/RangeTestingAxisMapperBuilder.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/axis/mappers/builders/RangeTestingAxisMapperBuilder.java
@@ -1,0 +1,49 @@
+package com.ignfab.minalac.generator.utils.axis.mappers.builders;
+
+import com.ignfab.minalac.generator.utils.axis.mappers.AxisMapper;
+
+public class RangeTestingAxisMapperBuilder implements AxisMapperBuilder {
+    private final int min;
+    private final int max;
+    private final int origin;
+
+    public RangeTestingAxisMapperBuilder(int min, int max, int origin) {
+        if (max < min)
+            throw new IllegalArgumentException("max should be greater than min");
+        this.min = min;
+        this.max = max;
+        this.origin = origin;
+    }
+
+    public RangeTestingAxisMapperBuilder(int min, int max) {
+        this(min, max, 0);
+    }
+
+    public RangeTestingAxisMapperBuilder(int size) {
+        min = size;
+        max = size;
+        origin = 0;
+    }
+
+    @Override
+    public AxisMapper build(int size) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public int maxSizeUnder(int size) {
+        if (size < min)
+            return -1;
+        return Math.min(size, max);
+    }
+
+    @Override
+    public int minimumSize() {
+        return min;
+    }
+
+    @Override
+    public int origin() {
+        return origin;
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/utils/axis/mappers/builders/RangeTestingAxisMapperBuilderTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/axis/mappers/builders/RangeTestingAxisMapperBuilderTest.java
@@ -1,0 +1,37 @@
+package com.ignfab.minalac.generator.utils.axis.mappers.builders;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class RangeTestingAxisMapperBuilderTest {
+    @Test
+    public void testBuild() {
+        assertThrows(IllegalArgumentException.class, () -> new RangeTestingAxisMapperBuilder(5, 2, 0));
+        assertDoesNotThrow(() -> new RangeTestingAxisMapperBuilder(2, 2, 0));
+    }
+
+    @Test
+    public void testMaxSizeUnder() {
+        assertEquals(0, new RangeTestingAxisMapperBuilder(0).maxSizeUnder(1));
+        assertEquals(1, new RangeTestingAxisMapperBuilder(0, 2).maxSizeUnder(1));
+
+        assertEquals(-1, new RangeTestingAxisMapperBuilder(2, 5).maxSizeUnder(1));
+
+        assertEquals(2, new RangeTestingAxisMapperBuilder(2, 5).maxSizeUnder(2));
+        assertEquals(5, new RangeTestingAxisMapperBuilder(2, 5).maxSizeUnder(5));
+        assertEquals(3, new RangeTestingAxisMapperBuilder(2, 5).maxSizeUnder(3));
+        assertEquals(5, new RangeTestingAxisMapperBuilder(2, 5).maxSizeUnder(6));
+
+        assertEquals(2, new RangeTestingAxisMapperBuilder(2).maxSizeUnder(3));
+        assertEquals(2, new RangeTestingAxisMapperBuilder(2).maxSizeUnder(2));
+        assertEquals(-1, new RangeTestingAxisMapperBuilder(2).maxSizeUnder(1));
+
+    }
+
+    @Test
+    public void testMinimumSize() {
+        assertEquals(2, new RangeTestingAxisMapperBuilder(2, 5).minimumSize());
+        assertEquals(2, new RangeTestingAxisMapperBuilder(2).minimumSize());
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/utils/axis/mappers/builders/RepeatAxisMapperBuilderTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/axis/mappers/builders/RepeatAxisMapperBuilderTest.java
@@ -1,0 +1,81 @@
+package com.ignfab.minalac.generator.utils.axis.mappers.builders;
+
+import org.junit.jupiter.api.Test;
+
+import com.ignfab.minalac.generator.exceptions.UnbuildableException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class RepeatAxisMapperBuilderTest {
+    @Test
+    public void testBuild() {
+        assertThrows(UnbuildableException.class, () -> new RepeatAxisMapperBuilder(new RangeTestingAxisMapperBuilder(3), 1, Integer.MAX_VALUE).build(5));
+        assertThrows(UnbuildableException.class, () -> new RepeatAxisMapperBuilder(new RangeTestingAxisMapperBuilder(3), 1, Integer.MAX_VALUE).build(7));
+    }
+
+    @Test
+    public void testMaxSizeUnder() {
+        assertEquals(6, assertDoesNotThrow(
+            () ->  new RepeatAxisMapperBuilder(new RangeTestingAxisMapperBuilder(3), 2, Integer.MAX_VALUE).maxSizeUnder(6))
+        );
+
+
+        assertEquals(-1, assertDoesNotThrow(
+            () ->  new RepeatAxisMapperBuilder(new RangeTestingAxisMapperBuilder(3), 2, Integer.MAX_VALUE).maxSizeUnder(5))
+        );
+
+        assertThrows(
+            UnbuildableException.class,
+            () -> new RepeatAxisMapperBuilder(new RangeTestingAxisMapperBuilder(0), 1, Integer.MAX_VALUE).maxSizeUnder(0)
+        );
+        assertThrows(
+            UnbuildableException.class,
+            () -> new RepeatAxisMapperBuilder(new RangeTestingAxisMapperBuilder(0, 2), 1, Integer.MAX_VALUE).maxSizeUnder(5)
+        );
+
+        assertEquals(6, assertDoesNotThrow(
+            () ->  new RepeatAxisMapperBuilder(new RangeTestingAxisMapperBuilder(3, 4), 2, Integer.MAX_VALUE).maxSizeUnder(6))
+        );
+        assertEquals(10, assertDoesNotThrow(
+            () ->  new RepeatAxisMapperBuilder(new RangeTestingAxisMapperBuilder(3, 4), 2, Integer.MAX_VALUE).maxSizeUnder(10))
+        );
+
+        // Unresizable underlying structure
+        // Max under 25 is 2 * 7 = 14
+        assertEquals(14, assertDoesNotThrow(
+            () -> new RepeatAxisMapperBuilder(new RangeTestingAxisMapperBuilder(7, 7), 2, 2).maxSizeUnder(25))
+        );
+        // Max under 14 is 2 * 7 = 14
+        assertEquals(14, assertDoesNotThrow(
+            () -> new RepeatAxisMapperBuilder(new RangeTestingAxisMapperBuilder(7, 7), 2, 2).maxSizeUnder(14))
+        );
+
+        // Resizable underlying structure (Can take any size from 2 to 8)
+        // Max under 30 is max([2, 8]) * maxOccurences (3 here) -> 8 * 3 = 24
+        assertEquals(24, assertDoesNotThrow(
+            () -> new RepeatAxisMapperBuilder(new RangeTestingAxisMapperBuilder(2, 8), 2, 3).maxSizeUnder(30))
+        );
+
+        // Tree 8
+        assertEquals(24, assertDoesNotThrow(
+            () -> new RepeatAxisMapperBuilder(new AllowlistTestingAxisMapperBuilder(6, 8), 2, 3).maxSizeUnder(25))
+        );
+        // Two 8 and one 6
+        assertEquals(22, assertDoesNotThrow(
+            () -> new RepeatAxisMapperBuilder(new AllowlistTestingAxisMapperBuilder(6, 8), 2, 3).maxSizeUnder(23))
+        );
+    }
+
+    @Test
+    public void testMinimumSize() {
+        assertEquals(0, assertDoesNotThrow(
+            () ->  new RepeatAxisMapperBuilder(new RangeTestingAxisMapperBuilder(3), 0, Integer.MAX_VALUE).minimumSize())
+        );
+        assertEquals(3, assertDoesNotThrow(
+            () ->  new RepeatAxisMapperBuilder(new RangeTestingAxisMapperBuilder(3), 1, Integer.MAX_VALUE).minimumSize())
+        );
+        assertEquals(6, assertDoesNotThrow(
+            () ->  new RepeatAxisMapperBuilder(new RangeTestingAxisMapperBuilder(3), 2, Integer.MAX_VALUE).minimumSize())
+        );
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/utils/axis/mappers/builders/StretcherAxisMapperBuilderTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/utils/axis/mappers/builders/StretcherAxisMapperBuilderTest.java
@@ -1,0 +1,44 @@
+package com.ignfab.minalac.generator.utils.axis.mappers.builders;
+
+import org.junit.jupiter.api.Test;
+
+import com.ignfab.minalac.generator.exceptions.UnbuildableException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class StretcherAxisMapperBuilderTest {
+    @Test
+    public void testBuild() {
+        // Not enough space
+        assertThrows(UnbuildableException.class, () -> new StretcherAxisMapperBuilder(new RangeTestingAxisMapperBuilder(3), 0, 1, 2).build(2));
+        // Requested size too much
+        assertThrows(UnbuildableException.class, () -> new StretcherAxisMapperBuilder(new RangeTestingAxisMapperBuilder(3), 0, 1, 2).build(5));
+
+        // Underlying builder with min size of 0
+        assertThrows(UnbuildableException.class, () -> new StretcherAxisMapperBuilder(new RangeTestingAxisMapperBuilder(0, 3), 0, 0, 0));
+        assertThrows(UnbuildableException.class, () -> new StretcherAxisMapperBuilder(new RangeTestingAxisMapperBuilder(0), 0, 0, 0));
+    }
+
+    @Test
+    public void testMaxSizeUnder() {
+        assertEquals(-1, assertDoesNotThrow(() -> new StretcherAxisMapperBuilder(new RangeTestingAxisMapperBuilder(3), 0, 1, Integer.MAX_VALUE)).maxSizeUnder(2));
+        assertEquals(3, assertDoesNotThrow(() -> new StretcherAxisMapperBuilder(new RangeTestingAxisMapperBuilder(3), 0, 1, Integer.MAX_VALUE)).maxSizeUnder(3));
+        assertEquals(7, assertDoesNotThrow(() -> new StretcherAxisMapperBuilder(new RangeTestingAxisMapperBuilder(3), 0, 1, Integer.MAX_VALUE)).maxSizeUnder(7));
+
+        assertEquals(-1, assertDoesNotThrow(() -> new StretcherAxisMapperBuilder(new RangeTestingAxisMapperBuilder(3), 0, 0, Integer.MAX_VALUE)).maxSizeUnder(1));
+        assertEquals(2, assertDoesNotThrow(() -> new StretcherAxisMapperBuilder(new RangeTestingAxisMapperBuilder(3), 0, 0, Integer.MAX_VALUE)).maxSizeUnder(2));
+        assertEquals(3, assertDoesNotThrow(() -> new StretcherAxisMapperBuilder(new RangeTestingAxisMapperBuilder(3), 0, 0, Integer.MAX_VALUE)).maxSizeUnder(3));
+
+        assertEquals(4, assertDoesNotThrow(() -> new StretcherAxisMapperBuilder(new RangeTestingAxisMapperBuilder(3), 0, 1, 2)).maxSizeUnder(6));
+    }
+
+    @Test
+    public void testMinimumSize() {
+        assertEquals(2, assertDoesNotThrow(() -> new StretcherAxisMapperBuilder(new RangeTestingAxisMapperBuilder(3), 0, 0, Integer.MAX_VALUE)).minimumSize());
+        assertEquals(3, assertDoesNotThrow(() -> new StretcherAxisMapperBuilder(new RangeTestingAxisMapperBuilder(3), 0, 1, Integer.MAX_VALUE)).minimumSize());
+        assertEquals(7, assertDoesNotThrow(() -> new StretcherAxisMapperBuilder(new RangeTestingAxisMapperBuilder(3), 0, 5, Integer.MAX_VALUE)).minimumSize());
+
+        // Shrink to 0
+        assertEquals(0, assertDoesNotThrow(() -> new StretcherAxisMapperBuilder(new RangeTestingAxisMapperBuilder(1), 0, 0, Integer.MAX_VALUE)).minimumSize());
+    }
+}


### PR DESCRIPTION
### Changes

This PR adds layouts and a task to render facades.

#### Feature description

Layouts are a kind of structure that can resize itself to fit a requested space. Contrary to Structure, its size aren't fixed, it can stretch, be repeated to fill the available space.

With that we can define layouts and have building facades rendered dynamically. 

The type of Layouts are:
- Stretchable : it makes a structure stretchable by having one band per axis that gets repeated or ommited to fit the requested size.
- Repeat: it repeats a another layout along a given axis.
- Concatenate: it places several layout side by side. 

#### Showcase

<img width="1671" height="818" alt="Capture d’écran du 2026-08-28 16-38-09" src="https://github.com/user-attachments/assets/e48ed792-bbab-4840-8a2f-5eee7c9e1b13" />

### Reason

This adds more expressiveness on building rendering. Moreover with models values, we can have layout that are rendered depending on metadata, randomly.. 

### TODOs

Left one TODO on `full.yaml`. Layout parameters can be very long, it could a good idea to define it elsewhere. (As it uses voxels defined on format, could be `common.yaml` file. But that is a detail.

### Self-checks

- [x] The code has unit tests associated
- [x] The code has Javadoc Comments associated
- [x] Complex / Unexpected code is explained / justified with a small comment
- [x] Relevant documentation inside the `/docs` folder has been updated
- [x] All examples in `examples/` work the same (or have been adapted if subject to changes in this PR)
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [x] The texts have been proofread (documentation, error messages, logs, comments...)

# TODOs

- [ ] Reorg commits (squash, distribute, separate generate.sh update in a commit)