### PR TITLE
Rename `put` to `place` in structures

### DIFF
--- a/docs/usage/parameters/Placeables.md
+++ b/docs/usage/parameters/Placeables.md
@@ -85,7 +85,7 @@ Example of a structure as placeable:
 ```yaml
 place:
   structure:
-    put: default:dirt
+    place: default:dirt
     at: [-1..1, -1..1, -1..1]
 ```
 
@@ -100,17 +100,17 @@ Structure can be described as a list of boxes filled with a placeable (could be 
 ```yaml
 place:
   structure:
-    - put: default:dirt
+    - place: default:dirt
       at: [-1..1, -1..1, -1..0]
-    - put: default:dirt_with_grass
+    - place: default:dirt_with_grass
       at: [-1..1, -1..1, 1]
-    - put: default:tree
+    - place: default:tree
       at: [0, 0, 2]
 ```
 
 Fields:
-- `put`: Placeable to put at given position(s)
-- `at`: Where to put that placeable. Can be a single postion, or a box.
+- `place`: Placeable to set at given position(s)
+- `at`: Where to set that placeable. Can be a single postion, or a box.
 
 Boxes are noted as `[x, y, z]` where `x`, `y` and `z` can be an interval noted `start..end` where `start` and `end` are starting and ending value of the interval, or a single coordinate (`5` is equivalent to `5..5`). All values are integers.
 
@@ -219,9 +219,9 @@ place:
         - "W-O-O-O-OW"
         - "WO-O-O-O-W"
         - "WWWWWWWWWW"
-    - put: default:slab_desert_stone_block
+    - place: default:slab_desert_stone_block
       at: [ 3, 5, 1 ]
-    - put: default:slab_silver_sandstone_block
+    - place: default:slab_silver_sandstone_block
       at: [ 8, 2, 1 ]
 ```
 
@@ -287,7 +287,7 @@ A pattern that repeats a [structure](#structures):
 ```yaml
 place:
   pattern:
-    repeatStructure: 
+    repeatStructure:
       with:
         '░': default:goldblock
         '█': default:desert_stone_block
@@ -305,7 +305,7 @@ When repeating a structure, you can apply a shift to each repetition along the 3
 ```yaml
 place:
   pattern:
-    repeatStructure: 
+    repeatStructure:
       with:
         '░': default:goldblock
         '█': default:desert_stone_block
@@ -325,7 +325,7 @@ Applying a shift in the direction of the axis results in a space between placeme
 ```yaml
 place:
   pattern:
-    repeatStructure: 
+    repeatStructure:
       with:
         '░': default:goldblock
         '█': default:desert_stone_block
@@ -364,7 +364,7 @@ Fields:
 ```yaml
 place:
   pattern:
-    repeatStructure: 
+    repeatStructure:
       with:
         '/': wool:black
       axes: [ x, y ]

--- a/examples/formats/minecraft.yaml
+++ b/examples/formats/minecraft.yaml
@@ -14,7 +14,7 @@ references:
   - &forest-grass minecraft:fern
   - &forest-tree1
     structure:
-      - put:
+      - place:
           pattern:
             place:
               block: minecraft:oak_leaves
@@ -22,11 +22,11 @@ references:
                 persistent: true
             chance: 0.8
         at: [ -3..3, -3..3, 4..10 ]
-      - put: minecraft:oak_log
+      - place: minecraft:oak_log
         at: [ 0, 0, 0..5 ]
   - &forest-tree2
     structure:
-      - put:
+      - place:
           pattern:
             place:
               block: minecraft:birch_leaves
@@ -34,7 +34,7 @@ references:
                 persistent: true
             chance: 0.8
         at: [ -3..3, -3..3, 4..10 ]
-      - put: minecraft:birch_log
+      - place: minecraft:birch_log
         at: [ 0, 0, 0..5 ]
   - &voxel-water minecraft:water
   - &voxel-air minecraft:air

--- a/examples/formats/minetest.yaml
+++ b/examples/formats/minetest.yaml
@@ -14,21 +14,21 @@ references:
   - &forest-grass default:junglegrass
   - &forest-tree1
     structure:
-      - put:
+      - place:
           pattern:
             place: default:leaves
             chance: 0.8
         at: [ -3..3, -3..3, 4..10 ]
-      - put: default:tree
+      - place: default:tree
         at: [ 0, 0, 0..5 ]
   - &forest-tree2
     structure:
-      - put:
+      - place:
           pattern:
             place: default:aspen_leaves
             chance: 0.8
         at: [ -3..3, -3..3, 4..10 ]
-      - put: default:aspen_tree
+      - place: default:aspen_tree
         at: [ 0, 0, 0..5 ]
   - &voxel-water default:water_source
   - &voxel-air air

--- a/examples/processes/full.yaml
+++ b/examples/processes/full.yaml
@@ -87,11 +87,11 @@ forEachTile:
     at: ground
     place:
       structure:
-        - put: *voxel-grass
+        - place: *voxel-grass
           at: [0, 0, 0]
-        - put: *voxel-dirt
+        - place: *voxel-dirt
           at: [0, 0, -3..-1]
-        - put: *voxel-stone
+        - place: *voxel-stone
           at: [0, 0, -20..-4]
 
   computeBuildingsAltitude:
@@ -160,7 +160,7 @@ forEachTile:
               place:
                 structure:
                   - at: [0, 0, 1]
-                    put: *forest-grass
+                    place: *forest-grass
           - *voxel-forest-ground
           - pattern:
               seed: forest-tree1
@@ -214,10 +214,10 @@ forEachTile:
     maximum: ground
     place:
       structure:
-        - put: *voxel-water
+        - place: *voxel-water
           at: [ 0, 0, 0 ]
         # This a dirt fix to remove vegetation on water
-        - put: *voxel-air
+        - place: *voxel-air
           at: [ 0, 0, 1..12 ]
 
   path:
@@ -232,9 +232,9 @@ forEachTile:
         metadata: nature
         in: [ "Chemin", "Sentier", "Route empierrée" ]
     structure:
-      - put: *path
+      - place: *path
         at: [ 0, -1..1, 0]
-      - put: *voxel-air
+      - place: *voxel-air
         at: [ 0, -1..1, 1..2 ]
 
   renderBridges:

--- a/src/main/java/com/ignfab/minalac/generator/parameters/placeables/structures/BoxPlaceableStructureParams.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/placeables/structures/BoxPlaceableStructureParams.java
@@ -17,40 +17,39 @@ import com.ignfab.minalac.generator.utils.random.Seed;
  */
 public class BoxPlaceableStructureParams extends PlaceableStructureParams.Variant {
 
-
     /**
-     * Box, in structure relative coordinates, where placeable should be put (required).
+     * Box, in structure relative coordinates, where placeable should be set (required).
      */
     @JsonSetter(nulls = Nulls.FAIL)
     public WorldBBox3dParams at;
 
     /**
-     * Placeable to put at each position inside the given box (required).
+     * Placeable to set at each position inside the given box (required).
      */
     @JsonSetter(nulls = Nulls.FAIL)
-    public PlaceableParams put;
+    public PlaceableParams place;
 
     /**
      * Creates a new {@code PlaceableStructureParams}.
      *
-     * @param at Box into which put placeables
-     * @param put Placeable to put into given box
+     * @param at Box into which set placeables
+     * @param place Placeable to set into given box
      */
-    @ConstructorProperties({"at", "put"})
-    public BoxPlaceableStructureParams(WorldBBox3dParams at, PlaceableParams put) {
-        this.put = put;
+    @ConstructorProperties({"at", "place"})
+    public BoxPlaceableStructureParams(WorldBBox3dParams at, PlaceableParams place) {
+        this.place = place;
         this.at = at;
     }
 
     @Override
     public void validate() {
         // Only validation propagation
-        put.validate();
+        place.validate();
         at.validate();
     }
 
     @Override
     public void apply(Seed seed, PlaceableStructure.Builder structureBuilder) {
-        structureBuilder.set(at.create(), put.create(seed));
+        structureBuilder.set(at.create(), place.create(seed));
     }
 }

--- a/src/test/java/com/ignfab/minalac/generator/parameters/placeables/PlaceableParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/placeables/PlaceableParamsTest.java
@@ -99,7 +99,7 @@ public class PlaceableParamsTest {
         params = assertDoesNotThrow(() -> ParamsTester.deserialize(PlaceableParams.class, """
             structure:
               - at: [0, 0, 0]
-                put: A
+                place: A
         """));
 
         assertInstanceOf(PlaceableStructureParams.class, params);

--- a/src/test/java/com/ignfab/minalac/generator/parameters/placeables/structures/PlaceableStructureParamsTest.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/placeables/structures/PlaceableStructureParamsTest.java
@@ -28,7 +28,7 @@ public class PlaceableStructureParamsTest {
         assertDoesNotThrow(() -> ParamsTester.deserialize(
             PlaceableStructureParams.class, """
               - at: [0, 0, 0]
-                put: A
+                place: A
             """
         ));
 
@@ -71,7 +71,7 @@ public class PlaceableStructureParamsTest {
                   'a': A
                 blueprint: a
               - at: [0, 0, 0]
-                put: A
+                place: A
             """
         ));
     }
@@ -84,7 +84,7 @@ public class PlaceableStructureParamsTest {
         params = ParamsTester.deserialize(
             PlaceableStructureParams.class, """
               - at: [0, 0, 0]
-                put: A
+                place: A
               - axes: x
                 with:
                   'a': A
@@ -97,7 +97,7 @@ public class PlaceableStructureParamsTest {
         params = ParamsTester.deserialize(
             PlaceableStructureParams.class, """
               - at: [0, 0, 0]
-                put: A
+                place: A
               - axes: [ x, y ]
                 with:
                   'a': A
@@ -111,7 +111,7 @@ public class PlaceableStructureParamsTest {
         params = ParamsTester.deserialize(
             PlaceableStructureParams.class, """
               - at: [2..1, 0, 0]
-                put: A
+                place: A
               - axes: x
                 with:
                   'a': A


### PR DESCRIPTION
<!--
Thank you for contributing to this project!
You must fill out the information below before we can review this pull request.
Be sure to update the relevant sections of this template and to complete the list of self-checks at the end.

If you need more time to check everything, consider opening a draft pull request instead.
Don't forget to update this comment to track your progress.
-->

### Changes
In box structure, rename `put:` to `place:`

### Reason
It was a pain in the...

### Self-checks

- [x] The code has unit tests associated
- ~~The code has Javadoc Comments associated~~
- ~~Complex / Unexpected code is explained / justified with a small comment~~
- [x] Relevant documentation inside the `/docs` folder has been updated
- [x] All examples in `examples/` work the same (or have been adapted if subject to changes in this PR)
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
-  ~~The texts have been proofread (documentation, error messages, logs, comments...)~~
