### PR TITLE
feat(minecraft): Improve Minecraft voxel management with ens-gijs/NBT fork library

### DIFF
--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -29,5 +29,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Javadoc
-          path: target/site/apidocs
+          path: target/reports/apidocs
           if-no-files-found: error

--- a/docs/usage/parameters/Luanti.md
+++ b/docs/usage/parameters/Luanti.md
@@ -1,0 +1,55 @@
+# Luanti output format
+
+Luanti output format exports world in Luanti map version 28, convertible in-game to newer versions.
+
+## Table of contents
+
+* [Output format description](#output-format-description)
+* [Voxel placeable description](#voxel-placeable-description)
+  * [Full format](#full-format)
+  * [Short format](#short-format)
+
+## Output format description
+
+```yaml
+format: luanti
+```
+
+## Voxel placeable description
+
+Voxels in Luanti are [nodes](https://docs.luanti.org/for-players/nodes/). Refer to the documentation of the selected game (e.g. [Minetest Game](https://wiki.minetest.org/Games/Minetest_Game/Nodes)) and mods to find a list of possible values.
+
+#### Full format
+
+Example of a Luanti voxel description for `place` field:
+
+```yaml
+place:
+  node: stairs:stair_stone
+  param2: 2
+```
+
+Fields:
+- `node`: Node type name in Luanti (required)
+- `param1`: Node param1 (integer, optional, default `0`)
+- `param2`: Node param2 (integer, optional, default `0`)
+
+`param1` and `param2` meaning depends on node type. Refer to game documentation for more information.
+
+#### Short format
+
+The Luanti voxel short form string is interpreted as the node type, with all other optional parameters set to their default value.
+
+In other words, writing:
+```yaml
+place: default:stone
+```
+is strictly equivalent to:
+```yaml
+place:
+  node: default:stone
+  param1: 0
+  param2: 0
+```
+
+This short form thus doesn't support setting `param1` or `param2` values.

--- a/docs/usage/parameters/Minecraft.md
+++ b/docs/usage/parameters/Minecraft.md
@@ -1,0 +1,113 @@
+# Minecraft output format
+
+Minecraft output format exports world in Minecraft Java Edition 1.21.11, convertible in-game to newer versions.
+
+## Table of contents
+
+* [Output format description](#output-format-description)
+* [Voxel placeable description](#voxel-placeable-description)
+  * [Full format](#full-format)
+  * [Short format](#short-format)
+
+## Output format description
+
+```yaml
+format: minecraft
+```
+
+## Voxel placeable description
+
+Voxels in Minecraft are [blocks](https://minecraft.wiki/w/Block#List_of_blocks).
+
+### Full format
+
+Example of a Minecraft voxel description for `place` field:
+
+```yaml
+place:
+  block: oak_leaves
+  properties:
+    persistent: true
+```
+
+Example of a Minecraft block entity voxel description for `place` field:
+
+```yaml
+place:
+  block: white_banner
+  properties:
+    rotation: 8
+  blockEntity: banner
+  dataTags: >-
+    {
+      patterns: [
+        {
+          color: "blue",
+          pattern: "stripe_left"
+        },
+        {
+          color: "red",
+          pattern: "stripe_right"
+        }
+      ]
+    }
+```
+
+Fields:
+- `block`: Block name in Minecraft (required, will be namespaced using `minecraft:` if no namespace given)
+- `properties`: Block properties (optional, default none)
+  - _`<property name>`_: Property value (refer to [Minecraft Wiki](https://minecraft.wiki/w/Block_states) for more information)
+
+Additional fields applicable only for [block entities](https://minecraft.wiki/w/Block_entity):
+- `blockEntity`: Block entity ID in Minecraft, or `true` to use the same value as the `block` field (required, will be namespaced using `minecraft:` if no namespace given)
+- `dataTags`: Block entity data encoded as [SNBT](https://minecraft.wiki/w/NBT_format#SNBT_format) (optional, default none, refer to [Minecraft Wiki](https://minecraft.wiki/w/Block_entity_format#Types) for more information)
+
+### Short format
+
+The Minecraft voxel short form string is interpreted as a compact block definition, including block type, optional properties and optional block entity data.
+It follows the syntax of the [block state command argument type](https://minecraft.wiki/w/Argument_types#minecraft:block_state): `block_name[property=value,other_property=other_value]{DataTags: "NBT data"}`.
+
+When data tags are absent (no `{}`), it is a simple block with properties.
+
+In other words, writing:
+```yaml
+place: stone
+```
+is strictly equivalent to:
+```yaml
+place:
+  block: minecraft:stone
+  properties: {}
+```
+
+Another example, with properties:
+```yaml
+place: blue_candle[candles=3,lit=true]
+```
+equivalent to:
+```yaml
+place:
+  block: minecraft:blue_candle
+  properties:
+    candles: 3
+    lit: true
+```
+
+When data tags are provided, the block is turned into a block entity, using the block type as the block entity ID.
+
+In other words, writing:
+```yaml
+# Value is quoted here to prevent YAML interpretation of data tags
+place: 'jukebox[has_record=true]{RecordItem: {id: "minecraft:music_disc_cat"}, ticks_since_song_started: 0L}'
+```
+is strictly equivalent to:
+```yaml
+place:
+  block: default:jukebox
+  properties:
+    has_record: true
+  blockEntity: true
+  dataTags: '{RecordItem: {id: "minecraft:music_disc_cat"}, ticks_since_song_started: 0L}'
+```
+
+This short form thus doesn't support setting `blockEntity` value to something different from the `block`.

--- a/docs/usage/parameters/Parameters.md
+++ b/docs/usage/parameters/Parameters.md
@@ -107,7 +107,7 @@ forEachTile:
 - `verticalScale`: Vertical size of voxels (in map units, usually meters)
 - `horizontalScale`: Horizontal size of voxels (in map units, usually meters)
 - `crs`: Coordinate Reference System to be used for projecting geographical data into voxel world
-- `format`: Output format (`minetest` or `minecraft`)
+- `format`: Output format ([`luanti`](Luanti.md) or [`minecraft`](Minecraft.md))
 - `heightmaps`: [Heightmaps](Heightmaps.md) used for the generation
   - _`<name>`_: Unique name of the heightmap
       - `default`: Default value for all heightmap cells (integer or one of `minimal`, `min`, `maximal` or `max`)

--- a/docs/usage/parameters/Placeables.md
+++ b/docs/usage/parameters/Placeables.md
@@ -7,7 +7,7 @@ A placeable is something that can be placed in voxel world at a given position: 
 
 * [Voxels](#voxels)
   * [Minecraft voxel description](#minecraft-voxel-description)
-  * [Minetest voxel description](#minetest-voxel-description)
+  * [Luanti voxel description](#luanti-voxel-description)
   * [Disambiguation](#disambiguation)
 * [Nothing](#nothing)
 * [Structures](#structures)
@@ -32,53 +32,28 @@ place:
 
 ## Voxels
 
-Voxel descriptions depend on chosen game format. In both Minecraft and Minetest, voxels are mainly defined by a string (block type or node type). They may have some extra optional parameters (like metadata).
+Voxel descriptions depend on chosen game format. In both Minecraft and Luanti, voxels are mainly defined by a string (block type or node type). They may have some extra optional parameters (like metadata).
 
-When a string is given as value for a placeable field, it is interpreted as block type for Minecraft and node type for Minetest. All other parameters are set to default (see Minecraft and Minetest sections below). Other future formats may accept or not this shortcut.
+When a string is given as value for a placeable field, it is interpreted as the voxel short form, if supported by the format. Otherwise, full voxel format should be used (object with fields).
 
 Example of a simple voxel value for `place` field:
 ```yaml
-place: default:stone # Stone node in Minetest
+place: default:stone # Stone node in Minetest Game
 ```
 
-When parameters others than block/node type has to be provided, voxel description must be an object with fields. These fields depends on the game format.
+Note: Format-specific voxel short form cannot be used to represent a voxel named `nothing`, as it would collide with the [Nothing](#nothing) placeable short form.
 
 ### Minecraft voxel description
 
-Example of a Minecraft voxel description for `place` field:
+See [Minecraft voxel placeable](Minecraft.md#voxel-placeable-description) documentation.
 
-```yaml
-place:
-  block: oak_leaves
-  properties:
-    persistent: true
-```
+### Luanti voxel description
 
-Fields:
-  - `block`: Block name in Minecraft (required)
-  - `properties`: Block properties (optional, default none)
-    - _`<property name>`_: Property value (refer to [Minecraft Wiki](https://minecraft.wiki/w/Block_states) for more information)
-
-### Minetest voxel description
-
-Example of a Minetest voxel description for `place` field:
-
-```yaml
-place:
-  node: stairs:stair_stone
-  param2: 2
-```
-
-Fields:
-  - `node`: Node type name in Minetest (required)
-  - `param1`: Node param1 (integer, optional, default `0`)
-  - `param2`: Node param2 (integer, optional, default `0`)
-
-`param1` and `param2` meaning depends on node type. Refer to Minetest documentation for more information.
+See [Luanti voxel placeable](Luanti.md#voxel-placeable-description) documentation.
 
 ### Disambiguation
 
-Another working notation uses an extra `voxel:` field. It gives exactly the same result and so is useless until a game field name conflicts with some generator keywords:
+Another working notation uses an extra `voxel:` field. It gives exactly the same result and so is useless unless a game field name conflicts with some other placeable keywords:
 
 ```yaml
 place:
@@ -89,7 +64,7 @@ place:
 
 ## Nothing
 
-Places nothing. This convenient if placeable is required but you want to place nothing:
+Places nothing. This is convenient if placeable is required, but you don't want to place anything:
 
 ```yaml
 place:

--- a/pom.xml
+++ b/pom.xml
@@ -143,9 +143,10 @@
         </dependency>
         <!-- Minecraft NBT file format -->
         <dependency>
-            <groupId>com.github.Querz</groupId>
-            <artifactId>NBT</artifactId>
-            <version>6.1</version>
+            <groupId>io.github.ens-gijs.nbt</groupId>
+            <artifactId>nbt-mca</artifactId>
+            <version>0.2.0</version>
+            <scope>compile</scope>
         </dependency>
         <!-- Jackson (Yaml/Json deserialization) -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -231,31 +231,31 @@
             <plugins>
                 <plugin>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>3.3.2</version>
+                    <version>3.5.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.3.1</version>
+                    <version>3.5.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.13.0</version>
+                    <version>3.15.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.2.5</version>
+                    <version>3.5.6</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.4.1</version>
+                    <version>3.5.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-install-plugin</artifactId>
-                    <version>3.1.2</version>
+                    <version>3.1.4</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-deploy-plugin</artifactId>
-                    <version>3.1.2</version>
+                    <version>3.1.4</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -265,7 +265,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.6.0</version>
+                <version>3.6.2</version>
                 <executions>
                     <!-- Binds the shade:shade goal to the package phase -->
                     <execution>
@@ -330,7 +330,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.5.0</version>
+                <version>3.6.0</version>
                 <dependencies>
                     <dependency>
                         <!-- Overrides checkstyle version -->
@@ -360,7 +360,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.7.0</version>
+                <version>3.12.0</version>
                 <configuration>
                     <!-- Disable warnings about missing Javadoc Comments -->
                     <doclint>all,-missing</doclint>

--- a/src/main/java/com/ignfab/minalac/generator/modules/minecraft/MinecraftBlockEntityVoxel.java
+++ b/src/main/java/com/ignfab/minalac/generator/modules/minecraft/MinecraftBlockEntityVoxel.java
@@ -1,47 +1,171 @@
 package com.ignfab.minalac.generator.modules.minecraft;
 
+import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
 
-import net.querz.nbt.tag.CompoundTag;
+import io.github.ensgijs.nbt.io.NamedTag;
+import io.github.ensgijs.nbt.io.TextNbtHelpers;
+import io.github.ensgijs.nbt.tag.CompoundTag;
 
 /**
- * {@code MinecraftBlockEntityVoxel} abstract class represents a Minecraft block with additional data associated with it.
+ * {@code MinecraftBlockEntityVoxel} class represents a Minecraft block with additional data associated with it.
  * That additional information is known as block entity.
- * @see <a href="https://minecraft.wiki/w/Block_entity"> Block entity (Minecraft wiki)</a>
+ * <p>
+ * Like {@link MinecraftVoxel}, it is immutable. A builder pattern may help to abstract the raw NBT structure
+ * used to represent its data.
+ * @see <a href="https://minecraft.wiki/w/Block_entity"> Block entity (Minecraft Wiki)</a>
  */
-public abstract class MinecraftBlockEntityVoxel extends MinecraftVoxel {
+public class MinecraftBlockEntityVoxel extends MinecraftVoxel {
+    private final String id;
+    private final CompoundTag data;
+
     /**
      * Constructs a new {@code MinecraftBlockEntityVoxel}.
      *
-     * @param type the block type string
+     * @param voxel the block state as an existing voxel
+     * @param id the block entity ID
+     * @param data the block entity data
      */
-    public MinecraftBlockEntityVoxel(String type) {
-        super(type);
+    public MinecraftBlockEntityVoxel(MinecraftVoxel voxel, String id, CompoundTag data) {
+        this(voxel.type(), id, voxel.properties(), data);
     }
 
     /**
      * Constructs a new {@code MinecraftBlockEntityVoxel}.
      *
      * @param type the block type string
+     * @param id the block entity ID
      * @param properties the block state properties
+     * @param data the block entity data
      */
-    public MinecraftBlockEntityVoxel(String type, Map<String, String> properties) {
+    public MinecraftBlockEntityVoxel(String type, String id, Map<String, String> properties, CompoundTag data) {
         super(type, properties);
+        this.id = MinecraftHelpers.ensureNamespaced(id);
+        this.data = data == null ? new CompoundTag() : data.clone();
     }
 
-    protected abstract void serialize(CompoundTag tag);
+    /**
+     * {@return the block entity ID}
+     * @see <a href="https://minecraft.wiki/w/Block_entity_format#Types">List of block entities (Minecraft Wiki)</a>
+     */
+    public String id() {
+        return id;
+    }
+
+    /**
+     * {@return a copy of the block entity data}
+     * The meaning of that data is entirely dependent on the {@link #id}.
+     */
+    public CompoundTag data() {
+        return data.clone();
+    }
+
+    /**
+     * Returns the voxel representing this block, without additional block entity data.
+     *
+     * @return simple voxel with block entity data stripped
+     */
+    public MinecraftVoxel stripBlockEntity() {
+        return new MinecraftVoxel(type(), properties());
+    }
 
     @Override
     protected void place(MinecraftVoxelTile tile, int x, int y, int z)  {
         super.place(tile, x, y, z);
         CompoundTag block = new CompoundTag();
-        block.putString("id", type);
+        block.putString("id", id);
         block.putBoolean("keepPacked", false);
-        // X/Y/Z => X/Z/-Y
-        block.putInt("x", x);
-        block.putInt("y", z);
-        block.putInt("z", -y - 1);
-        serialize(block);
+        for (NamedTag tag : data)
+            block.put(tag);
         tile.addBlockEntity(x, z, -y - 1, block); // X/Y/Z => X/Z/-Y
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!super.equals(o)) return false;
+        MinecraftBlockEntityVoxel that = (MinecraftBlockEntityVoxel) o;
+        return id.equals(that.id) && data.equals(that.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), id, data);
+    }
+
+    /**
+     * Serializes this voxel to a block state string including block entity data.
+     *
+     * @return a string representing the block
+     * @see #fromString(String)
+     */
+    @Override
+    public String toString() {
+        String str = super.toString();
+        if (data.isEmpty())
+            return str;
+        return str + TextNbtHelpers.toTextNbt(data, false, true);
+    }
+
+    /**
+     * Creates a new instance of {@link MinecraftBlockEntityVoxel} from a serialized block state string.
+     * The block entity ID will be the same as the block type name.
+     * Example: {@code minecraft:jukebox[has_record=true]{RecordItem: {id: "minecraft:music_disc_cat"}, ticks_since_song_started: 0L}}.
+     * Extra whitespaces outside of data tags are not allowed!
+     *
+     * @param block the string representing a block
+     * @return a new {@code MinecraftBlockEntityVoxel}
+     * @see #toString()
+     */
+    public static MinecraftBlockEntityVoxel fromString(String block) {
+        return fromString(block, null);
+    }
+
+    /**
+     * Creates a new instance of {@link MinecraftBlockEntityVoxel} from a serialized block state string and a block entity ID.
+     * Example: {@code minecraft:jukebox[has_record=true]{RecordItem: {id: "minecraft:music_disc_cat"}, ticks_since_song_started: 0L}}.
+     * Extra whitespaces outside of data tags are not allowed!
+     *
+     * @param block the string representing a block
+     * @param id the block entity ID
+     * @return a new {@code MinecraftBlockEntityVoxel}
+     * @see #toString()
+     */
+    public static MinecraftBlockEntityVoxel fromString(String block, String id) {
+        int bracket = block.indexOf('{');
+        if (bracket == -1) {
+            MinecraftVoxel voxel = MinecraftVoxel.fromString(block);
+            return new MinecraftBlockEntityVoxel(voxel, Objects.requireNonNullElse(id, voxel.type()), null);
+        }
+        if (block.lastIndexOf('}') != block.length() - 1)
+            throw new IllegalArgumentException("Invalid block entity definition: " + block);
+        MinecraftVoxel voxel = MinecraftVoxel.fromString(block.substring(0, bracket));
+        String dataTags = block.substring(bracket);
+        CompoundTag data;
+        try {
+            data = TextNbtHelpers.fromTextNbt(dataTags).getTagAutoCast();
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Malformed data tags: " + dataTags, e);
+        }
+        return new MinecraftBlockEntityVoxel(voxel, Objects.requireNonNullElse(id, voxel.type()), data);
+    }
+
+    /**
+     * Creates a new instance of {@link MinecraftBlockEntityVoxel} from
+     * a {@link CompoundTag} and an existing {@link MinecraftVoxel}.
+     *
+     * @param block the {@code CompoundTag} representing a block entity
+     * @param voxel the {@code MinecraftVoxel} representing the block state to use as a base
+     * @return a new {@code MinecraftBlockEntityVoxel}
+     */
+    public static MinecraftBlockEntityVoxel fromBlockEntity(CompoundTag block, MinecraftVoxel voxel) {
+        String id = block.getStringTag("id").getValue();
+        CompoundTag data = block.clone();
+        data.remove("id");
+        data.remove("keepPacked");
+        data.remove("x");
+        data.remove("y");
+        data.remove("z");
+        return new MinecraftBlockEntityVoxel(voxel, id, data);
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/modules/minecraft/MinecraftBlockEntityVoxelParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/modules/minecraft/MinecraftBlockEntityVoxelParams.java
@@ -1,0 +1,64 @@
+package com.ignfab.minalac.generator.modules.minecraft;
+
+import java.beans.ConstructorProperties;
+import java.io.IOException;
+
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import io.github.ensgijs.nbt.io.TextNbtHelpers;
+import io.github.ensgijs.nbt.tag.CompoundTag;
+
+import com.ignfab.minalac.generator.utils.random.Seed;
+
+/**
+ * Parameters for Minecraft block entity voxel.
+ */
+public class MinecraftBlockEntityVoxelParams extends MinecraftVoxelParams {
+    /**
+     * Block entity ID (required).
+     * Special case: If value is {@code "true"}, block type name will be used.
+     * This is needed to determine that a block entity is wanted.
+     */
+    @JsonSetter(nulls = Nulls.FAIL)
+    public String blockEntity;
+
+    /**
+     * Block state data (optional).
+     */
+    @JsonSetter(nulls = Nulls.SKIP)
+    public String dataTags = null;
+
+    /**
+     * Creates a new {@code MinecraftBlockEntityVoxelParams}.
+     *
+     * @param block Block type name
+     * @param blockEntity Block entity ID
+     */
+    @ConstructorProperties({ "block", "blockEntity" })
+    public MinecraftBlockEntityVoxelParams(String block, String blockEntity) {
+        super(block);
+        this.blockEntity = blockEntity.equals("true") ? block : blockEntity;
+    }
+
+    @Override
+    public void validate() throws IllegalArgumentException {
+        super.validate();
+        if (blockEntity.isBlank())
+            throw new IllegalArgumentException("blockEntity should not be empty or blank");
+    }
+
+    @Override
+    public MinecraftBlockEntityVoxel create(Seed seed) {
+        CompoundTag data;
+        if (dataTags == null)
+            data = null;
+        else {
+            try {
+                data = TextNbtHelpers.fromTextNbt(dataTags).getTagAutoCast();
+            } catch (IOException e) {
+                throw new IllegalArgumentException("Malformed data tags: " + dataTags, e);
+            }
+        }
+        return new MinecraftBlockEntityVoxel(block, blockEntity, properties, data);
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/modules/minecraft/MinecraftHelpers.java
+++ b/src/main/java/com/ignfab/minalac/generator/modules/minecraft/MinecraftHelpers.java
@@ -1,0 +1,34 @@
+package com.ignfab.minalac.generator.modules.minecraft;
+
+import io.github.ensgijs.nbt.tag.CompoundTag;
+
+/**
+ * Miscellaneous utility functions for Minecraft-related operations.
+ */
+public final class MinecraftHelpers {
+    private MinecraftHelpers() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@return the given resource location with explicit namespace}
+     * If the input string already has a namespace, it is returned untouched,
+     * otherwise the default namespace {@code minecraft:} is prepended.
+     * @param resourceLocation the resource location
+     */
+    public static String ensureNamespaced(String resourceLocation) {
+        return resourceLocation.indexOf(':') == -1 ? "minecraft:" + resourceLocation : resourceLocation;
+    }
+
+    /**
+     * Checks that the position contained in the data is equals to the given one.
+     * @param data the data containing the position as {@code x}, {@code y} and {@code z} fields
+     * @param x the test value of the x-coordinate
+     * @param y the test value of the y-coordinate
+     * @param z the test value of the z-coordinate
+     * @return {@code true} if the position are the same, {@code false} otherwise
+     */
+    public static boolean xyzEquals(CompoundTag data, int x, int y, int z) {
+        return data.getInt("x") == x && data.getInt("y") == y && data.getInt("z") == z;
+    }
+}

--- a/src/main/java/com/ignfab/minalac/generator/modules/minecraft/MinecraftOutputModule.java
+++ b/src/main/java/com/ignfab/minalac/generator/modules/minecraft/MinecraftOutputModule.java
@@ -8,9 +8,8 @@ import com.ignfab.minalac.generator.utils.modules.Module;
  * A module for Minecraft format output.
  */
 public class MinecraftOutputModule extends Module {
-
     @Override
     public void registerParams(ParamsParser parser) {
-        parser.registerFormat("minecraft", new OutputFormat(MinecraftVoxelWorld::new, MinecraftVoxelParams.class, MinecraftVoxelParams::new));
+        parser.registerFormat("minecraft", new OutputFormat(MinecraftVoxelWorld::new, MinecraftVoxelParams.class, MinecraftVoxelParams::packed));
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/modules/minecraft/MinecraftVoxel.java
+++ b/src/main/java/com/ignfab/minalac/generator/modules/minecraft/MinecraftVoxel.java
@@ -4,8 +4,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-import net.querz.nbt.tag.CompoundTag;
-import net.querz.nbt.tag.StringTag;
+import io.github.ensgijs.nbt.tag.CompoundTag;
+import io.github.ensgijs.nbt.tag.StringTag;
 
 import com.ignfab.minalac.generator.placeables.Placeable;
 import com.ignfab.minalac.generator.world.VoxelTile;
@@ -15,24 +15,16 @@ import com.ignfab.minalac.generator.world.VoxelTile;
  * A voxel in Minecraft, known as block, consists of two parameters: type and state properties.
  */
 public class MinecraftVoxel implements Placeable {
+    private final String type;
+    private final Map<String, String> properties;
+
+    // Lazily-initialized reusable block data
+    private CompoundTag block;
 
     /**
      * Default voxel used on map initialization.
      */
     public static final MinecraftVoxel DEFAULT_VOXEL = new MinecraftVoxel("minecraft:air");
-
-    /**
-     * The block type string.
-     * @see <a href="https://minecraft.wiki/w/Block">List of block types (Minecraft Wiki)</a>
-     */
-    protected final String type;
-    /**
-     * The block state properties.
-     */
-    protected final Map<String, String> properties;
-
-    // Lazily-initialized reusable block data
-    private CompoundTag block;
 
     /**
      * Constructs a new {@code MinecraftVoxel}.
@@ -50,30 +42,23 @@ public class MinecraftVoxel implements Placeable {
      * @param properties the block state properties
      */
     public MinecraftVoxel(String type, Map<String, String> properties) {
-        this.type = type;
-        this.properties = properties;
+        this.type = MinecraftHelpers.ensureNamespaced(type);
+        this.properties = properties == null ? Map.of() : Map.copyOf(properties);
     }
 
     /**
-     * Creates a new instance of {@link MinecraftVoxel} from a {@link CompoundTag} and a {@link MinecraftVoxelWorld}.
-     *
-     * @param block the {@code CompoundTag} representing a block.
-     * @return a new {@code MinecraftVoxel}
+     * {@return the block type string}
+     * @see <a href="https://minecraft.wiki/w/Block">List of block types (Minecraft Wiki)</a>
      */
-    public static MinecraftVoxel fromBlockState(CompoundTag block) {
-        String type = block.getStringTag("Name").getValue();
+    public String type() {
+        return type;
+    }
 
-        CompoundTag propertiesTag = block.getCompoundTag("Properties");
-        if (propertiesTag != null) {
-            Map<String, String> properties = new HashMap<>();
-            propertiesTag.forEach(entry -> properties.put(
-                entry.getKey(),
-                ((StringTag) entry.getValue()).getValue()
-            ));
-            return new MinecraftVoxel(type, properties);
-        }
-
-        return new MinecraftVoxel(type);
+    /**
+     * {@return the block state properties}
+     */
+    public Map<String, String> properties() {
+        return properties;
     }
 
     @Override
@@ -97,7 +82,7 @@ public class MinecraftVoxel implements Placeable {
         if (block == null) {
             block = new CompoundTag();
             block.putString("Name", type);
-            if (properties != null) {
+            if (!properties.isEmpty()) {
                 CompoundTag state = new CompoundTag();
                 properties.forEach(state::putString);
                 block.put("Properties", state);
@@ -111,11 +96,79 @@ public class MinecraftVoxel implements Placeable {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         MinecraftVoxel that = (MinecraftVoxel) o;
-        return type.equals(that.type) && Objects.equals(properties, that.properties);
+        return type.equals(that.type) && properties.equals(that.properties);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(type, properties);
+    }
+
+    /**
+     * Serializes this voxel to a block state string.
+     *
+     * @return a string representing the block
+     * @see #fromString(String)
+     */
+    @Override
+    public String toString() {
+        if (properties.isEmpty())
+            return type;
+        StringBuilder builder = new StringBuilder(type).append('[');
+        properties.entrySet().stream()
+            .sorted(Map.Entry.comparingByKey())
+            .forEach(entry -> builder.append(entry.getKey()).append('=').append(entry.getValue()).append(','));
+        return builder.deleteCharAt(builder.length() - 1).append(']').toString();
+    }
+
+    /**
+     * Creates a new instance of {@link MinecraftVoxel} from a serialized block state string.
+     * Example: {@code minecraft:blue_candle[candles=3,lit=true]}.
+     * Extra whitespaces are not allowed!
+     *
+     * @param block the string representing a block
+     * @return a new {@code MinecraftVoxel}
+     * @see #toString()
+     */
+    public static MinecraftVoxel fromString(String block) {
+        int bracket = block.indexOf('[');
+        if (bracket == -1)
+            return new MinecraftVoxel(block);
+        if (block.lastIndexOf(']') != block.length() - 1)
+            throw new IllegalArgumentException("Invalid block state definition: " + block);
+        String type = block.substring(0, bracket);
+        String propertiesStr = block.substring(bracket + 1, block.length() - 1);
+        if (propertiesStr.isEmpty())
+            return new MinecraftVoxel(type);
+        Map<String, String> properties = new HashMap<>();
+        for (String property : propertiesStr.split(",")) {
+            int eq = property.indexOf('=');
+            if (eq == -1)
+                throw new IllegalArgumentException("Invalid property definition: " + property);
+            properties.put(property.substring(0, eq), property.substring(eq + 1));
+        }
+        return new MinecraftVoxel(type, properties);
+    }
+
+    /**
+     * Creates a new instance of {@link MinecraftVoxel} from a {@link CompoundTag} and a {@link MinecraftVoxelWorld}.
+     *
+     * @param block the {@code CompoundTag} representing a block
+     * @return a new {@code MinecraftVoxel}
+     */
+    public static MinecraftVoxel fromBlockState(CompoundTag block) {
+        String type = block.getStringTag("Name").getValue();
+
+        CompoundTag propertiesTag = block.getCompoundTag("Properties");
+        if (propertiesTag != null) {
+            Map<String, String> properties = new HashMap<>();
+            propertiesTag.forEach(entry -> properties.put(
+                entry.getName(),
+                entry.<StringTag>getTagAutoCast().getValue()
+            ));
+            return new MinecraftVoxel(type, properties);
+        }
+
+        return new MinecraftVoxel(type);
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/modules/minecraft/MinecraftVoxelParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/modules/minecraft/MinecraftVoxelParams.java
@@ -4,15 +4,20 @@ import java.beans.ConstructorProperties;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.Nulls;
 
 import com.ignfab.minalac.generator.parameters.placeables.PlaceableParams;
-import com.ignfab.minalac.generator.placeables.Placeable;
 import com.ignfab.minalac.generator.utils.random.Seed;
 
 /**
  * Parameters for simple Minecraft voxel with only block type name.
  */
+// defaultImpl is needed because Jackson deduction cannot rely on absence of field to determine a subtype
+// See this GitHub issue for more info: https://github.com/FasterXML/jackson-databind/issues/2976
+@JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION, defaultImpl = MinecraftVoxelParams.class)
+@JsonSubTypes(@JsonSubTypes.Type(MinecraftBlockEntityVoxelParams.class))
 public class MinecraftVoxelParams extends PlaceableParams {
     /**
      * Block type name (required).
@@ -31,7 +36,7 @@ public class MinecraftVoxelParams extends PlaceableParams {
      *
      * @param block Block type name
      */
-    @ConstructorProperties({"block"})
+    @ConstructorProperties("block")
     public MinecraftVoxelParams(String block) {
         this.block = block;
     }
@@ -43,7 +48,29 @@ public class MinecraftVoxelParams extends PlaceableParams {
     }
 
     @Override
-    public Placeable create(Seed seed) {
+    public MinecraftVoxel create(Seed seed) {
         return new MinecraftVoxel(block, properties);
+    }
+
+    /**
+     * Creates a new {@code MinecraftVoxelParams} from packed form.
+     * @param block Block in packed form
+     * @return The created params
+     */
+    public static MinecraftVoxelParams packed(String block) {
+        return new Packed(block);
+    }
+
+    private static final class Packed extends MinecraftVoxelParams {
+        private Packed(String block) {
+            super(block);
+        }
+
+        @Override
+        public MinecraftVoxel create(Seed seed) {
+            if (block.indexOf('{') == -1)
+                return MinecraftVoxel.fromString(block);
+            return MinecraftBlockEntityVoxel.fromString(block);
+        }
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/modules/minecraft/MinecraftVoxelTile.java
+++ b/src/main/java/com/ignfab/minalac/generator/modules/minecraft/MinecraftVoxelTile.java
@@ -3,13 +3,13 @@ package com.ignfab.minalac.generator.modules.minecraft;
 import java.io.File;
 import java.io.IOException;
 
+import io.github.ensgijs.nbt.mca.TerrainChunk;
+import io.github.ensgijs.nbt.mca.io.McaFileHelpers;
+import io.github.ensgijs.nbt.tag.CompoundTag;
+import io.github.ensgijs.nbt.tag.ListTag;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMaps;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
-import net.querz.mca.Chunk;
-import net.querz.mca.MCAUtil;
-import net.querz.nbt.tag.CompoundTag;
-import net.querz.nbt.tag.ListTag;
 
 import com.ignfab.minalac.generator.placeables.Placeable;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
@@ -38,9 +38,13 @@ public class MinecraftVoxelTile extends VoxelTile {
     /**
      * {@inheritDoc}
      * The world is exported in a format for Minecraft.
+     * @throws MapWriteException if a {@link Region} cannot be {@link Region#save(File) saved}
      */
     @Override
     public void save() throws MapWriteException {
+        if (destination == null)
+            return; // Save disabled if null destination
+
         for (Region region : regions.values()) {
             try {
                 region.save(destination);
@@ -51,16 +55,30 @@ public class MinecraftVoxelTile extends VoxelTile {
     }
 
     // In-Game coords
-    /* package-private */ synchronized void setBlockState(int blockX, int blockY, int blockZ, CompoundTag block) {
-        // This method is synchronized as a workaround because the Querz library is not thread-safe.
-        // This is a performance-killer!
-        // The only part that really needs synchronization is inside nbt.querz.mca.Section:
-        // During a palette update (adjustBlockStateBits), it should block, until operation
-        // is complete, any other thread trying to add a block to the palette (addToPalette,
-        // after the check for existing block inside palette).
-
+    /* package-private */ void setBlockState(int blockX, int blockY, int blockZ, CompoundTag block) {
         if (isOutOfLimits(blockX, blockY, blockZ)) return;
-        getOrCreateRegion(blockX, blockZ).file().setBlockStateAt(blockX, blockY, blockZ, block, false);
+        TerrainChunk chunk = getOrCreateRegion(blockX, blockZ).getOrCreateChunk(McaFileHelpers.blockToChunk(blockX), McaFileHelpers.blockToChunk(blockZ));
+        if (!chunk.containsSection(blockY / 16)) {
+            synchronized (chunk) {
+                if (!chunk.containsSection(blockY / 16))
+                    chunk.createSection(blockY / 16);
+            }
+        }
+        synchronized (chunk) {
+            // This call is synchronized as a workaround because the NBT library is not thread-safe.
+            // This is a performance-killer!
+            // The only part that really needs synchronization is inside io.github.ensgijs.nbt.mca.util.PalettizedCuboid:
+            // When adding a block, if the palette must be modified, it should be synchronized.
+            // See: https://github.com/ens-gijs/NBT/issues/7
+
+            chunk.setBlockAt(
+                McaFileHelpers.blockAbsoluteToChunkRelative(blockX),
+                blockY,
+                McaFileHelpers.blockAbsoluteToChunkRelative(blockZ),
+                block
+            );
+        }
+        clearBlockEntity(blockX, blockY, blockZ); // TODO This negatively affects performances and should be optimized!
         // (In-Game coords to world coords) X/Z/-Y => X/Y/Z
         updateHeightmaps(blockX, -(blockZ + 1), blockY);
     }
@@ -68,13 +86,34 @@ public class MinecraftVoxelTile extends VoxelTile {
     // In-Game coords
     /* package-private */ void addBlockEntity(int blockX, int blockY, int blockZ, CompoundTag block)  {
         if (isOutOfLimits(blockX, blockY, blockZ)) return;
-        Chunk chunk = getOrCreateRegion(blockX, blockZ).getOrCreateChunk(MCAUtil.blockToChunk(blockX), MCAUtil.blockToChunk(blockZ));
+        TerrainChunk chunk = getOrCreateRegion(blockX, blockZ).getOrCreateChunk(McaFileHelpers.blockToChunk(blockX), McaFileHelpers.blockToChunk(blockZ));
         ListTag<CompoundTag> blockEntities = chunk.getTileEntities();
         if (blockEntities == null) {
-            blockEntities = new ListTag<>(CompoundTag.class);
-            chunk.setTileEntities(blockEntities);
+            synchronized (chunk) {
+                blockEntities = chunk.getTileEntities();
+                if (blockEntities == null) {
+                    blockEntities = new ListTag<>(CompoundTag.class);
+                    chunk.setTileEntities(blockEntities);
+                }
+            }
         }
-        blockEntities.add(block);
+        block.putInt("x", blockX);
+        block.putInt("y", blockY);
+        block.putInt("z", blockZ);
+        synchronized (blockEntities) {
+            blockEntities.add(block);
+        }
+    }
+
+    private void clearBlockEntity(int blockX, int blockY, int blockZ) {
+        if (isOutOfLimits(blockX, blockY, blockZ)) return;
+        TerrainChunk chunk = getOrCreateRegion(blockX, blockZ).getOrCreateChunk(McaFileHelpers.blockToChunk(blockX), McaFileHelpers.blockToChunk(blockZ));
+        ListTag<CompoundTag> blockEntities = chunk.getTileEntities();
+        if (blockEntities == null)
+            return;
+        synchronized (blockEntities) {
+            blockEntities.removeIf(blockEntity -> MinecraftHelpers.xyzEquals(blockEntity, blockX, blockY, blockZ));
+        }
     }
 
     // In-Game coords
@@ -97,11 +136,21 @@ public class MinecraftVoxelTile extends VoxelTile {
      */
     @Override
     public Placeable getVoxel(int x, int y, int z) {
-        Region region = regions.get(Region.computeKeyFromBlock(x, -y - 1));
-
-        if (region == null) return MinecraftVoxel.DEFAULT_VOXEL;
-
         // (World coords to In-Game coords) X/Y/Z => X/Z/-Y-1
-        return region.getBlock(x, z, -y - 1);
+        int blockX = x;
+        int blockY = z;
+        int blockZ = -y - 1;
+
+        Region region = regions.get(Region.computeKeyFromBlock(blockX, blockZ));
+        if (region == null)
+            return MinecraftVoxel.DEFAULT_VOXEL;
+
+        CompoundTag blockState = region.getBlockState(blockX, blockY, blockZ);
+        if (blockState == null)
+            return MinecraftVoxel.DEFAULT_VOXEL;
+        MinecraftVoxel voxel = MinecraftVoxel.fromBlockState(blockState);
+
+        CompoundTag blockEntity = region.getBlockEntity(blockX, blockY, blockZ);
+        return blockEntity == null ? voxel : MinecraftBlockEntityVoxel.fromBlockEntity(blockEntity, voxel);
     }
 }

--- a/src/main/java/com/ignfab/minalac/generator/modules/minecraft/MinecraftVoxelWorld.java
+++ b/src/main/java/com/ignfab/minalac/generator/modules/minecraft/MinecraftVoxelWorld.java
@@ -6,14 +6,15 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.Random;
 
-import net.querz.mca.Chunk;
-import net.querz.nbt.io.NBTUtil;
-import net.querz.nbt.tag.CompoundTag;
-import net.querz.nbt.tag.DoubleTag;
-import net.querz.nbt.tag.FloatTag;
-import net.querz.nbt.tag.IntTag;
-import net.querz.nbt.tag.ListTag;
-import net.querz.nbt.tag.StringTag;
+import io.github.ensgijs.nbt.io.BinaryNbtHelpers;
+import io.github.ensgijs.nbt.io.CompressionType;
+import io.github.ensgijs.nbt.mca.DataVersion;
+import io.github.ensgijs.nbt.tag.CompoundTag;
+import io.github.ensgijs.nbt.tag.DoubleTag;
+import io.github.ensgijs.nbt.tag.FloatTag;
+import io.github.ensgijs.nbt.tag.IntTag;
+import io.github.ensgijs.nbt.tag.ListTag;
+import io.github.ensgijs.nbt.tag.StringTag;
 
 import com.ignfab.minalac.generator.generation.SquareUnitsTileGenerator;
 import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
@@ -29,12 +30,11 @@ import com.ignfab.minalac.generator.world.VoxelWorldMetadata;
  */
 public class MinecraftVoxelWorld extends VoxelWorld {
     // Note: The two z-component values aren't strictly hard-limits.
-    // We can extends from -2032 to 2031 but the client
+    // We can extend from -2032 to 2031 but the client
     // will need higher performances to play the game!
-    // The Querz library does not support extended limits...
     private static final WorldBBox3d MAX_LIMIT = new WorldBBox3d(
-        new WorldCoords3d(-30_000_000, -30_000_000, 0),
-        new WorldCoords3d(30_000_000, 30_000_000, 255)
+        new WorldCoords3d(-30_000_000, -30_000_000, -64),
+        new WorldCoords3d(30_000_000, 30_000_000, 319)
     );
 
     private final File destination;
@@ -49,12 +49,7 @@ public class MinecraftVoxelWorld extends VoxelWorld {
     public MinecraftVoxelWorld(File destination) {
         super(new VoxelWorldMetadata());
         this.destination = destination;
-
-        if (destination == null)
-            regionDirectory = null;
-        else {
-            regionDirectory = new File(destination, "region");
-        }
+        regionDirectory = destination == null ? null : new File(destination, "region");
     }
 
     @Override
@@ -73,9 +68,10 @@ public class MinecraftVoxelWorld extends VoxelWorld {
             return;
 
         if (!destination.exists() || !destination.isDirectory())
-            throw new MapWriteException("Directory %s can not be accessed".formatted(destination));
+            throw new MapWriteException("Directory %s cannot be accessed".formatted(destination));
 
-        regionDirectory.mkdir();
+        if (!regionDirectory.mkdir())
+            throw new MapWriteException("Region directory %s cannot be created".formatted(regionDirectory));
     }
 
     /**
@@ -88,7 +84,7 @@ public class MinecraftVoxelWorld extends VoxelWorld {
             return; // Save disabled if null destination
 
         try {
-            NBTUtil.write(createLevelData(), new File(destination, "level.dat"), true);
+            BinaryNbtHelpers.write(createLevelData(), new File(destination, "level.dat"), CompressionType.GZIP);
         } catch (IOException e) {
             throw new MapWriteException("Unable to save level.dat", e);
         }
@@ -96,6 +92,7 @@ public class MinecraftVoxelWorld extends VoxelWorld {
 
     @SuppressWarnings({ "checkstyle:MethodLength", "checkstyle:AvoidNestedBlocks", "checkstyle:LocalVariableName" })
     private CompoundTag createLevelData() {
+        DataVersion mcVersion = DataVersion.JAVA_1_21_11;
         long seed = new Random().nextLong();
 
         CompoundTag root = new CompoundTag();
@@ -129,7 +126,7 @@ public class MinecraftVoxelWorld extends VoxelWorld {
                 }
                 data.put("DataPacks", dataPacks);
 
-                data.putInt("DataVersion", Chunk.DEFAULT_DATA_VERSION);
+                data.putInt("DataVersion", mcVersion.id());
 
                 data.putLong("DayTime", 0);
 
@@ -151,12 +148,15 @@ public class MinecraftVoxelWorld extends VoxelWorld {
 
                 CompoundTag gameRules = new CompoundTag();
                 {
-                    // Commented out gamerule were added after 1.16.1
+                    gameRules.putString("allowEnteringUsingNetherPortals", "true");
+                    gameRules.putString("allowFireTicksAwayFromPlayer", "false");
                     gameRules.putString("announceAdvancements", "true");
-                    // gameRules.putString("blockExplosionDropDecay", "true"); // 1.19.3
+                    gameRules.putString("blockExplosionDropDecay", "true");
+                    gameRules.putString("commandBlocksEnabled", "true");
                     gameRules.putString("commandBlockOutput", "true");
-                    // gameRules.putString("commandModificationBlockLimit", "32768"); // 1.19.4
+                    gameRules.putString("commandModificationBlockLimit", "32768");
                     gameRules.putString("disableElytraMovementCheck", "false");
+                    gameRules.putString("disablePlayerMovementCheck", "false");
                     gameRules.putString("disableRaids", "false");
                     gameRules.putString("doDaylightCycle", "true");
                     gameRules.putString("doEntityDrops", "true");
@@ -169,49 +169,49 @@ public class MinecraftVoxelWorld extends VoxelWorld {
                     gameRules.putString("doPatrolSpawning", "true");
                     gameRules.putString("doTileDrops", "true");
                     gameRules.putString("doTraderSpawning", "true");
-                    // gameRules.putString("doVinesSpread", "true"); // 1.19.4
+                    gameRules.putString("doVinesSpread", "true");
                     gameRules.putString("doWeatherCycle", "true");
-                    // gameRules.putString("doWardenSpawning", "true"); // 1.19
+                    gameRules.putString("doWardenSpawning", "true");
                     gameRules.putString("drowningDamage", "true");
-                    // gameRules.putString("enderPearlsVanishOnDeath", "true"); // 1.20.2
+                    gameRules.putString("enderPearlsVanishOnDeath", "true");
                     gameRules.putString("fallDamage", "true");
                     gameRules.putString("fireDamage", "true");
                     gameRules.putString("forgiveDeadPlayers", "true");
-                    // gameRules.putString("freezeDamage", "true"); // 1.17
-                    // gameRules.putString("globalSoundEvents", "true"); // 1.19.3
+                    gameRules.putString("freezeDamage", "true");
+                    gameRules.putString("globalSoundEvents", "true");
                     gameRules.putString("keepInventory", "false");
-                    // gameRules.putString("lavaSourceConversion", "false"); // 1.19.3
+                    gameRules.putString("lavaSourceConversion", "false");
+                    gameRules.putString("locatorBar", "true");
                     gameRules.putString("logAdminCommands", "true");
                     gameRules.putString("maxCommandChainLength", "65536");
-                    // gameRules.putString("maxCommandForkCount", "65536"); // 1.20.3
+                    gameRules.putString("maxCommandForkCount", "65536");
                     gameRules.putString("maxEntityCramming", "24");
-                    // gameRules.putString("mobExplosionDropDecay", "true"); // 1.19.3
+                    gameRules.putString("mobExplosionDropDecay", "true");
                     gameRules.putString("mobGriefing", "true");
                     gameRules.putString("naturalRegeneration", "true");
-                    // gameRules.putString("playersNetherPortalCreativeDelay", "1"); // 1.20.3
-                    // gameRules.putString("playersNetherPortalDefaultDelay", "80"); // 1.20.3
-                    // gameRules.putString("playersSleepingPercentage", "100"); // 1.17
-                    // gameRules.putString("projectilesCanBreakBlocks", "true"); // 1.20.3
+                    gameRules.putString("playersNetherPortalCreativeDelay", "1");
+                    gameRules.putString("playersNetherPortalDefaultDelay", "80");
+                    gameRules.putString("playersSleepingPercentage", "100");
+                    gameRules.putString("projectilesCanBreakBlocks", "true");
+                    gameRules.putString("pvp", "true");
                     gameRules.putString("randomTickSpeed", "3");
                     gameRules.putString("reducedDebugInfo", "false");
                     gameRules.putString("sendCommandFeedback", "true");
                     gameRules.putString("showDeathMessages", "true");
-                    // gameRules.putString("snowAccumulationHeight", "1"); // 1.19.3
-                    // gameRules.putString("spawnChunkRadius", "2"); // 1.20.5
+                    gameRules.putString("snowAccumulationHeight", "1");
+                    gameRules.putString("spawnerBlocksEnabled", "true");
+                    gameRules.putString("spawnMonsters", "true");
+                    gameRules.putString("spawnChunkRadius", "2");
                     gameRules.putString("spawnRadius", "10");
                     gameRules.putString("spectatorsGenerateChunks", "true");
-                    // gameRules.putString("tntExplosionDropDecay", "false"); // 1.19.3
+                    gameRules.putString("tntExplodes", "true");
+                    gameRules.putString("tntExplosionDropDecay", "false");
                     gameRules.putString("universalAnger", "false");
-                    // gameRules.putString("waterSourceConversion", "true"); // 1.19.3
+                    gameRules.putString("waterSourceConversion", "true");
                 }
                 data.put("GameRules", gameRules);
 
                 data.putInt("GameType", 1);
-
-                // Legacy (1.15 and below)
-                // data.putString("generatorName", "default");
-                // data.putInt("generatorVersion", 0);
-                // data.putString("generatorOptions", "generatorOptions");
 
                 data.putBoolean("hardcore", false);
 
@@ -258,7 +258,7 @@ public class MinecraftVoxelWorld extends VoxelWorld {
                     }
                     player.put("Brain", brain);
 
-                    player.putInt("DataVersion", Chunk.DEFAULT_DATA_VERSION);
+                    player.putInt("DataVersion", mcVersion.id());
 
                     player.putShort("DeathTime", (short) 0);
 
@@ -381,8 +381,8 @@ public class MinecraftVoxelWorld extends VoxelWorld {
                 data.putInt("version", 19133);
                 CompoundTag version = new CompoundTag();
                 {
-                    version.putInt("Id", Chunk.DEFAULT_DATA_VERSION);
-                    version.putString("Name", "1.16.1");
+                    version.putInt("Id", mcVersion.id());
+                    version.putString("Name", mcVersion.toSimpleString());
                     version.putString("Series", "main");
                     version.putBoolean("Snapshot", false);
                 }
@@ -405,13 +405,11 @@ public class MinecraftVoxelWorld extends VoxelWorld {
                             {
                                 CompoundTag biomeSource = new CompoundTag();
                                 {
-                                    biomeSource.putBoolean("large_biomes", false);
-                                    biomeSource.putLong("seed", seed);
-                                    biomeSource.putString("type", "minecraft:vanilla_layered");
+                                    biomeSource.putString("preset", "minecraft:overworld");
+                                    biomeSource.putString("type", "minecraft:multi_noise");
                                 }
                                 generator.put("biome_source", biomeSource);
 
-                                generator.putLong("seed", seed);
                                 generator.putString("settings", "minecraft:overworld");
                                 generator.putString("type", "minecraft:noise");
                             }
@@ -427,12 +425,10 @@ public class MinecraftVoxelWorld extends VoxelWorld {
                             {
                                 CompoundTag biomeSource = new CompoundTag();
                                 {
-                                    biomeSource.putLong("seed", seed);
                                     biomeSource.putString("type", "minecraft:the_end");
                                 }
                                 generator.put("biome_source", biomeSource);
 
-                                generator.putLong("seed", seed);
                                 generator.putString("settings", "minecraft:end");
                                 generator.putString("type", "minecraft:noise");
                             }
@@ -449,12 +445,10 @@ public class MinecraftVoxelWorld extends VoxelWorld {
                                 CompoundTag biomeSource = new CompoundTag();
                                 {
                                     biomeSource.putString("preset", "minecraft:nether");
-                                    biomeSource.putLong("seed", seed);
                                     biomeSource.putString("type", "minecraft:multi_noise");
                                 }
                                 generator.put("biome_source", biomeSource);
 
-                                generator.putLong("seed", seed);
                                 generator.putString("settings", "minecraft:nether");
                                 generator.putString("type", "minecraft:noise");
                             }

--- a/src/main/java/com/ignfab/minalac/generator/modules/minecraft/Region.java
+++ b/src/main/java/com/ignfab/minalac/generator/modules/minecraft/Region.java
@@ -3,10 +3,11 @@ package com.ignfab.minalac.generator.modules.minecraft;
 import java.io.File;
 import java.io.IOException;
 
-import net.querz.mca.Chunk;
-import net.querz.mca.MCAFile;
-import net.querz.mca.MCAUtil;
-import net.querz.nbt.tag.CompoundTag;
+import io.github.ensgijs.nbt.mca.McaRegionFile;
+import io.github.ensgijs.nbt.mca.TerrainChunk;
+import io.github.ensgijs.nbt.mca.io.McaFileHelpers;
+import io.github.ensgijs.nbt.tag.CompoundTag;
+import io.github.ensgijs.nbt.tag.ListTag;
 
 /**
  * Represents a Minecraft region.
@@ -14,11 +15,11 @@ import net.querz.nbt.tag.CompoundTag;
  *
  * @param regionX the x-coordinate of this region
  * @param regionZ the y-coordinate of this region
- * @param file the {@link MCAFile} representing the file used by Minecraft
+ * @param file the {@link McaRegionFile} representing the file used by Minecraft
  * @see <a href="https://minecraft.wiki/w/Region_file_format">Region (Minecraft Wiki)</a>
  * @see <a href="https://minecraft.wiki/w/Chunk">Chunk (Minecraft Wiki)</a>
  */
-public record Region(int regionX, int regionZ, MCAFile file) {
+public record Region(int regionX, int regionZ, McaRegionFile file) {
 
     /**
      * Region size, used for tiling.
@@ -30,9 +31,10 @@ public record Region(int regionX, int regionZ, MCAFile file) {
      *
      * @param regionX the x-coordinate of this region
      * @param regionZ the y-coordinate of this region
+     * @see McaFileHelpers#blockToRegion(int)
      */
     public Region(int regionX, int regionZ) {
-        this(regionX, regionZ, new MCAFile(regionX, regionZ));
+        this(regionX, regionZ, new McaRegionFile(regionX, regionZ));
     }
 
     /**
@@ -46,17 +48,24 @@ public record Region(int regionX, int regionZ, MCAFile file) {
     }
 
     /**
-     * Returns the {@link Chunk} at the specified coordinates or creates it if it doesn't exist.
+     * Returns the {@link TerrainChunk} at the specified coordinates or creates it if it doesn't exist.
      *
      * @param chunkX the x-coordinate of the chunk
      * @param chunkZ the z-coordinate of the chunk
      * @return the corresponding chunk
+     * @throws IndexOutOfBoundsException if chunk coordinates are out of bounds
+     * @see McaFileHelpers#blockToChunk(int)
      */
-    public Chunk getOrCreateChunk(int chunkX, int chunkZ) {
-        Chunk chunk = file.getChunk(chunkX, chunkZ);
+    public TerrainChunk getOrCreateChunk(int chunkX, int chunkZ) {
+        TerrainChunk chunk = file.getChunk(chunkX, chunkZ);
         if (chunk == null) {
-            chunk = Chunk.newChunk();
-            file.setChunk(chunkX, chunkZ, chunk);
+            synchronized (file) {
+                chunk = file.getChunk(chunkX, chunkZ);
+                if (chunk == null) {
+                    chunk = file.createChunk();
+                    file.setChunk(chunkX, chunkZ, chunk);
+                }
+            }
         }
         return chunk;
     }
@@ -65,7 +74,7 @@ public record Region(int regionX, int regionZ, MCAFile file) {
      * {@return the filename of this region}
      */
     public String getFileName() {
-        return MCAUtil.createNameFromRegionLocation(regionX, regionZ);
+        return McaFileHelpers.createNameFromRegionLocation(regionX, regionZ);
     }
 
     /**
@@ -75,39 +84,63 @@ public record Region(int regionX, int regionZ, MCAFile file) {
      * @throws IOException if something goes wrong while saving
      */
     public void save(File regionDirectory) throws IOException {
-        file.cleanupPalettesAndBlockStates();
-        for (int i = 0; i < 1024; i++) {
-            Chunk chunk = file.getChunk(i);
+        for (TerrainChunk chunk : file)
             if (chunk != null)
                 chunk.setStatus("minecraft:full");
-        }
-        MCAUtil.write(file, new File(regionDirectory, getFileName()), true);
+        McaFileHelpers.write(file, new File(regionDirectory, getFileName()), true);
     }
 
     /**
-     * Loads a {@code Region} from a file region.
+     * Loads a {@code Region} from a region file.
      *
      * @param regionsDirectory the directory where the region file is located
      * @param regionX the x-value of the location of the region
      * @param regionZ the z-value of the location of the region
-     * @return a new {@link Region} corresponding to the file region
-     * @throws IOException if something goes wrong while deserializing the file region
+     * @return a new {@link Region} corresponding to the region file
+     * @throws IOException if something goes wrong while deserializing the region file
      */
     public static Region load(String regionsDirectory, int regionX, int regionZ) throws IOException {
-        return new Region(regionX, regionZ, MCAUtil.read(new File(regionsDirectory, MCAUtil.createNameFromRegionLocation(regionX, regionZ))));
+        return new Region(regionX, regionZ, McaFileHelpers.readAuto(new File(regionsDirectory, McaFileHelpers.createNameFromRegionLocation(regionX, regionZ))));
     }
 
     /**
-     * Returns a block as a new {@link MinecraftVoxel}.
+     * Returns the block state at the given coordinates.
      *
      * @param blockX the in-game x-coordinate
      * @param blockY the in-game y-coordinate
      * @param blockZ the in-game z-coordinate
-     * @return the corresponding voxel, or {@code null} if it doesn't exist
+     * @return the corresponding block state, or {@code null} if it doesn't exist
      */
-    public MinecraftVoxel getBlock(int blockX, int blockY, int blockZ) {
-        CompoundTag block = file().getBlockStateAt(blockX, blockY, blockZ);
-        return (block == null) ? MinecraftVoxel.DEFAULT_VOXEL : MinecraftVoxel.fromBlockState(block);
+    public CompoundTag getBlockState(int blockX, int blockY, int blockZ) {
+        TerrainChunk chunk = file.getChunk(McaFileHelpers.blockToChunk(blockX), McaFileHelpers.blockToChunk(blockZ));
+        return chunk == null ? null : chunk.getBlockAtByRef(
+            McaFileHelpers.blockAbsoluteToChunkRelative(blockX),
+            blockY,
+            McaFileHelpers.blockAbsoluteToChunkRelative(blockZ)
+        );
+    }
+
+    /**
+     * Returns the block entity at the given coordinates.
+     *
+     * @param blockX the in-game x-coordinate
+     * @param blockY the in-game y-coordinate
+     * @param blockZ the in-game z-coordinate
+     * @return the corresponding block entity, or {@code null} if it doesn't exist
+     */
+    public CompoundTag getBlockEntity(int blockX, int blockY, int blockZ) {
+        TerrainChunk chunk = file.getChunk(McaFileHelpers.blockToChunk(blockX), McaFileHelpers.blockToChunk(blockZ));
+        if (chunk == null)
+            return null;
+        ListTag<CompoundTag> blockEntities = chunk.getTileEntities();
+        if (blockEntities == null)
+            return null;
+        synchronized (blockEntities) {
+            for (CompoundTag blockEntity : blockEntities)
+                if (MinecraftHelpers.xyzEquals(blockEntity, blockX, blockY, blockZ))
+                    return blockEntity;
+        }
+        return null;
     }
 
     /**
@@ -115,9 +148,10 @@ public record Region(int regionX, int regionZ, MCAFile file) {
      * @param blockX the x-coordinate of the block
      * @param blockZ the z-coordinate of the block
      * @return the region key
+     * @see #computeKey(int, int)
      */
     public static int computeKeyFromBlock(int blockX, int blockZ) {
-        return computeKey(MCAUtil.blockToRegion(blockX), MCAUtil.blockToRegion(blockZ));
+        return computeKey(McaFileHelpers.blockToRegion(blockX), McaFileHelpers.blockToRegion(blockZ));
     }
 
     /**
@@ -125,6 +159,8 @@ public record Region(int regionX, int regionZ, MCAFile file) {
      * @param regionX the x-coordinate of the region
      * @param regionZ the z-coordinate of the region
      * @return the region key
+     * @see #keyToRegionX(int)
+     * @see #keyToRegionZ(int)
      */
     public static int computeKey(int regionX, int regionZ) {
         return (regionX << 16) | (regionZ & 0xFFFF);
@@ -134,6 +170,7 @@ public record Region(int regionX, int regionZ, MCAFile file) {
      * Extracts the x-coordinate of the region from its key.
      * @param regionKey the region key
      * @return the x-coordinate of the region
+     * @see #computeKey(int, int)
      */
     public static int keyToRegionX(int regionKey) {
         return (short) ((regionKey >> 16) & 0xFFFF); // cast to short to properly restore sign
@@ -143,6 +180,7 @@ public record Region(int regionX, int regionZ, MCAFile file) {
      * Extracts the z-coordinate of the region from its key.
      * @param regionKey the region key
      * @return the z-coordinate of the region
+     * @see #computeKey(int, int)
      */
     public static int keyToRegionZ(int regionKey) {
         return (short) (regionKey & 0xFFFF); // cast to short to properly restore sign

--- a/src/test/java/com/ignfab/minalac/generator/generation/TestingGenerationTile.java
+++ b/src/test/java/com/ignfab/minalac/generator/generation/TestingGenerationTile.java
@@ -3,10 +3,10 @@ package com.ignfab.minalac.generator.generation;
 import com.ignfab.minalac.generator.generation.heightmaps.HeightmapDeclarationStore;
 import com.ignfab.minalac.generator.generation.heightmaps.HeightmapStore;
 import com.ignfab.minalac.generator.generation.heightmaps.TestingHeightmap;
-import com.ignfab.minalac.generator.outputs.testing.TestingVoxelTile;
-import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
 import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+import com.ignfab.minalac.generator.world.TestingVoxelTile;
+import com.ignfab.minalac.generator.world.TestingVoxelWorld;
 
 /**
  * A fake GenerationTile over a {@link TestingVoxelWorld}.

--- a/src/test/java/com/ignfab/minalac/generator/generation/heightmaps/computed/operators/CappedManhattanHeightmapOperatorTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/generation/heightmaps/computed/operators/CappedManhattanHeightmapOperatorTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import com.ignfab.minalac.generator.generation.heightmaps.Heightmap;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class CappedManhattanHeightmapOperatorTest {
     @Test

--- a/src/test/java/com/ignfab/minalac/generator/generation/heightmaps/computed/operators/SimpleBinaryOperatorHeightmapTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/generation/heightmaps/computed/operators/SimpleBinaryOperatorHeightmapTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 import com.ignfab.minalac.generator.generation.heightmaps.Heightmap;
 import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class SimpleBinaryOperatorHeightmapTest {
     @Test

--- a/src/test/java/com/ignfab/minalac/generator/generation/heightmaps/computed/operators/UnaryOperatorHeightmapTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/generation/heightmaps/computed/operators/UnaryOperatorHeightmapTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test;
 import com.ignfab.minalac.generator.generation.heightmaps.Heightmap;
 import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class UnaryOperatorHeightmapTest {
     @Test

--- a/src/test/java/com/ignfab/minalac/generator/models/filters/ModelFilterOnMetadataValueTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/models/filters/ModelFilterOnMetadataValueTest.java
@@ -2,7 +2,7 @@ package com.ignfab.minalac.generator.models.filters;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ModelFilterOnMetadataValueTest {
     @Test

--- a/src/test/java/com/ignfab/minalac/generator/modules/luanti/LuantiVoxelTileTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/modules/luanti/LuantiVoxelTileTest.java
@@ -5,8 +5,7 @@ import org.junit.jupiter.api.Test;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class LuantiVoxelTileTest {
     private static final LuantiVoxel GRASS = new LuantiVoxel("default:dirt_with_grass", (byte) 0, (byte) 0);

--- a/src/test/java/com/ignfab/minalac/generator/modules/minecraft/MinecraftBlockEntityVoxelParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/modules/minecraft/MinecraftBlockEntityVoxelParamsTest.java
@@ -1,0 +1,42 @@
+package com.ignfab.minalac.generator.modules.minecraft;
+
+import io.github.ensgijs.nbt.tag.CompoundTag;
+import org.junit.jupiter.api.Test;
+
+import com.ignfab.minalac.generator.utils.random.TestingSeed;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MinecraftBlockEntityVoxelParamsTest {
+    @Test
+    public void testConstructor() {
+        assertDoesNotThrow(() -> new MinecraftBlockEntityVoxelParams("minecraft:beacon", "true"));
+        assertDoesNotThrow(() -> new MinecraftBlockEntityVoxelParams("minecraft:beacon", "minecraft:beacon"));
+    }
+
+    @Test
+    public void testValidate() {
+        MinecraftBlockEntityVoxelParams validParams = new MinecraftBlockEntityVoxelParams("minecraft:daylight_detector", "true");
+        assertDoesNotThrow(validParams::validate);
+
+        MinecraftBlockEntityVoxelParams invalidParams1 = new MinecraftBlockEntityVoxelParams("", "id");
+        assertThrows(IllegalArgumentException.class, invalidParams1::validate);
+
+        MinecraftBlockEntityVoxelParams invalidParams2 = new MinecraftBlockEntityVoxelParams("type", "");
+        assertThrows(IllegalArgumentException.class, invalidParams2::validate);
+    }
+
+    @Test
+    public void testCreate() {
+        MinecraftBlockEntityVoxelParams beaconParams = new MinecraftBlockEntityVoxelParams("minecraft:beacon", "true");
+        MinecraftBlockEntityVoxel beaconVoxel = assertDoesNotThrow(() -> beaconParams.create(TestingSeed.UNUSED));
+        assertEquals(new MinecraftBlockEntityVoxel("minecraft:beacon", "minecraft:beacon", null, null), beaconVoxel);
+
+        MinecraftBlockEntityVoxelParams comparatorParams = new MinecraftBlockEntityVoxelParams("minecraft:comparator", "true");
+        comparatorParams.dataTags = "{ OutputSignal: 7 }";
+        MinecraftBlockEntityVoxel comparatorVoxel = assertDoesNotThrow(() -> comparatorParams.create(TestingSeed.UNUSED));
+        CompoundTag data = new CompoundTag();
+        data.putInt("OutputSignal", 7);
+        assertEquals(new MinecraftBlockEntityVoxel("minecraft:comparator", "minecraft:comparator", null, data), comparatorVoxel);
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/modules/minecraft/MinecraftBlockEntityVoxelTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/modules/minecraft/MinecraftBlockEntityVoxelTest.java
@@ -1,0 +1,180 @@
+package com.ignfab.minalac.generator.modules.minecraft;
+
+import java.util.Map;
+
+import io.github.ensgijs.nbt.tag.CompoundTag;
+import org.junit.jupiter.api.Test;
+
+import com.ignfab.minalac.generator.outputs.testing.TestingVoxelTile;
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MinecraftBlockEntityVoxelTest {
+    @Test
+    public void testConstructor() {
+        MinecraftBlockEntityVoxel block = new MinecraftBlockEntityVoxel("type", "id", null, null);
+        assertEquals("minecraft:type", block.type());
+        assertEquals("minecraft:id", block.id());
+        assertNotNull(block.properties());
+        assertNotNull(block.data());
+
+        CompoundTag data = new CompoundTag();
+        data.putLong("OutputSignal", 7);
+        MinecraftBlockEntityVoxel comparator = new MinecraftBlockEntityVoxel("comparator", "comparator", null, data);
+        assertEquals(data, comparator.data());
+        assertNotSame(data, comparator.data());
+
+        MinecraftBlockEntityVoxel daylightDetector = new MinecraftBlockEntityVoxel(new MinecraftVoxel("minecraft:daylight_detector", Map.of("inverted", "true")), "minecraft:daylight_detector", null);
+        assertEquals("minecraft:daylight_detector", daylightDetector.type());
+        assertEquals(Map.of("inverted", "true"), daylightDetector.properties());
+    }
+
+    @Test
+    public void testStripBlockEntity() {
+        MinecraftBlockEntityVoxel beacon = new MinecraftBlockEntityVoxel("minecraft:beacon", "minecraft:beacon", null, null);
+        assertEquals(new MinecraftVoxel("minecraft:beacon"), beacon.stripBlockEntity());
+
+        CompoundTag data = new CompoundTag();
+        data.putLong("OutputSignal", 7);
+        MinecraftBlockEntityVoxel comparator = new MinecraftBlockEntityVoxel("comparator", "comparator", Map.of("powered", "true"), data);
+        assertEquals(new MinecraftVoxel("minecraft:comparator", Map.of("powered", "true")), comparator.stripBlockEntity());
+    }
+
+    @Test
+    public void testToString() {
+        assertEquals("minecraft:beacon", new MinecraftBlockEntityVoxel("minecraft:beacon", "minecraft:beacon", null, null).toString());
+
+        CompoundTag data = new CompoundTag();
+        CompoundTag item = new CompoundTag();
+        item.putString("id", "minecraft:music_disc_cat");
+        data.put("RecordItem", item);
+        data.putLong("ticks_since_song_started", 0);
+        assertEquals(
+            "minecraft:jukebox[has_record=true]{RecordItem:{id:\"minecraft:music_disc_cat\"},ticks_since_song_started:0l}",
+            new MinecraftBlockEntityVoxel("minecraft:jukebox", "minecraft:jukebox", Map.of("has_record", "true"), data).toString()
+        );
+    }
+
+    @Test
+    public void testFromString() {
+        MinecraftBlockEntityVoxel beacon = new MinecraftBlockEntityVoxel("minecraft:beacon", "minecraft:beacon", null, null);
+        assertEquals(beacon, MinecraftBlockEntityVoxel.fromString("minecraft:beacon", "minecraft:beacon"));
+        assertEquals(beacon, MinecraftBlockEntityVoxel.fromString("minecraft:beacon"));
+        assertEquals(beacon, MinecraftBlockEntityVoxel.fromString("minecraft:beacon{}"));
+        assertEquals(beacon, MinecraftBlockEntityVoxel.fromString("minecraft:beacon[]"));
+        assertEquals(beacon, MinecraftBlockEntityVoxel.fromString("minecraft:beacon[]{}"));
+
+        CompoundTag data = new CompoundTag();
+        CompoundTag item = new CompoundTag();
+        item.putString("id", "minecraft:music_disc_cat");
+        data.put("RecordItem", item);
+        data.putLong("ticks_since_song_started", 0);
+        assertEquals(
+            new MinecraftBlockEntityVoxel("minecraft:jukebox", "minecraft:jukebox", Map.of("has_record", "true"), data),
+            MinecraftBlockEntityVoxel.fromString("minecraft:jukebox[has_record=true]{RecordItem:{id:\"minecraft:music_disc_cat\"},ticks_since_song_started:0l}")
+        );
+
+        assertThrows(IllegalArgumentException.class, () -> MinecraftBlockEntityVoxel.fromString("minecraft:unclosed_bracket{"));
+        assertThrows(IllegalArgumentException.class, () -> MinecraftBlockEntityVoxel.fromString("minecraft:extra{}data"));
+        assertThrows(IllegalArgumentException.class, () -> MinecraftBlockEntityVoxel.fromString("minecraft:invalid{nbt}"));
+    }
+
+    @Test
+    public void testFromBlockEntity() {
+        CompoundTag beaconEntity = new CompoundTag();
+        beaconEntity.putString("id", "minecraft:beacon");
+        beaconEntity.putBoolean("keepPacked", false);
+        beaconEntity.putInt("x", 1);
+        beaconEntity.putInt("y", 2);
+        beaconEntity.putInt("z", 3);
+        assertEquals(
+            new MinecraftBlockEntityVoxel("minecraft:beacon", "minecraft:beacon", null, null),
+            MinecraftBlockEntityVoxel.fromBlockEntity(beaconEntity, new MinecraftVoxel("minecraft:beacon"))
+        );
+
+        CompoundTag jukeboxEntity = new CompoundTag();
+        jukeboxEntity.putString("id", "minecraft:jukebox");
+        jukeboxEntity.putBoolean("keepPacked", false);
+        jukeboxEntity.putInt("x", 1);
+        jukeboxEntity.putInt("y", 2);
+        jukeboxEntity.putInt("z", 3);
+        CompoundTag item = new CompoundTag();
+        item.putString("id", "minecraft:music_disc_cat");
+        jukeboxEntity.put("RecordItem", item);
+        jukeboxEntity.putLong("ticks_since_song_started", 0);
+
+        CompoundTag data = new CompoundTag();
+        data.put("RecordItem", item);
+        data.putLong("ticks_since_song_started", 0);
+        assertEquals(
+            new MinecraftBlockEntityVoxel("minecraft:jukebox", "minecraft:jukebox", Map.of("has_record", "true"), data),
+            MinecraftBlockEntityVoxel.fromBlockEntity(jukeboxEntity, new MinecraftVoxel("minecraft:jukebox", Map.of("has_record", "true")))
+        );
+    }
+
+    @Test
+    public void testPlaceSimple() {
+        MinecraftVoxelTileMock tile = new MinecraftVoxelTileMock(new WorldBBox3d(
+            new WorldCoords3d(-50, -10, 0),
+            new WorldCoords3d(10, 0, 200)
+        ));
+
+        MinecraftBlockEntityVoxel beacon = new MinecraftBlockEntityVoxel("minecraft:beacon", "minecraft:beacon", null, null);
+        beacon.place(tile, 3, -7, 64);
+
+        CompoundTag expectedBeaconState = new CompoundTag();
+        expectedBeaconState.putString("Name", "minecraft:beacon");
+        tile.assertBlockStateAt(3, 64, 6, expectedBeaconState); // X/Y/Z => X/Z/-Y
+
+        CompoundTag expectedBeaconEntity = new CompoundTag();
+        expectedBeaconEntity.putString("id", "minecraft:beacon");
+        expectedBeaconEntity.putBoolean("keepPacked", false);
+        // X/Y/Z => X/Z/-Y
+        expectedBeaconEntity.putInt("x", 3);
+        expectedBeaconEntity.putInt("y", 64);
+        expectedBeaconEntity.putInt("z", 6);
+        tile.assertBlockEntityAt(3, 64, 6, expectedBeaconEntity); // X/Y/Z => X/Z/-Y
+    }
+
+    @Test
+    public void testPlaceWithData() {
+        MinecraftVoxelTileMock tile = new MinecraftVoxelTileMock(new WorldBBox3d(
+            new WorldCoords3d(-50, -10, 0),
+            new WorldCoords3d(10, 0, 200)
+        ));
+
+        CompoundTag data = new CompoundTag();
+        CompoundTag item = new CompoundTag();
+        item.putString("id", "minecraft:music_disc_cat");
+        data.put("RecordItem", item);
+        data.putLong("ticks_since_song_started", 0);
+        MinecraftBlockEntityVoxel jukebox = new MinecraftBlockEntityVoxel("minecraft:jukebox", "minecraft:jukebox", Map.of("has_record", "true"), data);
+        jukebox.place(tile, -43, 0, 192);
+
+        CompoundTag expectedJukeboxState = new CompoundTag();
+        expectedJukeboxState.putString("Name", "minecraft:jukebox");
+        CompoundTag properties = new CompoundTag();
+        properties.putString("has_record", "true");
+        expectedJukeboxState.put("Properties", properties);
+        tile.assertBlockStateAt(-43, 192, -1, expectedJukeboxState); // X/Y/Z => X/Z/-Y
+
+        CompoundTag expectedJukeboxEntity = new CompoundTag();
+        expectedJukeboxEntity.putString("id", "minecraft:jukebox");
+        expectedJukeboxEntity.putBoolean("keepPacked", false);
+        expectedJukeboxEntity.put("RecordItem", item);
+        expectedJukeboxEntity.putLong("ticks_since_song_started", 0);
+        // X/Y/Z => X/Z/-Y
+        expectedJukeboxEntity.putInt("x", -43);
+        expectedJukeboxEntity.putInt("y", 192);
+        expectedJukeboxEntity.putInt("z", -1);
+        tile.assertBlockEntityAt(-43, 192, -1, expectedJukeboxEntity); // X/Y/Z => X/Z/-Y
+    }
+
+    @Test
+    public void testPlaceIllegal() {
+        MinecraftBlockEntityVoxel beacon = new MinecraftBlockEntityVoxel("minecraft:beacon", "minecraft:beacon", null, null);
+        assertThrows(IllegalArgumentException.class, () -> beacon.place(new TestingVoxelTile(WorldBBox3d.EMPTY), 0, 0, 0));
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/modules/minecraft/MinecraftBlockEntityVoxelTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/modules/minecraft/MinecraftBlockEntityVoxelTest.java
@@ -5,9 +5,9 @@ import java.util.Map;
 import io.github.ensgijs.nbt.tag.CompoundTag;
 import org.junit.jupiter.api.Test;
 
-import com.ignfab.minalac.generator.outputs.testing.TestingVoxelTile;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
+import com.ignfab.minalac.generator.world.TestingVoxelTile;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/ignfab/minalac/generator/modules/minecraft/MinecraftHelpersTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/modules/minecraft/MinecraftHelpersTest.java
@@ -1,0 +1,29 @@
+package com.ignfab.minalac.generator.modules.minecraft;
+
+import io.github.ensgijs.nbt.tag.CompoundTag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MinecraftHelpersTest {
+    @Test
+    public void testEnsureNamespaced() {
+        assertEquals("minecraft:stone", MinecraftHelpers.ensureNamespaced("minecraft:stone"));
+        assertEquals("minecraft:stone", MinecraftHelpers.ensureNamespaced("stone"));
+        assertEquals("aether:holystone", MinecraftHelpers.ensureNamespaced("aether:holystone"));
+    }
+
+    @Test
+    public void testXyzEquals() {
+        assertTrue(MinecraftHelpers.xyzEquals(new CompoundTag(), 0, 0, 0));
+
+        CompoundTag xyz = new CompoundTag();
+        xyz.putInt("x", 1);
+        xyz.putInt("y", 2);
+        xyz.putInt("z", 3);
+        assertTrue(MinecraftHelpers.xyzEquals(xyz, 1, 2, 3));
+        assertFalse(MinecraftHelpers.xyzEquals(xyz, 0, 2, 3));
+        assertFalse(MinecraftHelpers.xyzEquals(xyz, 1, 0, 3));
+        assertFalse(MinecraftHelpers.xyzEquals(xyz, 1, 2, 0));
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/modules/minecraft/MinecraftVoxelParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/modules/minecraft/MinecraftVoxelParamsTest.java
@@ -1,5 +1,8 @@
 package com.ignfab.minalac.generator.modules.minecraft;
 
+import java.util.Map;
+
+import io.github.ensgijs.nbt.tag.CompoundTag;
 import org.junit.jupiter.api.Test;
 
 import com.ignfab.minalac.generator.utils.random.TestingSeed;
@@ -7,25 +10,43 @@ import com.ignfab.minalac.generator.utils.random.TestingSeed;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class MinecraftVoxelParamsTest {
-
     @Test
     public void testConstructor() {
-        assertDoesNotThrow(() -> new MinecraftVoxelParams("toto"));
+        assertDoesNotThrow(() -> new MinecraftVoxelParams("minecraft:dirt"));
     }
 
     @Test
     public void testValidate() {
-        MinecraftVoxelParams params;
-        params = new MinecraftVoxelParams("titi");
-        assertDoesNotThrow(params::validate);
+        MinecraftVoxelParams validParams = new MinecraftVoxelParams("minecraft:stone");
+        assertDoesNotThrow(validParams::validate);
 
-        params = new MinecraftVoxelParams("");
-        assertThrows(IllegalArgumentException.class, params::validate);
+        MinecraftVoxelParams invalidParams = new MinecraftVoxelParams("");
+        assertThrows(IllegalArgumentException.class, invalidParams::validate);
     }
 
     @Test
     public void testCreate() {
-        MinecraftVoxelParams params = new MinecraftVoxelParams("tata");
-        assertDoesNotThrow(() -> params.create(TestingSeed.UNUSED));
+        MinecraftVoxelParams airParams = new MinecraftVoxelParams("minecraft:air");
+        MinecraftVoxel airVoxel = assertDoesNotThrow(() -> airParams.create(TestingSeed.UNUSED));
+        assertEquals(new MinecraftVoxel("minecraft:air"), airVoxel);
+
+        MinecraftVoxelParams oakLeavesParams = new MinecraftVoxelParams("minecraft:oak_leaves");
+        oakLeavesParams.properties = Map.of("persistent", "true");
+        MinecraftVoxel oakLeavesVoxel = assertDoesNotThrow(() -> oakLeavesParams.create(TestingSeed.UNUSED));
+        assertEquals(new MinecraftVoxel("minecraft:oak_leaves", Map.of("persistent", "true")), oakLeavesVoxel);
+    }
+
+    @Test
+    public void testPacked() {
+        MinecraftVoxelParams oakLeavesParams = MinecraftVoxelParams.packed("minecraft:oak_leaves[persistent=true]");
+        oakLeavesParams.properties = Map.of("persistent", "true");
+        MinecraftVoxel oakLeavesVoxel = assertDoesNotThrow(() -> oakLeavesParams.create(TestingSeed.UNUSED));
+        assertEquals(new MinecraftVoxel("minecraft:oak_leaves", Map.of("persistent", "true")), oakLeavesVoxel);
+
+        MinecraftVoxelParams comparatorParams = MinecraftVoxelParams.packed("minecraft:comparator{OutputSignal: 7}");
+        MinecraftVoxel comparatorVoxel = assertDoesNotThrow(() -> comparatorParams.create(TestingSeed.UNUSED));
+        CompoundTag data = new CompoundTag();
+        data.putInt("OutputSignal", 7);
+        assertEquals(new MinecraftBlockEntityVoxel("minecraft:comparator", "minecraft:comparator", null, data), comparatorVoxel);
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/modules/minecraft/MinecraftVoxelTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/modules/minecraft/MinecraftVoxelTest.java
@@ -6,9 +6,9 @@ import java.util.Map;
 import io.github.ensgijs.nbt.tag.CompoundTag;
 import org.junit.jupiter.api.Test;
 
-import com.ignfab.minalac.generator.outputs.testing.TestingVoxelTile;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
+import com.ignfab.minalac.generator.world.TestingVoxelTile;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/ignfab/minalac/generator/modules/minecraft/MinecraftVoxelTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/modules/minecraft/MinecraftVoxelTest.java
@@ -3,34 +3,90 @@ package com.ignfab.minalac.generator.modules.minecraft;
 import java.util.HashMap;
 import java.util.Map;
 
-import net.querz.nbt.tag.CompoundTag;
-import org.junit.jupiter.api.BeforeEach;
+import io.github.ensgijs.nbt.tag.CompoundTag;
 import org.junit.jupiter.api.Test;
 
+import com.ignfab.minalac.generator.outputs.testing.TestingVoxelTile;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
-import com.ignfab.minalac.generator.world.MapWriteException;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 public class MinecraftVoxelTest {
-    private TileMock tileMock;
+    @Test
+    public void testConstructor() {
+        MinecraftVoxel air = new MinecraftVoxel("air");
+        assertEquals("minecraft:air", air.type());
+        assertNotNull(air.properties());
 
-    @BeforeEach
-    public void setUp() throws MapWriteException {
-        WorldBBox3d limits = new WorldBBox3d(new WorldCoords3d(-50, -10, 0), new WorldCoords3d(10, 0, 200));
-        MinecraftVoxelWorld world = new MinecraftVoxelWorld(null);
-        world.setLimits(limits);
-        tileMock = new TileMock(world, limits);
+        Map<String, String> properties = new HashMap<>();
+        properties.put("persistent", "true");
+        MinecraftVoxel oakLeaves = new MinecraftVoxel("oak_leaves", properties);
+        assertEquals(properties, oakLeaves.properties());
+        assertNotSame(properties, oakLeaves.properties());
     }
 
     @Test
-    public void testPlace() {
+    public void testToString() {
+        assertEquals("minecraft:air", new MinecraftVoxel("minecraft:air").toString());
+        assertEquals("minecraft:blue_candle[candles=3,lit=true]", new MinecraftVoxel("minecraft:blue_candle", Map.of(
+            "candles", "3",
+            "lit", "true"
+        )).toString());
+    }
+
+    @Test
+    public void testFromString() {
+        assertEquals(new MinecraftVoxel("minecraft:air"), MinecraftVoxel.fromString("minecraft:air"));
+        assertEquals(new MinecraftVoxel("minecraft:air"), MinecraftVoxel.fromString("minecraft:air[]"));
+        assertEquals(new MinecraftVoxel("minecraft:blue_candle", Map.of(
+            "candles", "3",
+            "lit", "true"
+        )), MinecraftVoxel.fromString("minecraft:blue_candle[candles=3,lit=true]"));
+
+        assertThrows(IllegalArgumentException.class, () -> MinecraftVoxel.fromString("minecraft:unclosed_bracket["));
+        assertThrows(IllegalArgumentException.class, () -> MinecraftVoxel.fromString("minecraft:extra[]data"));
+        assertThrows(IllegalArgumentException.class, () -> MinecraftVoxel.fromString("minecraft:invalid[property]"));
+    }
+
+    @Test
+    public void testFromBlockState() {
+        CompoundTag airState = new CompoundTag();
+        airState.putString("Name", "minecraft:air");
+        assertEquals(new MinecraftVoxel("minecraft:air"), MinecraftVoxel.fromBlockState(airState));
+        CompoundTag candleState = new CompoundTag();
+        candleState.putString("Name", "minecraft:blue_candle");
+        CompoundTag properties = new CompoundTag();
+        properties.putString("candles", "3");
+        properties.putString("lit", "true");
+        candleState.put("Properties", properties);
+        assertEquals(new MinecraftVoxel("minecraft:blue_candle", Map.of(
+            "candles", "3",
+            "lit", "true"
+        )), MinecraftVoxel.fromBlockState(candleState));
+    }
+
+    @Test
+    public void testPlaceSimple() {
+        MinecraftVoxelTileMock tile = new MinecraftVoxelTileMock(new WorldBBox3d(
+            new WorldCoords3d(-50, -10, 0),
+            new WorldCoords3d(10, 0, 200)
+        ));
+
         MinecraftVoxel air = new MinecraftVoxel("minecraft:air");
-        air.place(tileMock, 3, -7, 64);
+        air.place(tile, 3, -7, 64);
+
         CompoundTag expectedAir = new CompoundTag();
         expectedAir.putString("Name", "minecraft:air");
-        tileMock.assertBlockStateAt(3, 64, 6, expectedAir); // X/Y/Z => X/Z/-Y
+        tile.assertBlockStateAt(3, 64, 6, expectedAir); // X/Y/Z => X/Z/-Y
+    }
+
+    @Test
+    public void testPlaceWithProperties() {
+        MinecraftVoxelTileMock tile = new MinecraftVoxelTileMock(new WorldBBox3d(
+            new WorldCoords3d(-50, -10, 0),
+            new WorldCoords3d(10, 0, 200)
+        ));
 
         MinecraftVoxel stairs = new MinecraftVoxel("minecraft:oak_stairs", Map.of(
             "facing", "north",
@@ -38,7 +94,8 @@ public class MinecraftVoxelTest {
             "shape", "straight",
             "waterlogged", "false"
         ));
-        stairs.place(tileMock, -43, 0, 192);
+        stairs.place(tile, -43, 0, 192);
+
         CompoundTag expectedStairs = new CompoundTag();
         expectedStairs.putString("Name", "minecraft:oak_stairs");
         CompoundTag properties = new CompoundTag();
@@ -47,29 +104,12 @@ public class MinecraftVoxelTest {
         properties.putString("shape", "straight");
         properties.putString("waterlogged", "false");
         expectedStairs.put("Properties", properties);
-        tileMock.assertBlockStateAt(-43, 192, -1, expectedStairs); // X/Y/Z => X/Z/-Y
+        tile.assertBlockStateAt(-43, 192, -1, expectedStairs); // X/Y/Z => X/Z/-Y
     }
 
-    private static final class TileMock extends MinecraftVoxelTile {
-        private final Map<String, CompoundTag> blockStates = new HashMap<>();
-
-        TileMock(MinecraftVoxelWorld world, WorldBBox3d limits) {
-            super(null, limits);
-        }
-
-        @Override
-        void setBlockState(int blockX, int blockY, int blockZ, CompoundTag block)  {
-            if (isOutOfLimits(blockX, blockY, blockZ)) return;
-            blockStates.put(key(blockX, blockY, blockZ), block);
-        }
-
-        public void assertBlockStateAt(int blockX, int blockY, int blockZ, CompoundTag block) {
-            CompoundTag state = blockStates.get(key(blockX, blockY, blockZ));
-            assertEquals(block, state, "Block state mismatch at (%d, %d, %d)".formatted(blockX, blockY, blockZ));
-        }
-
-        private String key(int x, int y, int z) {
-            return x + "," + y + "," + z;
-        }
+    @Test
+    public void testPlaceIllegal() {
+        MinecraftVoxel air = new MinecraftVoxel("minecraft:air");
+        assertThrows(IllegalArgumentException.class, () -> air.place(new TestingVoxelTile(WorldBBox3d.EMPTY), 0, 0, 0));
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/modules/minecraft/MinecraftVoxelTileMock.java
+++ b/src/test/java/com/ignfab/minalac/generator/modules/minecraft/MinecraftVoxelTileMock.java
@@ -1,0 +1,73 @@
+package com.ignfab.minalac.generator.modules.minecraft;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.github.ensgijs.nbt.tag.CompoundTag;
+
+import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Mock class for {@link MinecraftVoxelTile} to simplify block placement tests.
+ */
+final class MinecraftVoxelTileMock extends MinecraftVoxelTile {
+    private final Map<String, CompoundTag> blockStates = new HashMap<>();
+    private final Map<String, CompoundTag> blockEntities = new HashMap<>();
+
+    /**
+     * Creates a new mock tile.
+     * @param limits limits of the tile
+     */
+    MinecraftVoxelTileMock(WorldBBox3d limits) {
+        super(null, limits);
+    }
+
+    @Override
+    void setBlockState(int blockX, int blockY, int blockZ, CompoundTag block) {
+        if (isOutOfLimits(blockX, blockY, blockZ)) return;
+        String key = key(blockX, blockY, blockZ);
+        blockStates.put(key, block);
+        blockEntities.remove(key);
+    }
+
+    @Override
+    void addBlockEntity(int blockX, int blockY, int blockZ, CompoundTag block) {
+        if (isOutOfLimits(blockX, blockY, blockZ)) return;
+        block.putInt("x", blockX);
+        block.putInt("y", blockY);
+        block.putInt("z", blockZ);
+        blockEntities.put(key(blockX, blockY, blockZ), block);
+    }
+
+    /**
+     * Asserts that the block state placed at given position matches the given one.
+     * The position is in game coordinates.
+     * @param blockX x-coordinate of the position
+     * @param blockY y-coordinate of the position
+     * @param blockZ z-coordinate of the position
+     * @param block block state to match
+     */
+    public void assertBlockStateAt(int blockX, int blockY, int blockZ, CompoundTag block) {
+        CompoundTag state = blockStates.get(key(blockX, blockY, blockZ));
+        assertEquals(block, state, "Block state mismatch at (%d, %d, %d)".formatted(blockX, blockY, blockZ));
+    }
+
+    /**
+     * Asserts that the block entity placed at given position matches the given one.
+     * The position is in game coordinates.
+     * @param blockX x-coordinate of the position
+     * @param blockY y-coordinate of the position
+     * @param blockZ z-coordinate of the position
+     * @param block block entity to match
+     */
+    public void assertBlockEntityAt(int blockX, int blockY, int blockZ, CompoundTag block) {
+        CompoundTag entity = blockEntities.get(key(blockX, blockY, blockZ));
+        assertEquals(block, entity, "Block entity mismatch at (%d, %d, %d)".formatted(blockX, blockY, blockZ));
+    }
+
+    private String key(int x, int y, int z) {
+        return x + "," + y + "," + z;
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/modules/minecraft/MinecraftVoxelTileTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/modules/minecraft/MinecraftVoxelTileTest.java
@@ -2,11 +2,11 @@ package com.ignfab.minalac.generator.modules.minecraft;
 
 import java.util.Map;
 
+import io.github.ensgijs.nbt.tag.CompoundTag;
 import org.junit.jupiter.api.Test;
 
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
-import com.ignfab.minalac.generator.world.MapWriteException;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -21,7 +21,7 @@ public class MinecraftVoxelTileTest {
     }
 
     @Test
-    public void testIsOutOfLimits() throws MapWriteException {
+    public void testIsOutOfLimits() {
         MinecraftVoxelTile tile = initTile(new WorldBBox3d(new WorldCoords3d(-10, -20, 0), new WorldCoords3d(20, 30, 40)));
 
         // X/Y/Z => X/Z/-Y
@@ -39,7 +39,7 @@ public class MinecraftVoxelTileTest {
     }
 
     @Test
-    public void testGetVoxel() throws MapWriteException {
+    public void testGetVoxel() {
         MinecraftVoxelTile tile = initTile(new WorldBBox3d(new WorldCoords3d(-20, -20, 0), new WorldCoords3d(50, 50, 255)));
         MinecraftVoxel barrel = new MinecraftVoxel("minecraft:barrel", Map.of(
             "facing", "south",
@@ -60,6 +60,24 @@ public class MinecraftVoxelTileTest {
         // Minecraft zMin
         barrel.place(tile, -9, -8, 0);
         assertEquals(barrel, tile.getVoxel(-9, -8, 0));
+    }
+
+    @Test
+    public void testGetBlockEntityVoxel() {
+        MinecraftVoxelTile tile = initTile(new WorldBBox3d(new WorldCoords3d(-20, -20, 0), new WorldCoords3d(50, 50, 255)));
+        CompoundTag data = new CompoundTag();
+        data.putInt("OutputSignal", 7);
+        MinecraftBlockEntityVoxel comparator = new MinecraftBlockEntityVoxel("minecraft:comparator", "minecraft:comparator", Map.of(
+            "facing", "south",
+            "mode", "compare",
+            "powered", "true"
+        ), null);
+        MinecraftBlockEntityVoxel daylightDetector = new MinecraftBlockEntityVoxel("minecraft:daylight_detector", "minecraft:daylight_detector", null, null);
+        comparator.place(tile, -9, -8, 1);
+        daylightDetector.place(tile, -7, 5, 55);
+
+        assertEquals(comparator, tile.getVoxel(-9, -8, 1));
+        assertEquals(daylightDetector, tile.getVoxel(-7, 5, 55));
     }
 
     @Test

--- a/src/test/java/com/ignfab/minalac/generator/modules/minecraft/MinecraftVoxelWorldTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/modules/minecraft/MinecraftVoxelWorldTest.java
@@ -1,21 +1,41 @@
 package com.ignfab.minalac.generator.modules.minecraft;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import net.querz.nbt.tag.CompoundTag;
+import io.github.ensgijs.nbt.tag.CompoundTag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
+import com.ignfab.minalac.generator.world.MapWriteException;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 public class MinecraftVoxelWorldTest {
     @TempDir
     private File dir;
+
+    @Test
+    public void testInitialize() throws IOException {
+        assertDoesNotThrow(new MinecraftVoxelWorld(dir)::initialize);
+        File[] files = dir.listFiles();
+        assertNotNull(files);
+        assertEquals(1, files.length);
+        File file = files[0];
+        assertTrue(file.isDirectory());
+        assertEquals("region", file.getName());
+
+        File unknownDir = new File(dir, "unknown");
+        assertThrows(MapWriteException.class, new MinecraftVoxelWorld(unknownDir)::initialize);
+
+        File existingFile = new File(dir, "file");
+        assertTrue(existingFile.createNewFile());
+        assertThrows(MapWriteException.class, new MinecraftVoxelWorld(existingFile)::initialize);
+    }
 
     @Test
     public void testSave() {
@@ -37,15 +57,15 @@ public class MinecraftVoxelWorldTest {
         tile.setBlockState(0, 64, 0, block); // Region (0, 0)
         tile.setBlockState(0, 64, -1, block); // Region (0, -1)
 
-        assertDoesNotThrow(() -> tile.save());
-        assertDoesNotThrow(() -> world.finalizeAndSave());
+        assertDoesNotThrow(tile::save);
+        assertDoesNotThrow(world::finalizeAndSave);
         File[] files = dir.listFiles();
         assertNotNull(files);
         assertEquals(2, files.length);
 
         for (File file : files) {
             switch (file.getName()) {
-                case "level.dat" -> assertTrue(file.exists());
+                case "level.dat" -> assertTrue(file.isFile());
                 case "region" -> {
                     assertTrue(file.isDirectory());
                     File[] regions = file.listFiles();

--- a/src/test/java/com/ignfab/minalac/generator/modules/minecraft/RegionTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/modules/minecraft/RegionTest.java
@@ -1,0 +1,73 @@
+package com.ignfab.minalac.generator.modules.minecraft;
+
+import java.io.File;
+import java.util.HashSet;
+import java.util.Set;
+
+import io.github.ensgijs.nbt.mca.TerrainChunk;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class RegionTest {
+    @Test
+    public void testGetOrCreateChunk() {
+        Region region = new Region(0, 0);
+        assertNull(region.file().getChunk(0, 0));
+
+        TerrainChunk chunk = region.getOrCreateChunk(0, 0);
+        assertNotNull(chunk);
+
+        assertSame(chunk, region.getOrCreateChunk(0, 0));
+        assertNotSame(chunk, region.getOrCreateChunk(0, 1));
+        assertNotSame(chunk, region.getOrCreateChunk(1, 0));
+    }
+
+    @Test
+    public void testSave(@TempDir File tempDir) {
+        Region region = new Region(0, 0);
+        region.getOrCreateChunk(0, 0);
+        assertDoesNotThrow(() -> region.save(tempDir));
+        File[] files = tempDir.listFiles();
+        assertNotNull(files);
+        assertEquals(1, files.length);
+        File file = files[0];
+        assertTrue(file.isFile());
+        assertEquals("r.0.0.mca", file.getName());
+        assertNotEquals(0, file.length());
+    }
+
+    @Test
+    public void testComputeKey() {
+        // Keys must be distinct from each other
+        Set<Integer> keys = new HashSet<>();
+        keys.add(Region.computeKey(-1, -1));
+        keys.add(Region.computeKey(-1, 0));
+        keys.add(Region.computeKey(-1, 1));
+        keys.add(Region.computeKey(0, -1));
+        keys.add(Region.computeKey(0, 0));
+        keys.add(Region.computeKey(0, 1));
+        keys.add(Region.computeKey(1, -1));
+        keys.add(Region.computeKey(1, 0));
+        keys.add(Region.computeKey(1, 1));
+        assertEquals(9, keys.size());
+
+        // And must be decodable
+        assertKey(-1, -1);
+        assertKey(-1, 0);
+        assertKey(-1, 1);
+        assertKey(0, -1);
+        assertKey(0, 0);
+        assertKey(0, 1);
+        assertKey(1, -1);
+        assertKey(1, 0);
+        assertKey(1, 1);
+    }
+
+    private static void assertKey(int x, int z) {
+        int key = Region.computeKey(x, z);
+        assertEquals(x, Region.keyToRegionX(key));
+        assertEquals(z, Region.keyToRegionZ(key));
+    }
+}

--- a/src/test/java/com/ignfab/minalac/generator/parameters/GenerationParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/GenerationParamsTest.java
@@ -7,13 +7,13 @@ import org.junit.jupiter.api.Test;
 
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.generation.heightmaps.HeightmapDeclaration;
-import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
 import com.ignfab.minalac.generator.parameters.placeables.voxels.TestingVoxelParams;
 import com.ignfab.minalac.generator.parameters.providers.TestingProviderParams;
 import com.ignfab.minalac.generator.parameters.tasks.FetchDataTaskParams;
 import com.ignfab.minalac.generator.parameters.tasks.NoOperationTaskParams;
 import com.ignfab.minalac.generator.parameters.tasks.RenderBuildingsTaskParams;
 import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
+import com.ignfab.minalac.generator.world.TestingVoxelWorld;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/ParamsParserTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/ParamsParserTest.java
@@ -4,9 +4,9 @@ import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 
-import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
 import com.ignfab.minalac.generator.parameters.placeables.voxels.TestingVoxelParams;
 import com.ignfab.minalac.generator.parameters.tasks.TestingTaskParams;
+import com.ignfab.minalac.generator.world.TestingVoxelWorld;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/heightmaps/CappedManhattanHeightmapParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/heightmaps/CappedManhattanHeightmapParamsTest.java
@@ -5,14 +5,11 @@ import tools.jackson.core.JacksonException;
 
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.generation.heightmaps.HeightmapDeclaration;
-import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
 import com.ignfab.minalac.generator.parameters.ParamsTester;
 import com.ignfab.minalac.generator.utils.random.TestingSeed;
+import com.ignfab.minalac.generator.world.TestingVoxelWorld;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class CappedManhattanHeightmapParamsTest {
     @Test

--- a/src/test/java/com/ignfab/minalac/generator/parameters/heightmaps/ConstantHeightmapParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/heightmaps/ConstantHeightmapParamsTest.java
@@ -3,13 +3,11 @@ package com.ignfab.minalac.generator.parameters.heightmaps;
 import org.junit.jupiter.api.Test;
 
 import com.ignfab.minalac.generator.generation.Generation;
-import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
 import com.ignfab.minalac.generator.parameters.ParamsTester;
 import com.ignfab.minalac.generator.utils.random.TestingSeed;
+import com.ignfab.minalac.generator.world.TestingVoxelWorld;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ConstantHeightmapParamsTest {
     @Test

--- a/src/test/java/com/ignfab/minalac/generator/parameters/heightmaps/LocalMinimumHeightmapParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/heightmaps/LocalMinimumHeightmapParamsTest.java
@@ -5,14 +5,11 @@ import tools.jackson.core.JacksonException;
 
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.generation.heightmaps.HeightmapDeclaration;
-import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
 import com.ignfab.minalac.generator.parameters.ParamsTester;
 import com.ignfab.minalac.generator.utils.random.TestingSeed;
+import com.ignfab.minalac.generator.world.TestingVoxelWorld;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class LocalMinimumHeightmapParamsTest {
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/heightmaps/MultiOperandsHeightmapParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/heightmaps/MultiOperandsHeightmapParamsTest.java
@@ -11,14 +11,12 @@ import com.ignfab.minalac.generator.generation.heightmaps.HeightmapDeclaration;
 import com.ignfab.minalac.generator.generation.heightmaps.ReadableHeightmap;
 import com.ignfab.minalac.generator.generation.heightmaps.ReadableHeightmapSpec;
 import com.ignfab.minalac.generator.generation.heightmaps.WritableHeightmap;
-import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
 import com.ignfab.minalac.generator.parameters.ParamsTester;
 import com.ignfab.minalac.generator.utils.random.TestingSeed;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+import com.ignfab.minalac.generator.world.TestingVoxelWorld;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class MultiOperandsHeightmapParamsTest {
     @Test

--- a/src/test/java/com/ignfab/minalac/generator/parameters/heightmaps/ReadableHeightmapParamsDeserializerTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/heightmaps/ReadableHeightmapParamsDeserializerTest.java
@@ -5,9 +5,7 @@ import org.junit.jupiter.api.Test;
 
 import com.ignfab.minalac.generator.parameters.ParamsTester;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ReadableHeightmapParamsDeserializerTest {
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/heightmaps/RemapHeightmapParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/heightmaps/RemapHeightmapParamsTest.java
@@ -11,15 +11,13 @@ import com.ignfab.minalac.generator.generation.heightmaps.HeightmapDeclaration;
 import com.ignfab.minalac.generator.generation.heightmaps.ReadableHeightmap;
 import com.ignfab.minalac.generator.generation.heightmaps.ReadableHeightmapSpec;
 import com.ignfab.minalac.generator.generation.heightmaps.WritableHeightmap;
-import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
 import com.ignfab.minalac.generator.parameters.ParamsTester;
 import com.ignfab.minalac.generator.parameters.utils.IntegerIntervalParams;
 import com.ignfab.minalac.generator.utils.random.TestingSeed;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+import com.ignfab.minalac.generator.world.TestingVoxelWorld;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class RemapHeightmapParamsTest {
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/models/filters/ModelFilterMetadataGreaterThanParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/models/filters/ModelFilterMetadataGreaterThanParamsTest.java
@@ -4,9 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import com.ignfab.minalac.generator.models.filters.ModelFilterOnMetadataValue;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ModelFilterMetadataGreaterThanParamsTest {
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/placeables/CombinedPlaceableParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/placeables/CombinedPlaceableParamsTest.java
@@ -5,12 +5,12 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import tools.jackson.core.JacksonException;
 
-import com.ignfab.minalac.generator.outputs.testing.TestingVoxelTile;
 import com.ignfab.minalac.generator.placeables.CombinedPlaceable;
 import com.ignfab.minalac.generator.placeables.Placeable;
 import com.ignfab.minalac.generator.placeables.TestingPlaceable;
 import com.ignfab.minalac.generator.utils.random.TestingSeed;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+import com.ignfab.minalac.generator.world.TestingVoxelTile;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/placeables/patterns/RepeatPatternParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/placeables/patterns/RepeatPatternParamsTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import com.ignfab.minalac.generator.parameters.ParamsTester;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class RepeatPatternParamsTest {
     @Test

--- a/src/test/java/com/ignfab/minalac/generator/parameters/placeables/voxels/TestingVoxelParams.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/placeables/voxels/TestingVoxelParams.java
@@ -6,10 +6,10 @@ import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.Nulls;
 
-import com.ignfab.minalac.generator.outputs.testing.TestingVoxel;
 import com.ignfab.minalac.generator.parameters.placeables.PlaceableParams;
 import com.ignfab.minalac.generator.placeables.Placeable;
 import com.ignfab.minalac.generator.utils.random.Seed;
+import com.ignfab.minalac.generator.world.TestingVoxel;
 
 /**
  * Voxel parameters for testing with name only.

--- a/src/test/java/com/ignfab/minalac/generator/parameters/processors/FloatMatrixProcessorParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/processors/FloatMatrixProcessorParamsTest.java
@@ -6,8 +6,8 @@ import org.geotools.referencing.CRS;
 import org.junit.jupiter.api.Test;
 
 import com.ignfab.minalac.generator.generation.Generation;
-import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
 import com.ignfab.minalac.generator.utils.random.TestingSeed;
+import com.ignfab.minalac.generator.world.TestingVoxelWorld;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/processors/GeoToolsVectorProcessorParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/processors/GeoToolsVectorProcessorParamsTest.java
@@ -6,8 +6,8 @@ import org.geotools.referencing.CRS;
 import org.junit.jupiter.api.Test;
 
 import com.ignfab.minalac.generator.generation.Generation;
-import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
 import com.ignfab.minalac.generator.utils.random.TestingSeed;
+import com.ignfab.minalac.generator.world.TestingVoxelWorld;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/processors/OsmVectorProcessorParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/processors/OsmVectorProcessorParamsTest.java
@@ -6,8 +6,8 @@ import org.geotools.referencing.CRS;
 import org.junit.jupiter.api.Test;
 
 import com.ignfab.minalac.generator.generation.Generation;
-import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
 import com.ignfab.minalac.generator.utils.random.TestingSeed;
+import com.ignfab.minalac.generator.world.TestingVoxelWorld;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/providers/GeoPackageProviderParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/providers/GeoPackageProviderParamsTest.java
@@ -10,8 +10,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import com.ignfab.minalac.generator.generation.Generation;
-import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
 import com.ignfab.minalac.generator.utils.random.TestingSeed;
+import com.ignfab.minalac.generator.world.TestingVoxelWorld;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/providers/GeoTiffProviderParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/providers/GeoTiffProviderParamsTest.java
@@ -10,8 +10,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import com.ignfab.minalac.generator.generation.Generation;
-import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
 import com.ignfab.minalac.generator.utils.random.TestingSeed;
+import com.ignfab.minalac.generator.world.TestingVoxelWorld;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/providers/OverpassProviderParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/providers/OverpassProviderParamsTest.java
@@ -7,8 +7,8 @@ import org.geotools.referencing.CRS;
 import org.junit.jupiter.api.Test;
 
 import com.ignfab.minalac.generator.generation.Generation;
-import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
 import com.ignfab.minalac.generator.utils.random.TestingSeed;
+import com.ignfab.minalac.generator.world.TestingVoxelWorld;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/providers/ShapefileProviderParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/providers/ShapefileProviderParamsTest.java
@@ -10,8 +10,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import com.ignfab.minalac.generator.generation.Generation;
-import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
 import com.ignfab.minalac.generator.utils.random.TestingSeed;
+import com.ignfab.minalac.generator.world.TestingVoxelWorld;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/providers/WFSProviderParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/providers/WFSProviderParamsTest.java
@@ -7,8 +7,8 @@ import org.geotools.referencing.CRS;
 import org.junit.jupiter.api.Test;
 
 import com.ignfab.minalac.generator.generation.Generation;
-import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
 import com.ignfab.minalac.generator.utils.random.TestingSeed;
+import com.ignfab.minalac.generator.world.TestingVoxelWorld;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/providers/WMSFloatBilProviderParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/providers/WMSFloatBilProviderParamsTest.java
@@ -7,8 +7,8 @@ import org.geotools.referencing.CRS;
 import org.junit.jupiter.api.Test;
 
 import com.ignfab.minalac.generator.generation.Generation;
-import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
 import com.ignfab.minalac.generator.utils.random.TestingSeed;
+import com.ignfab.minalac.generator.world.TestingVoxelWorld;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/tasks/CopyHeightmapTaskParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/tasks/CopyHeightmapTaskParamsTest.java
@@ -6,13 +6,13 @@ import tools.jackson.databind.cfg.MapperBuilder;
 
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.generation.heightmaps.HeightmapDeclaration;
-import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
 import com.ignfab.minalac.generator.parameters.ParamsTester;
 import com.ignfab.minalac.generator.parameters.heightmaps.TestingHeightmapParams;
 import com.ignfab.minalac.generator.parameters.heightmaps.WritableHeightmapParams;
 import com.ignfab.minalac.generator.parameters.models.ModelSelectionParams;
 import com.ignfab.minalac.generator.parameters.models.TestingModelSelectionParams;
 import com.ignfab.minalac.generator.utils.random.TestingSeed;
+import com.ignfab.minalac.generator.world.TestingVoxelWorld;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/tasks/PopulateHeightmapTaskParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/tasks/PopulateHeightmapTaskParamsTest.java
@@ -6,11 +6,11 @@ import tools.jackson.databind.cfg.MapperBuilder;
 
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.generation.heightmaps.HeightmapDeclaration;
-import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
 import com.ignfab.minalac.generator.parameters.ParamsTester;
 import com.ignfab.minalac.generator.parameters.heightmaps.TestingHeightmapParams;
 import com.ignfab.minalac.generator.parameters.models.ModelSelectionParams;
 import com.ignfab.minalac.generator.utils.random.TestingSeed;
+import com.ignfab.minalac.generator.world.TestingVoxelWorld;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/tasks/RenderHeightmapTaskParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/tasks/RenderHeightmapTaskParamsTest.java
@@ -5,13 +5,13 @@ import tools.jackson.databind.cfg.MapperBuilder;
 
 import com.ignfab.minalac.generator.generation.Generation;
 import com.ignfab.minalac.generator.generation.heightmaps.HeightmapDeclaration;
-import com.ignfab.minalac.generator.outputs.testing.TestingVoxelWorld;
 import com.ignfab.minalac.generator.parameters.ParamsTester;
 import com.ignfab.minalac.generator.parameters.heightmaps.TestingHeightmapParams;
 import com.ignfab.minalac.generator.parameters.heightmaps.WritableHeightmapParams;
 import com.ignfab.minalac.generator.parameters.placeables.TestingPlaceableParams;
 import com.ignfab.minalac.generator.parameters.placeables.voxels.TestingVoxelParams;
 import com.ignfab.minalac.generator.utils.random.TestingSeed;
+import com.ignfab.minalac.generator.world.TestingVoxelWorld;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/ignfab/minalac/generator/parameters/tasks/ScheduleParamsTester.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/tasks/ScheduleParamsTester.java
@@ -4,8 +4,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 public final class ScheduleParamsTester {
     // Utility class

--- a/src/test/java/com/ignfab/minalac/generator/placeables/CombinedPlaceableTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/placeables/CombinedPlaceableTest.java
@@ -2,8 +2,8 @@ package com.ignfab.minalac.generator.placeables;
 
 import org.junit.jupiter.api.Test;
 
-import com.ignfab.minalac.generator.outputs.testing.TestingVoxelTile;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
+import com.ignfab.minalac.generator.world.TestingVoxelTile;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/ignfab/minalac/generator/placeables/PlaceableStructureTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/placeables/PlaceableStructureTest.java
@@ -2,9 +2,9 @@ package com.ignfab.minalac.generator.placeables;
 
 import org.junit.jupiter.api.Test;
 
-import com.ignfab.minalac.generator.outputs.testing.TestingVoxel;
-import com.ignfab.minalac.generator.outputs.testing.TestingVoxelTile;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+import com.ignfab.minalac.generator.world.TestingVoxel;
+import com.ignfab.minalac.generator.world.TestingVoxelTile;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/ignfab/minalac/generator/placeables/patterns/RandomPatternTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/placeables/patterns/RandomPatternTest.java
@@ -2,12 +2,12 @@ package com.ignfab.minalac.generator.placeables.patterns;
 
 import org.junit.jupiter.api.Test;
 
-import com.ignfab.minalac.generator.outputs.testing.TestingVoxelTile;
 import com.ignfab.minalac.generator.placeables.Placeable;
 import com.ignfab.minalac.generator.placeables.TestingPlaceable;
 import com.ignfab.minalac.generator.utils.random.TestingRandom;
 import com.ignfab.minalac.generator.utils.random.TestingSeed;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
+import com.ignfab.minalac.generator.world.TestingVoxelTile;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/ignfab/minalac/generator/placeables/patterns/RepeatPatternTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/placeables/patterns/RepeatPatternTest.java
@@ -2,10 +2,10 @@ package com.ignfab.minalac.generator.placeables.patterns;
 
 import org.junit.jupiter.api.Test;
 
-import com.ignfab.minalac.generator.outputs.testing.TestingVoxel;
 import com.ignfab.minalac.generator.placeables.Nothing;
 import com.ignfab.minalac.generator.placeables.PlaceableStructure;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
+import com.ignfab.minalac.generator.world.TestingVoxel;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -163,6 +163,7 @@ public class RepeatPatternTest {
         assertEquals(X, pattern.get(2, 1, 5));
     }
 
+    @Test
     public void testSpacing() {
         PlaceableStructure struc = PlaceableStructure.builder().set(0, 0, 0, X).build();
 

--- a/src/test/java/com/ignfab/minalac/generator/processors/post/MetadataValueMappingPostProcessorTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/processors/post/MetadataValueMappingPostProcessorTest.java
@@ -9,9 +9,7 @@ import com.ignfab.minalac.generator.exceptions.IgnorableException;
 import com.ignfab.minalac.generator.models.Model;
 import com.ignfab.minalac.generator.models.TestingModel;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class MetadataValueMappingPostProcessorTest {
 

--- a/src/test/java/com/ignfab/minalac/generator/tasks/FillBetweenHeightmapAndModelTaskTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/tasks/FillBetweenHeightmapAndModelTaskTest.java
@@ -9,10 +9,10 @@ import com.ignfab.minalac.generator.generation.heightmaps.TestingHeightmap;
 import com.ignfab.minalac.generator.models.Model;
 import com.ignfab.minalac.generator.models.ModelSelection;
 import com.ignfab.minalac.generator.models.TestingRectangleShape2dModel;
-import com.ignfab.minalac.generator.outputs.testing.TestingVoxel;
 import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
+import com.ignfab.minalac.generator.world.TestingVoxel;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/ignfab/minalac/generator/tasks/RenderHeightmapTaskTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/tasks/RenderHeightmapTaskTest.java
@@ -4,9 +4,9 @@ import org.junit.jupiter.api.Test;
 
 import com.ignfab.minalac.generator.generation.TestingGenerationTile;
 import com.ignfab.minalac.generator.generation.heightmaps.TestingHeightmap;
-import com.ignfab.minalac.generator.outputs.testing.TestingVoxel;
 import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
+import com.ignfab.minalac.generator.world.TestingVoxel;
 
 public class RenderHeightmapTaskTest {
     @Test

--- a/src/test/java/com/ignfab/minalac/generator/tasks/RenderLines2dTaskTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/tasks/RenderLines2dTaskTest.java
@@ -9,12 +9,11 @@ import com.ignfab.minalac.generator.generation.TestingGenerationTile;
 import com.ignfab.minalac.generator.generation.heightmaps.computed.ConstantHeightmap;
 import com.ignfab.minalac.generator.models.ModelSelection;
 import com.ignfab.minalac.generator.models.TestingShape2dModel;
-import com.ignfab.minalac.generator.outputs.testing.TestingVoxel;
 import com.ignfab.minalac.generator.placeables.PlaceableStructure;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
 import com.ignfab.minalac.generator.voxelization.shape2d.LineString2d;
-
+import com.ignfab.minalac.generator.world.TestingVoxel;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/ignfab/minalac/generator/tasks/RenderLinesTaskTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/tasks/RenderLinesTaskTest.java
@@ -9,11 +9,11 @@ import com.ignfab.minalac.generator.generation.TestingGenerationTile;
 import com.ignfab.minalac.generator.generation.heightmaps.computed.ConstantHeightmap;
 import com.ignfab.minalac.generator.models.ModelSelection;
 import com.ignfab.minalac.generator.models.TestingShape3dModel;
-import com.ignfab.minalac.generator.outputs.testing.TestingVoxel;
 import com.ignfab.minalac.generator.placeables.PlaceableStructure;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
 import com.ignfab.minalac.generator.voxelization.shape3d.LineString3d;
+import com.ignfab.minalac.generator.world.TestingVoxel;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/ignfab/minalac/generator/tasks/RenderSurfacesTaskTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/tasks/RenderSurfacesTaskTest.java
@@ -10,11 +10,11 @@ import com.ignfab.minalac.generator.generation.TestingGenerationTile;
 import com.ignfab.minalac.generator.generation.heightmaps.TestingHeightmap;
 import com.ignfab.minalac.generator.models.ModelSelection;
 import com.ignfab.minalac.generator.models.TestingRectangleShape2dModel;
-import com.ignfab.minalac.generator.outputs.testing.TestingVoxel;
 import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
 import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
+import com.ignfab.minalac.generator.world.TestingVoxel;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/com/ignfab/minalac/generator/tasks/SetSpawnTaskTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/tasks/SetSpawnTaskTest.java
@@ -8,7 +8,7 @@ import com.ignfab.minalac.generator.utils.world2d.WorldCoords2d;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class SetSpawnTaskTest {
 

--- a/src/test/java/com/ignfab/minalac/generator/world/TestingVoxel.java
+++ b/src/test/java/com/ignfab/minalac/generator/world/TestingVoxel.java
@@ -1,9 +1,8 @@
-package com.ignfab.minalac.generator.outputs.testing;
+package com.ignfab.minalac.generator.world;
 
 import java.util.Objects;
 
 import com.ignfab.minalac.generator.placeables.Placeable;
-import com.ignfab.minalac.generator.world.VoxelTile;
 
 /**
  * A dummy voxel for {@code TestingVoxelWorld} and {@code TestingVoxelTile}.

--- a/src/test/java/com/ignfab/minalac/generator/world/TestingVoxelTile.java
+++ b/src/test/java/com/ignfab/minalac/generator/world/TestingVoxelTile.java
@@ -1,11 +1,9 @@
-package com.ignfab.minalac.generator.outputs.testing;
+package com.ignfab.minalac.generator.world;
 
 
 import com.ignfab.minalac.generator.placeables.Placeable;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
-import com.ignfab.minalac.generator.world.MapWriteException;
-import com.ignfab.minalac.generator.world.VoxelTile;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -13,43 +11,30 @@ import static org.junit.jupiter.api.Assertions.*;
  * Testing purpose {@link VoxelTile} intended to be used in unit tests.
  */
 public class TestingVoxelTile extends VoxelTile {
-    private String[] voxels;
+    private final String[] voxels;
 
     /**
      * A default {@code TestingVoxelTile} instance to pass as argument where it won't actually be used.
      */
-    public static final TestingVoxelTile UNUSED = new TestingVoxelTile(TestingVoxelWorld.UNUSED, WorldBBox3d.EMPTY);
+    public static final TestingVoxelTile UNUSED = new TestingVoxelTile(WorldBBox3d.EMPTY);
 
     /**
      * Constructs a new TestingVoxelTile.
-     *
-     * @param world World of which this tile is a part
-     * @param limits Limits of the voxel world to create
-     *
+     * <p>
      * Beware: Avoid large limits!
      * Each voxel is stored in memory as a string, which could be very large.
+     *
+     * @param limits Limits of the voxel world to create
      */
-    public TestingVoxelTile(TestingVoxelWorld world, WorldBBox3d limits) {
+    public TestingVoxelTile(WorldBBox3d limits) {
         super(limits);
         voxels = new String[limits.size().volume()];
     }
 
-    /**
-     * Constructs a new TestingVoxelTile and its corresponding world.
-     *
-     * @param limits Limits of the voxel world to create
-     *
-     * Beware: Avoid large limits!
-     * Each voxel is stored in memory as a string, which could be very large.
-     */
-    public TestingVoxelTile(WorldBBox3d limits) {
-        this(new TestingVoxelWorld(), limits);
-    }
-
     @Override
-    public void save() throws MapWriteException {}
+    public void save() {}
 
-    // This method should not be called with out of bounds coordinate
+    // This method should not be called with out-of-bounds coordinate
     private int index(int x, int y, int z) {
         return x - limits().minX() + limits().sizeX()
             * (y - limits().minY() + limits().sizeY()

--- a/src/test/java/com/ignfab/minalac/generator/world/TestingVoxelTileTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/world/TestingVoxelTileTest.java
@@ -1,4 +1,4 @@
-package com.ignfab.minalac.generator.outputs.testing;
+package com.ignfab.minalac.generator.world;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -47,6 +47,6 @@ public class TestingVoxelTileTest {
     @DisplayName("Just ensure save throws no exception")
     public void testSave() {
         TestingVoxelTile tile = new TestingVoxelTile(new WorldBBox3d(0, 0, 0, 1, 1, 1));
-        assertDoesNotThrow(() -> tile.save());
+        assertDoesNotThrow(tile::save);
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/world/TestingVoxelWorld.java
+++ b/src/test/java/com/ignfab/minalac/generator/world/TestingVoxelWorld.java
@@ -1,4 +1,4 @@
-package com.ignfab.minalac.generator.outputs.testing;
+package com.ignfab.minalac.generator.world;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -6,10 +6,6 @@ import java.util.Collections;
 import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.utils.world3d.WorldCoords3d;
-import com.ignfab.minalac.generator.world.MapWriteException;
-import com.ignfab.minalac.generator.world.VoxelTile;
-import com.ignfab.minalac.generator.world.VoxelWorld;
-import com.ignfab.minalac.generator.world.VoxelWorldMetadata;
 
 /**
  * Testing purpose {@link VoxelWorld} intended to be used in unit tests.
@@ -36,7 +32,7 @@ public class TestingVoxelWorld extends VoxelWorld {
     public void initialize() throws MapWriteException {}
 
     @Override
-    public void finalizeAndSave() throws MapWriteException {}
+    public void finalizeAndSave() {}
 
     /**
      * {@inheritDoc}
@@ -46,7 +42,7 @@ public class TestingVoxelWorld extends VoxelWorld {
      */
     @Override
     public VoxelTile newTile(WorldBBox3d limits) {
-        return new TestingVoxelTile(this, limits);
+        return new TestingVoxelTile(limits);
     }
 
     @Override

--- a/src/test/java/com/ignfab/minalac/generator/world/VoxelWorldTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/world/VoxelWorldTest.java
@@ -6,8 +6,6 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-import com.ignfab.minalac.generator.outputs.testing.TestingVoxel;
-import com.ignfab.minalac.generator.outputs.testing.TestingVoxelTile;
 import com.ignfab.minalac.generator.placeables.Placeable;
 import com.ignfab.minalac.generator.utils.world2d.WorldBBox2d;
 import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
@@ -19,29 +17,23 @@ public class VoxelWorldTest {
     @Test
     public void testSetLimits() {
         VoxelWorld world = new VoxelWorldMock();
-        assertThrows(IllegalArgumentException.class, () -> {
-            world.setLimits(new WorldBBox3d(
-                    new WorldCoords3d(-21, -19, -18),
-                    new WorldCoords3d(21, 22, 23)
-            ));
-        });
+        assertThrows(IllegalArgumentException.class, () -> world.setLimits(new WorldBBox3d(
+            new WorldCoords3d(-21, -19, -18),
+            new WorldCoords3d(21, 22, 23)
+        )));
 
-        assertDoesNotThrow(() -> {
-            world.setLimits(new WorldBBox3d(
-                new WorldCoords3d(-1, -2, -3),
-                new WorldCoords3d(4, 5, 6))
-            );
-        });
+        assertDoesNotThrow(() -> world.setLimits(new WorldBBox3d(
+            new WorldCoords3d(-1, -2, -3),
+            new WorldCoords3d(4, 5, 6))
+        ));
 
         assertEquals(new WorldBBox3d(new WorldCoords3d(-1, -2, -3), new WorldCoords3d(4, 5, 6)), world.limits());
         assertEquals(new WorldCoords3d(2, 2, 2), world.getMetadata().getSpawn());
 
-        assertThrows(IllegalStateException.class, () -> {
-            world.setLimits(new WorldBBox3d(
-                new WorldCoords3d(-1, -2, -3),
-                new WorldCoords3d(7, 8, 9))
-            );
-        });
+        assertThrows(IllegalStateException.class, () -> world.setLimits(new WorldBBox3d(
+            new WorldCoords3d(-1, -2, -3),
+            new WorldCoords3d(7, 8, 9))
+        ));
     }
 
     @Test
@@ -60,35 +52,29 @@ public class VoxelWorldTest {
         b.place(tile, 1, -2, 1);
         c.place(tile, 1, -2, -2);
 
-        assertDoesNotThrow(() -> {
-            assertIterableEquals(
-                List.of(
-                    new PlacedVoxel(a, new WorldCoords3d(-1, 2, 6)),
-                    new PlacedVoxel(b, new WorldCoords3d(-1, 2, 2)),
-                    new PlacedVoxel(c, new WorldCoords3d(-1, 2, 0)),
-                    new PlacedVoxel(a, new WorldCoords3d(-1, 2, -4)),
-                    new PlacedVoxel(c, new WorldCoords3d(-1, 2, -5))
-                ),
-                tile.voxels(-1, 2)
-            );
-        });
+        assertDoesNotThrow(() -> assertIterableEquals(
+            List.of(
+                new PlacedVoxel(a, new WorldCoords3d(-1, 2, 6)),
+                new PlacedVoxel(b, new WorldCoords3d(-1, 2, 2)),
+                new PlacedVoxel(c, new WorldCoords3d(-1, 2, 0)),
+                new PlacedVoxel(a, new WorldCoords3d(-1, 2, -4)),
+                new PlacedVoxel(c, new WorldCoords3d(-1, 2, -5))
+            ),
+            tile.voxels(-1, 2)
+        ));
 
-        assertDoesNotThrow(() -> {
-            assertIterableEquals(
-                List.of(
-                    new PlacedVoxel(b, new WorldCoords3d(1, -2, 1)),
-                    new PlacedVoxel(c, new WorldCoords3d(1, -2, -2))
-                ),
-                tile.voxels(1, -2)
-            );
-        });
+        assertDoesNotThrow(() -> assertIterableEquals(
+            List.of(
+                new PlacedVoxel(b, new WorldCoords3d(1, -2, 1)),
+                new PlacedVoxel(c, new WorldCoords3d(1, -2, -2))
+            ),
+            tile.voxels(1, -2)
+        ));
 
-        assertDoesNotThrow(() -> {
-            assertIterableEquals(
-                Collections.emptyList(),
-                tile.voxels(0, -2)
-            );
-        });
+        assertDoesNotThrow(() -> assertIterableEquals(
+            Collections.emptyList(),
+            tile.voxels(0, -2)
+        ));
     }
 
     private static class VoxelWorldMock extends VoxelWorld {
@@ -106,10 +92,10 @@ public class VoxelWorldTest {
         }
 
         @Override
-        public void initialize() throws MapWriteException {}
+        public void initialize() {}
 
         @Override
-        public void finalizeAndSave() throws MapWriteException {}
+        public void finalizeAndSave() {}
 
         @Override
         public VoxelTile newTile(WorldBBox3d limits) {


### PR DESCRIPTION
### Changes

This PR greatly improves the Minecraft module. Code now uses ens-gijs/NBT (fork) library instead of Querz/NBT (upstream) to better handle Minecraft versions as well as improved API.

#### Feature description

The main goal of this PR was to improve the Minecraft module, especially how voxels were parameterized and which Minecraft version was being generated. It extended a little beyond that scope to improve unit testing of output format, and a small Maven plugins version update.

**Minecraft module improvements**

A significant portion of changes consist of the replacement of the old NBT API by the new one. Overall, it improves readability of some methods, and now handles Minecraft 1.21.11 worlds (released on December 9, 2025, previously was 1.16.5, released on January 15, 2021).

Another big part of this feature is the (real) support for block entities. Previously it was kind of ready to be implemented, but not usable at all. Now, block entities can be used in parameters like regular blocks, and integrated seamlessly in any generation.

`MinecraftVoxel` and `MinecraftBlockEntityVoxel` objects are now fully immutable, with new methods to work with them. Minecraft voxel short form has been enhanced using [block state command argument type](https://minecraft.wiki/w/Argument_types#minecraft:block_state) syntax from vanilla Minecraft.

An issue where `MinecraftVoxelTile` was still saving `Region`s into the current working directory when saving was disabled has been fixed. Unfortunately such feature cannot be tested with unit tests since it would require asserting that the file system was not modified, which is not trivial, especially cross-platform.

Additionally, rare race conditions where first blocks were placed simultaneously in the same chunk/section causing multiple initializations was eliminated with stronger concurrency checks.

Finally, unit tests were completed with a lot of missing tests added. Markdown documentation about placeable was also reworked to improve voxel definition explanation, especially their short form.

**`TestingVoxelWorld` test classes relocation**

After the modularization of output formats, the "testing" output format was left into the `outputs/testing` test package despite not having an `outputs` package anymore in the sources. This commit simply relocated them into the `world` package which is more appropriate, being an implementation of those classes for testing purposes.

A few code style issues were auto-fixed as well (especially some imports).

The `testSpacing` method of the `RepeatPatternTest` test case was missing the `@Test` annotation, making it not triggered when executing tests.

**Maven plugins version update**

Maven plugins were slightly outdated and some were failing in CI. Updating them fixed the issue.

#### Technical changes

Maven dependency [`com.github.Querz:NBT:6.1`](https://github.com/Querz/NBT) was replaced by [`io.github.ens-gijs.nbt:nbt-mca:0.2.0`](https://github.com/ens-gijs/NBT).

All Maven plugins were updated to their latest stable release.

#### Showcase

Find some examples of parameters for Minecraft voxels in the `docs/usage/parameters/Placeables.md` file.

### Reason

The Querz/NBT library is quite outdated (can only handle Minecraft version from 5 years ago), and seems not really maintained anymore. The fork ens-gijs/NBT is more powerful and is being maintained currently.

Parameterizing Minecraft voxels with properties was cumbersome, while an inline syntax exists in vanilla Minecraft. Furthermore, using block entities open the way for more evolved structured and blocks with special features such as working lamp posts with functioning daylight detectors.

### TODOs

`MinecraftVoxelTile`, line 81: Due to the way block entities are implemented, when a block is placed somewhere, it must clear any existing block entity at that position. Since there is no index, and block entities of each section are stored in a list, it may be not optimal performances. Having a map-like data structure might help, but requires some work and testing (it might be an acceptable tradeoff to avoid higher memory consumption).

### Self-checks

- [x] The code has unit tests associated
- [x] The code has Javadoc Comments associated
- [x] Complex / Unexpected code is explained / justified with a small comment
- [x] Relevant documentation inside the `/docs` folder has been updated
- [x] All examples in `examples/` work the same (or have been adapted if subject to changes in this PR)
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- [x] The texts have been proofread (documentation, error messages, logs, comments...)
