### PR TITLE
Harvest vector features by misusing WMS `GetFeatureInfo`

### DIFF
--- a/src/main/java/com/ignfab/minalac/generator/MinalacGenerator.java
+++ b/src/main/java/com/ignfab/minalac/generator/MinalacGenerator.java
@@ -34,6 +34,7 @@ import com.ignfab.minalac.generator.parameters.providers.GeoTiffProviderParams;
 import com.ignfab.minalac.generator.parameters.providers.OverpassProviderParams;
 import com.ignfab.minalac.generator.parameters.providers.ShapefileProviderParams;
 import com.ignfab.minalac.generator.parameters.providers.WFSProviderParams;
+import com.ignfab.minalac.generator.parameters.providers.WMSFeatureInfoProviderParams;
 import com.ignfab.minalac.generator.parameters.providers.WMSFloatBilProviderParams;
 import com.ignfab.minalac.generator.parameters.tasks.CopyHeightmapTaskParams;
 import com.ignfab.minalac.generator.parameters.tasks.FetchDataTaskParams;
@@ -137,6 +138,7 @@ public final class MinalacGenerator {
         parser.registerParams("wfs", WFSProviderParams.class);
         parser.registerParams("gpkg", GeoPackageProviderParams.class);
         parser.registerParams("shapefile", ShapefileProviderParams.class);
+        parser.registerParams("wmsFeatureInfo", WMSFeatureInfoProviderParams.class);
         parser.registerParams("wmsFloat", WMSFloatBilProviderParams.class);
         parser.registerParams("geotiff", GeoTiffProviderParams.class);
         parser.registerParams("overpass", OverpassProviderParams.class);

--- a/src/main/java/com/ignfab/minalac/generator/inputs/WMSFeatureInfoDataProvider.java
+++ b/src/main/java/com/ignfab/minalac/generator/inputs/WMSFeatureInfoDataProvider.java
@@ -1,0 +1,485 @@
+package com.ignfab.minalac.generator.inputs;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.IntFunction;
+
+import org.geotools.api.feature.simple.SimpleFeature;
+import org.geotools.api.feature.simple.SimpleFeatureType;
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.feature.simple.SimpleFeatureBuilder;
+import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.CRS;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.LinearRing;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.Polygon;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+import com.ignfab.minalac.generator.exceptions.GenerationFailedException;
+import com.ignfab.minalac.generator.exceptions.IgnorableException;
+import com.ignfab.minalac.generator.exceptions.RetryableException;
+import com.ignfab.minalac.generator.exceptions.TransformException;
+import com.ignfab.minalac.generator.utils.coordinates.EnvelopeProvider;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+
+/**
+ * Data provider harvesting vector features through WMS {@code GetFeatureInfo}.
+ * <p>
+ * This is a workaround. {@code GetFeatureInfo} answers for a single <em>point</em>,
+ * to feed a map tooltip; covering an area therefore requires a grid of queries
+ * spaced by {@code spacing}, de-duplicated by feature identifier. Prefer
+ * {@link WFS1_1_GML3_1_DataProvider} wherever WFS is available — one bounding box
+ * query per tile instead of hundreds of point queries. This class only earns its
+ * place against a server that publishes a layer through WMS while keeping WFS
+ * disabled.
+ * <p>
+ * Two limits come with the detour. The number of requests follows the surface rather
+ * than the number of features, so the volume has to be weighed against the capacity
+ * of the target service. And since a rendering engine is being sampled rather than a
+ * feature store, completeness is not guaranteed: a feature shorter than
+ * {@code spacing} can fall between two grid points.
+ * <p>
+ * Defaults are indicative and have to be recalibrated per server, starting with
+ * {@code resolution} — see {@link #scaleDenominator()}.
+ */
+public class WMSFeatureInfoDataProvider implements Provider<SimpleFeature> {
+    private static final String SERVICE = "WMS";
+    private static final String VERSION = "1.1.1";
+
+    /** Guard against a huge query image when resolution is tiny against queryRadius. */
+    private static final int MAX_QUERY_IMAGE_SIZE = 2001;
+
+    private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory();
+
+    private final ParameterizedURL baseURL;
+    private final CoordinateReferenceSystem crs;
+    private final EnvelopeProvider envelopeProvider;
+    private final double queryRadius;
+    private final double spacing;
+    private final String layer;
+    private final boolean northEastAxisOrder;
+
+    /**
+     * Built from the first feature returned, then reused: a WMS layer has a fixed
+     * schema. Volatile and published under a lock, because a single provider instance
+     * is shared by the tiles, which are generated concurrently.
+     */
+    private volatile SimpleFeatureType featureType;
+
+    /**
+     * Creates a new {@code WMSFeatureInfoDataProvider}.
+     *
+     * @param baseURL base URL of the service, excluding query parameters
+     * @param layer name of the WMS layer to query
+     * @param crs coordinate reference system to use, which must be advertised by the
+     *            service for this layer
+     * @param resolution size of a pixel, in {@code crs} units; must place
+     *                   {@link #scaleDenominator()} inside the scale window of the layer
+     * @param queryRadius half-width of the bounding box of a single query, in
+     *                    {@code crs} units
+     * @param spacing distance between two query points of the grid, in {@code crs}
+     *                units; should not exceed the radius actually harvested by the
+     *                server, or features will be missed
+     * @param buffer value of the {@code BUFFER} parameter, in pixels
+     * @param maxFeaturesPerQuery value of the {@code FEATURE_COUNT} parameter
+     * @param envelopeProvider function to use to compute envelopes from bounding boxes
+     */
+    @SuppressWarnings("checkstyle:parameternumber")
+    public WMSFeatureInfoDataProvider(
+            String baseURL,
+            String layer,
+            CoordinateReferenceSystem crs,
+            double resolution,
+            double queryRadius,
+            double spacing,
+            int buffer,
+            int maxFeaturesPerQuery,
+            EnvelopeProvider envelopeProvider
+    ) {
+        this.crs = crs;
+        this.layer = layer;
+        this.queryRadius = queryRadius;
+        this.spacing = spacing;
+        this.envelopeProvider = envelopeProvider;
+
+        String srsName = CRS.toSRS(crs);
+        if (srsName == null)
+            throw new IllegalArgumentException("Could not retrieve SRS name for layer");
+
+        // A ReferencedEnvelope follows the axis order of its CRS, and several national
+        // systems are northing first: EPSG:6870 (Albania TM 2010) and EPSG:4326 among
+        // them, unlike EPSG:2154 or EPSG:3857. WMS 1.1.1 and the GeoJSON output of the
+        // service are both easting first, so coordinates are swapped at both boundaries.
+        northEastAxisOrder = CRS.getAxisOrder(crs) == CRS.AxisOrder.NORTH_EAST;
+
+        // The query image size follows from the radius and the pixel size, so that
+        // the scale of the request can be tuned independently of the area covered.
+        // Kept odd, so that the queried pixel sits exactly at the centre.
+        int queryImageSize = Math.min(
+            MAX_QUERY_IMAGE_SIZE,
+            Math.max(3, 1 | (int) Math.round(2 * queryRadius / resolution)));
+
+        this.baseURL = ParameterizedURL.base(baseURL)
+            .parameter("SERVICE", SERVICE)
+            .parameter("VERSION", VERSION)
+            .parameter("REQUEST", "GetFeatureInfo")
+            .parameter("LAYERS", layer)
+            .parameter("QUERY_LAYERS", layer)
+            .parameter("STYLES", "")
+            .parameter("SRS", srsName)
+            .parameter("INFO_FORMAT", "application/json")
+            .parameter("FEATURE_COUNT", maxFeaturesPerQuery)
+            .parameter("BUFFER", buffer)
+            .parameter("WIDTH", queryImageSize)
+            .parameter("HEIGHT", queryImageSize)
+            .parameter("X", queryImageSize / 2)
+            .parameter("Y", queryImageSize / 2)
+            .build();
+    }
+
+    @Override
+    public Class<SimpleFeature> providedType() {
+        return SimpleFeature.class;
+    }
+
+    @Override
+    public Result<SimpleFeature> provide(WorldBBox3d bbox)
+            throws GenerationFailedException, RetryableException {
+
+        ReferencedEnvelope envelope;
+        try {
+            envelope = envelopeProvider.computeForCRS(crs, bbox);
+        } catch (FactoryException | TransformException e) {
+            throw new GenerationFailedException(e);
+        }
+
+        return new GridResult(envelope);
+    }
+
+    /**
+     * Walks the grid of query points covering the requested envelope, issuing one
+     * request per point and buffering the features it returns.
+     * <p>
+     * De-duplication is local to this result: a feature straddling the boundary
+     * between two tiles is returned once per tile, as a bbox query would.
+     */
+    private final class GridResult implements Result<SimpleFeature> {
+        private final ReferencedEnvelope envelope;
+        private final int columns;
+        private final int rows;
+        private final Set<String> seen = new HashSet<>();
+        private final Deque<SimpleFeature> pending = new ArrayDeque<>();
+        private int index;
+
+        private GridResult(ReferencedEnvelope envelope) {
+            this.envelope = envelope;
+            this.columns = pointCount(envelope.getWidth());
+            this.rows = pointCount(envelope.getHeight());
+        }
+
+        private int pointCount(double span) {
+            return Math.max(1, (int) Math.ceil(span / spacing));
+        }
+
+        @Override
+        public CoordinateReferenceSystem crs() {
+            return crs;
+        }
+
+        @Override
+        public boolean hasNext() throws GenerationFailedException, RetryableException {
+            // Many query points return nothing at all, so keep walking the grid
+            // until a feature shows up or the grid is exhausted.
+            while (pending.isEmpty() && index < columns * rows)
+                fetchNextPoint();
+            return !pending.isEmpty();
+        }
+
+        @Override
+        public SimpleFeature next() throws GenerationFailedException, RetryableException {
+            if (!hasNext())
+                throw new NoSuchElementException();
+            return pending.removeFirst();
+        }
+
+        private void fetchNextPoint() throws GenerationFailedException, RetryableException {
+            int column = index % columns;
+            int row = index / columns;
+            index++;
+
+            // Query points are spread over the actual envelope rather than stepped by
+            // spacing, so that they stay inside it even when the tile is smaller than
+            // spacing: stepping would then place the single point beyond maxX.
+            double x = envelope.getMinX() + envelope.getWidth() * (column + 0.5) / columns;
+            double y = envelope.getMinY() + envelope.getHeight() * (row + 0.5) / rows;
+
+            for (SimpleFeature feature : getFeatureInfo(x, y))
+                if (seen.add(feature.getID()))
+                    pending.addLast(feature);
+        }
+
+        @Override
+        public void close() throws IgnorableException {
+            // Nothing to release: every connection is closed as soon as it is parsed.
+            pending.clear();
+            seen.clear();
+        }
+    }
+
+    private List<SimpleFeature> getFeatureInfo(double x, double y)
+            throws GenerationFailedException, RetryableException {
+
+        // WMS 1.1.1 always expects the easting first, whatever the axis order of the CRS.
+        double east = northEastAxisOrder ? y : x;
+        double north = northEastAxisOrder ? x : y;
+
+        ParameterizedURL url = baseURL.builder()
+            .parameter("BBOX", (east - queryRadius)
+                + "," + (north - queryRadius)
+                + "," + (east + queryRadius)
+                + "," + (north + queryRadius))
+            .build();
+
+        URLConnection connection;
+        try {
+            URL resolved = url.toURL();
+            connection = resolved.openConnection();
+            connection.setConnectTimeout(10_000);
+            connection.setReadTimeout(60_000);
+            connection.connect();
+        } catch (MalformedURLException e) {
+            throw new GenerationFailedException("Invalid URL for layer", e);
+        } catch (IOException e) {
+            throw new RetryableException("Error opening connection", e);
+        }
+
+        if (connection instanceof HttpURLConnection http) {
+            int status;
+            try {
+                status = http.getResponseCode();
+            } catch (IOException e) {
+                throw new RetryableException("Error reading response status", e);
+            }
+
+            if (status == 429 || status >= HttpURLConnection.HTTP_INTERNAL_ERROR)
+                throw new RetryableException("Service returned HTTP " + status);
+
+            if (status != HttpURLConnection.HTTP_OK)
+                throw new GenerationFailedException(
+                    "Service returned HTTP " + status + ": " + excerpt(http.getErrorStream()));
+        }
+
+        // GeoServer answers a ServiceExceptionReport in XML when the layer is not
+        // queryable or the info format is unsupported, with a 200 status.
+        String contentType = connection.getContentType();
+        if (contentType == null || !contentType.contains("json"))
+            throw new GenerationFailedException("Service exception (" + contentType + "): "
+                + excerpt(streamOrNull(connection)));
+
+        JsonNode root;
+        try (InputStream inputStream = connection.getInputStream()) {
+            root = readTree(inputStream);
+        } catch (IOException e) {
+            throw new RetryableException("Error fetching features", e);
+        } catch (JacksonException e) {
+            // Most likely a truncated response rather than a malformed service.
+            throw new RetryableException("Unparsable GeoJSON response", e);
+        }
+
+        List<SimpleFeature> features = new ArrayList<>();
+        for (JsonNode node : root.path("features")) {
+            SimpleFeature feature = readFeature(node);
+            if (feature != null)
+                features.add(feature);
+        }
+
+        return features;
+    }
+
+    /**
+     * Single entry point to Jackson, so that adapting to another mapper
+     * configuration only touches one place.
+     *
+     * @param inputStream the response body
+     * @return the parsed tree
+     */
+    private JsonNode readTree(InputStream inputStream) {
+        return JsonMapper.builder().build().readTree(inputStream);
+    }
+
+    private SimpleFeature readFeature(JsonNode node) {
+        Geometry geometry = readGeometry(node.path("geometry"));
+        if (geometry == null)
+            return null;
+
+        JsonNode properties = node.path("properties");
+
+        SimpleFeatureType type = featureType;
+        if (type == null)
+            synchronized (this) {
+                type = featureType;
+                if (type == null) {
+                    type = buildFeatureType(geometry, properties);
+                    featureType = type;
+                }
+            }
+
+        SimpleFeatureBuilder builder = new SimpleFeatureBuilder(type);
+        builder.set(type.getGeometryDescriptor().getLocalName(), geometry);
+
+        for (Map.Entry<String, JsonNode> property : properties.properties())
+            if (type.getDescriptor(property.getKey()) != null)
+                builder.set(property.getKey(), readValue(property.getValue()));
+
+        return builder.buildFeature(node.path("id").asString(null));
+    }
+
+    /**
+     * Builds the feature type from the first feature encountered. A WMS layer has a
+     * fixed schema, so the attributes of the first feature describe them all;
+     * attributes absent from a later feature are simply left null.
+     *
+     * @param geometry the geometry of the first feature, used for its binding
+     * @param properties the properties of the first feature
+     * @return the resulting feature type
+     */
+    private SimpleFeatureType buildFeatureType(Geometry geometry, JsonNode properties) {
+        SimpleFeatureTypeBuilder builder = new SimpleFeatureTypeBuilder();
+        builder.setName(layer);
+        builder.setCRS(crs);
+        builder.add("the_geom", geometry.getClass());
+        builder.setDefaultGeometry("the_geom");
+
+        for (Map.Entry<String, JsonNode> property : properties.properties())
+            builder.add(property.getKey(), bindingOf(property.getValue()));
+
+        return builder.buildFeatureType();
+    }
+
+    private static Class<?> bindingOf(JsonNode value) {
+        if (value.isIntegralNumber())
+            return Long.class;
+        if (value.isNumber())
+            return Double.class;
+        if (value.isBoolean())
+            return Boolean.class;
+        return String.class;
+    }
+
+    private static Object readValue(JsonNode value) {
+        if (value.isNull())
+            return null;
+        if (value.isIntegralNumber())
+            return value.asLong();
+        if (value.isNumber())
+            return value.asDouble();
+        if (value.isBoolean())
+            return value.asBoolean();
+        return value.asString();
+    }
+
+    private Geometry readGeometry(JsonNode geometry) {
+        String type = geometry.path("type").asString("");
+        JsonNode coordinates = geometry.path("coordinates");
+
+        return switch (type) {
+            case "Point" -> point(coordinates);
+            case "MultiPoint" -> GEOMETRY_FACTORY.createMultiPoint(
+                map(coordinates, this::point, Point[]::new));
+            case "LineString" -> lineString(coordinates);
+            case "MultiLineString" -> GEOMETRY_FACTORY.createMultiLineString(
+                map(coordinates, this::lineString, LineString[]::new));
+            case "Polygon" -> polygon(coordinates);
+            case "MultiPolygon" -> GEOMETRY_FACTORY.createMultiPolygon(
+                map(coordinates, this::polygon, Polygon[]::new));
+            default -> null;
+        };
+    }
+
+    private static <T> T[] map(JsonNode array, Function<JsonNode, T> mapper, IntFunction<T[]> factory) {
+        List<T> values = new ArrayList<>();
+        for (JsonNode element : array)
+            values.add(mapper.apply(element));
+        return values.toArray(factory.apply(values.size()));
+    }
+
+    private Point point(JsonNode position) {
+        return GEOMETRY_FACTORY.createPoint(coordinate(position));
+    }
+
+    private LineString lineString(JsonNode positions) {
+        return GEOMETRY_FACTORY.createLineString(coordinates(positions));
+    }
+
+    private Polygon polygon(JsonNode rings) {
+        LinearRing shell = GEOMETRY_FACTORY.createLinearRing(coordinates(rings.path(0)));
+
+        LinearRing[] holes = new LinearRing[Math.max(0, rings.size() - 1)];
+        for (int i = 1; i < rings.size(); i++)
+            holes[i - 1] = GEOMETRY_FACTORY.createLinearRing(coordinates(rings.path(i)));
+
+        return GEOMETRY_FACTORY.createPolygon(shell, holes);
+    }
+
+    private Coordinate[] coordinates(JsonNode positions) {
+        Coordinate[] result = new Coordinate[positions.size()];
+        for (int i = 0; i < positions.size(); i++)
+            result[i] = coordinate(positions.path(i));
+        return result;
+    }
+
+    private Coordinate coordinate(JsonNode position) {
+        // GeoJSON positions are [x, y] or [x, y, z], and the service writes them
+        // easting first; restore the axis order of the CRS so that the geometries
+        // match the CRS advertised by this result.
+        double first = position.path(0).asDouble();
+        double second = position.path(1).asDouble();
+        double x = northEastAxisOrder ? second : first;
+        double y = northEastAxisOrder ? first : second;
+
+        return position.size() > 2
+            ? new Coordinate(x, y, position.path(2).asDouble())
+            : new Coordinate(x, y);
+    }
+
+    private static InputStream streamOrNull(URLConnection connection) {
+        try {
+            return connection.getInputStream();
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    private static String excerpt(InputStream inputStream) {
+        if (inputStream == null)
+            return "<no response body>";
+        try (InputStream stream = inputStream) {
+            String text = new String(stream.readNBytes(2048), StandardCharsets.UTF_8);
+            return text.isBlank() ? "<empty response body>" : text.strip();
+        } catch (IOException e) {
+            return "<unreadable response body>";
+        }
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/parameters/providers/WMSFeatureInfoProviderParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/providers/WMSFeatureInfoProviderParams.java
@@ -1,0 +1,131 @@
+
+package com.ignfab.minalac.generator.parameters.providers;
+
+import java.beans.ConstructorProperties;
+
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import org.geotools.api.feature.simple.SimpleFeature;
+import org.geotools.api.referencing.FactoryException;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.referencing.CRS;
+
+import com.ignfab.minalac.generator.generation.Generation;
+import com.ignfab.minalac.generator.inputs.Provider;
+import com.ignfab.minalac.generator.inputs.WMSFeatureInfoDataProvider;
+import com.ignfab.minalac.generator.parameters.processors.GeoToolsVectorProcessorParams;
+import com.ignfab.minalac.generator.parameters.processors.ProcessorParams;
+
+/**
+ * Parameters for WMS GetFeatureInfo providers.
+ */
+public class WMSFeatureInfoProviderParams extends ProviderParams {
+    /**
+     * Base URL for WMS queries (required).
+     */
+    public String url;
+
+    /**
+     * Layer to query (required).
+     */
+    public String layer;
+
+    /**
+     * Coordinate reference system (optional, default: target CRS).
+     */
+    public String crs;
+
+    /**
+     * Pixel size of a query, in CRS units (optional, default: 1).
+     * <p>
+     * Must place {@code resolution / 0.00028} inside the scale window declared by the
+     * layer, otherwise the server answers an empty collection without any error. On
+     * ASIG: 0.14 to 1.40 for {@code adresar:adr_ndertese}, 0.06 to 0.70 for
+     * {@code zrpp:ndertesa_qkd_042025} and the INSTAT census layers, 0.06 to 14 for
+     * the ASHK cadastre.
+     */
+    @JsonSetter(nulls = Nulls.SKIP)
+    public double resolution = 1;
+
+    /**
+     * Half-width of a single query bounding box, in CRS units (optional, default: 70).
+     * <p>
+     * Together with {@code resolution} it sets the size of the query image, so keep
+     * their ratio reasonable: 70 at a resolution of 1 gives a 141 px query.
+     */
+    @JsonSetter(nulls = Nulls.SKIP)
+    public double queryRadius = 70;
+
+    /**
+     * Distance between two query points, in CRS units (optional, default: 50).
+     * <p>
+     * Must not exceed the radius the server actually harvests, which scales with
+     * {@code resolution} since the buffer cap is expressed in pixels: measured around
+     * 76 m at a resolution of 1.33 on ASIG, around 30 m at 0.5.
+     */
+    @JsonSetter(nulls = Nulls.SKIP)
+    public double spacing = 50;
+
+    /**
+     * Value of the WMS {@code BUFFER} parameter, in pixels (optional, default: 100).
+     * <p>
+     * Servers cap this value, so raising it past the cap has no effect.
+     */
+    @JsonSetter(nulls = Nulls.SKIP)
+    public int buffer = 100;
+
+    /**
+     * Maximum features fetched at once (optional, default: 1000).
+     */
+    @JsonSetter(nulls = Nulls.SKIP)
+    public int maxFeaturesPerQuery = 1000;
+
+    /**
+     * Creates a new WMSFeatureInfoProviderParams with mandatory fields.
+     *
+     * @param url Base URL for WMS queries (including protocol, port, domain name and path but not query arguments)
+     * @param layer Name of the WMS layer to query
+     */
+    @ConstructorProperties({"url", "layer"})
+    public WMSFeatureInfoProviderParams(String url, String layer) {
+        this.url = url;
+        this.layer = layer;
+    }
+
+    @Override
+    public Provider<SimpleFeature> create(Generation generation) {
+        CoordinateReferenceSystem layerCrs;
+        if (crs != null)
+            try {
+                layerCrs = CRS.decode(crs);
+            } catch (FactoryException e) {
+                throw new IllegalArgumentException("CRS code \"%s\" is invalid".formatted(crs), e);
+            }
+        else
+            layerCrs = generation.crs();
+
+        if (resolution <= 0)
+            throw new IllegalArgumentException("Resolution must be positive, got %s".formatted(resolution));
+        if (queryRadius <= 0)
+            throw new IllegalArgumentException("Query radius must be positive, got %s".formatted(queryRadius));
+        if (spacing <= 0)
+            throw new IllegalArgumentException("Spacing must be positive, got %s".formatted(spacing));
+
+        return new WMSFeatureInfoDataProvider(
+            url,
+            layer,
+            layerCrs,
+            resolution,
+            queryRadius,
+            spacing,
+            buffer,
+            maxFeaturesPerQuery,
+            generation::getEnvelopeForCRS
+        );
+    }
+
+    @Override
+    public ProcessorParams defaultProcessor() {
+        return new GeoToolsVectorProcessorParams();
+    }
+}


### PR DESCRIPTION
### Changes
Add a WMS provider working through `GetFeatureInfo` to read vector features.

#### Feature description
`WMSFeatureInfoDataProvider` reads geometries and their attributes from a WMS
layer, as GeoJSON.

`GetFeatureInfo` answers for a single *point*, it is meant to feed a map tooltip,
not to read an area. Covering a tile therefore means walking a grid of query
points spaced by `spacing`, and de-duplicating the results by feature identifier,
since a feature is returned by every neighbouring point that falls within the
harvested radius.

Two limits come with that detour, both documented on the class:

- the number of requests follows the surface rather than the number of features,
  so the volume has to be weighed against the capacity of the target service;
- completeness is not guaranteed, since a rendering engine is being sampled
  rather than a feature store: a feature shorter than `spacing` can fall between
  two grid points.

Transient failures are retried per grid point with an exponential backoff, rather
than left to the retry policy of the task: restarting `provide()` would replay
every point already walked, with no better odds of succeeding.

The existing `WMSFloatBilDataProvider` could not be extended for this. It is
declared `Provider<FloatGeographicDataMatrix2d>` where this one provides
`SimpleFeature`, and a class cannot implement `Provider` twice with two
parameterizations — they also feed two different processors.

New parameters type: `WMSFeatureInfoProviderParams`, registered as
`wmsFeatureInfo`.

### Reason
To exploit the WMS services of ASIG, whose GeoServer publishes vector layers
through WMS while keeping WFS disabled (`ServiceException: Service WFS is
disabled`). `GetFeatureInfo` is the only channel left for geometries.

Prefer `WFS1_1_GML3_1_DataProvider` wherever WFS is available: one bounding box
query per tile instead of hundreds of point queries.

### Self-checks

- [ ] The code has unit tests associated
- [ ] The code has Javadoc Comments associated
- [ ] Complex / Unexpected code is explained / justified with a small comment
- [ ] Relevant documentation inside the `/docs` folder has been updated
- [ ] All examples in `examples/` work the same (or have been adapted if subject to changes in this PR)
- [ ] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [ ] The texts have been proofread (documentation, error messages, logs, comments...)
