### PR TITLE
Rename main classes and environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,9 +45,9 @@ RUN mvn -Dmaven.test.skip=true clean package
 FROM $REGISTRY/library/eclipse-temurin:17-jre-jammy
 
 # User and group definition
-ENV USER=minalac
+ENV USER=voxatile
 ENV UID=10001
-ENV GROUP=minalac
+ENV GROUP=voxatile
 ENV GID=10001
 
 # Create user and group

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ cd voxatile # All commands are always based on the project root
 
 Compile and run using Maven (Unix only):
 ```shell
-mvn -Dmaven.test.skip=true clean package && ./generate.sh minetest full ign $HOME/.minetest/worlds/minalac
+mvn -Dmaven.test.skip=true clean package && ./generate.sh minetest full ign $HOME/.minetest/worlds/voxatile
 ```
 
 <!--

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ This folder contains additional documentation on various topics. Technical code 
 You may find useful the following links:
 - [`usage/Run.md`](usage/Run.md): How to run the generator?
 - [`tools/Maven.md`](tools/Maven.md): How to use Maven?
-- [Online Javadoc](https://ignfab.github.io/minalac-generator), automatically deployed on GitHub Pages.
+- [Online Javadoc](https://ignfab.github.io/voxatile), automatically deployed on GitHub Pages.
 
 If none of the above helped you, consider searching through the complete documentation. If the information you are looking for does not exist, feel free to add it!
 

--- a/docs/tools/Javadoc.md
+++ b/docs/tools/Javadoc.md
@@ -1,7 +1,7 @@
 # Javadoc
 
 > [!NOTE]
-> The Javadoc are available on [GitHub Pages](https://ignfab.github.io/minalac-generator).
+> The Javadoc are available on [GitHub Pages](https://ignfab.github.io/voxatile).
 
 We use [Javadoc](https://www.oracle.com/technical-resources/articles/java/javadoc-tool.html) Comments to document our code. If you're already familiar with this tool, skip to the [Usage](#Usage) section.
 

--- a/docs/usage/Docker.md
+++ b/docs/usage/Docker.md
@@ -2,12 +2,12 @@
 
 ## Build Docker image
 
-Build a `minalac-generator` image using the following command from project root directory:
+Build a `voxatile` image using the following command from project root directory:
 
 ```shell
 docker build --no-cache \
     --progress=plain \
-    -t minalac-generator .
+    -t voxatile .
 ```
 
 If corporate proxy is required:
@@ -18,30 +18,30 @@ docker build --no-cache \
     --build-arg http_proxy_protocol=http \
     --build-arg http_proxy_host=your.proxy.com \
     --build-arg http_proxy_port=1234 \
-    -t minalac-generator .
+    -t voxatile .
 ```
 
 ## Run image locally
 
-Here, the generation parameters are computed using the utility script `generate.sh` (with the `-y` option) and passed to the container using the `MINALAC_PARAMS` environment variable. A local `output/` directory must have been created beforehand.
+Here, the generation parameters are computed using the utility script `generate.sh` (with the `-y` option) and passed to the container using the `VOXATILE_PARAMS` environment variable. A local `output/` directory must have been created beforehand.
 
 ```shell
 mkdir output
-MINALAC_PARAMS=$(./generate.sh -y minetest full ign) docker run \
+VOXATILE_PARAMS=$(./generate.sh -y minetest full ign) docker run \
     -u $(id -u ${USER}):$(id -g ${USER}) \
     -v ./output:/output \
-    -e MINALAC_PARAMS \
-    minalac-generator
+    -e VOXATILE_PARAMS \
+    voxatile
 ```
 
 If corporate proxy is needed, use the `JAVA_TOOL_OPTIONS` environment variable to declare it:
 
 ```shell
 mkdir output
-MINALAC_PARAMS=$(./generate.sh -y minetest full ign) docker run \
+VOXATILE_PARAMS=$(./generate.sh -y minetest full ign) docker run \
     -u $(id -u ${USER}):$(id -g ${USER}) \
     -v ./output:/output \
-    -e MINALAC_PARAMS \
+    -e VOXATILE_PARAMS \
     -e JAVA_TOOL_OPTIONS="-Dhttp.proxyHost=your.proxy.com -Dhttp.proxyPort=1234 -Dhttps.proxyHost=your.proxy.com -Dhttps.proxyPort=1234" \
-    minalac-generator
+    voxatile
 ```

--- a/docs/usage/Generator.md
+++ b/docs/usage/Generator.md
@@ -7,7 +7,7 @@ This page is about different methods for building and running Generator. They ar
 
 ## Generation parameters
 
-Generation involves too many parameters to be passed on command line. They are passed either by file using `-p`/`--param-file` command line option or using `MINALAC_PARAMS` environment variable.
+Generation involves too many parameters to be passed on command line. They are passed either by file using `-p`/`--param-file` command line option or using `VOXATILE_PARAMS` environment variable.
 
 Refer to [generation parameters documentation](parameters/Parameters.md) for further information.
 
@@ -21,10 +21,10 @@ java -jar Generator.jar [OPTIONS] <outputPath>
 
 Options:
 - `-h` or `--help` display command usage.
-- `-p <path>` or `--param-file <path>` read generation parameters from given path. If omitted, parameters are read from [`MINALAC_PARAMS`](#minalac_params) environment variable.
+- `-p <path>` or `--param-file <path>` read generation parameters from given path. If omitted, parameters are read from [`VOXATILE_PARAMS`](#voxatile_params) environment variable.
 - `--generation-disabled` Stop before starting generation, after parameters parsed.
 - `--save-disabled` Stop before saving output file, after generation done.
-- `--max-tile-size <size>` Perform tiled generation with tiles no larger than `size` (positive integer) in both dimensions. See also [`MINALAC_MAX_TILE_SIZE`](#minalac_max_tile_size) environment variable.
+- `--max-tile-size <size>` Perform tiled generation with tiles no larger than `size` (positive integer) in both dimensions. See also [`VOXATILE_MAX_TILE_SIZE`](#voxatile_max_tile_size) environment variable.
 - `--modules-path <path>` Path to modules directory (see [modules](#modules)).
 
 `<outputPath>`: generation output path (must be an existing and writable directory).
@@ -33,15 +33,15 @@ Output path and generation parameters have to be provided.
 
 ## Environment variables
 
-### `MINALAC_PARAMS`
+### `VOXATILE_PARAMS`
 
 If set, may contain generation parameters to use when `--param-file` command line option is absent.
 
-### `MINALAC_MAX_TILE_SIZE`
+### `VOXATILE_MAX_TILE_SIZE`
 
 If set to a positive integer, perform tiled generation with tiles no larger than this number. Overridden by `--max-tile-size` command line option.
 
-### `MINALAC_MODULES_PATH`
+### `VOXATILE_MODULES_PATH`
 
 Path to modules directory (see [modules](#modules)).
 
@@ -49,7 +49,7 @@ Path to modules directory (see [modules](#modules)).
 
 If you have cloned the project repository, you can [build the JAR using Maven](../tools/Maven.md#create-an-executable-jar) and run it:
 ```shell
-mvn -Dmaven.test.skip=true clean package && java -jar target/Generator.jar -p parameters.yaml $HOME/.minetest/worlds/minalac
+mvn -Dmaven.test.skip=true clean package && java -jar target/Generator.jar -p parameters.yaml $HOME/.minetest/worlds/voxatile
 ```
 
 ## Download workflow artifact
@@ -61,7 +61,7 @@ If you just want to test the JAR from a different branch (e.g. to validate a PR)
 
 Once you downloaded (and extracted) the artifact, you should have the `Generator.jar` file and will be able to run it:
 ```shell
-java -jar Generator.jar -p parameters.yaml $HOME/.minetest/worlds/minalac
+java -jar Generator.jar -p parameters.yaml $HOME/.minetest/worlds/voxatile
 ```
 
 ## Run using Maven
@@ -70,15 +70,15 @@ If, for some reason, you don't want to build the JAR, you can run the [`exec:jav
 ```shell
 mvn clean compile exec:java \
   -Dexec.cleanupDaemonThreads=false \
-  -Dexec.mainClass="com.ignfab.minalac.generator.MinalacGenerator" \
-  -Dexec.args="-p parameters.yaml $HOME/.minetest/worlds/minalac"
+  -Dexec.mainClass="com.ignfab.minalac.generator.Voxatile" \
+  -Dexec.args="-p parameters.yaml $HOME/.minetest/worlds/voxatile"
 ```
 
 # Modules
 
 Modules are Jar files adding features to generator (output formats, source types, task types, ...).
 
-They should be placed in a directory specified either by `--modules-path` command line option or `MINALAC_MODULES_PATH` environment variable. If command line option is set, environment variable is ignored. If none set, no modules will be loaded.
+They should be placed in a directory specified either by `--modules-path` command line option or `VOXATILE_MODULES_PATH` environment variable. If command line option is set, environment variable is ignored. If none set, no modules will be loaded.
 
 All Jar files in modules directory, but not in subdirectories (no recursive loading), will be loaded. Beware that presence of Jar file that is not a module in that directory will make generation fail.
 

--- a/docs/usage/Run.md
+++ b/docs/usage/Run.md
@@ -8,20 +8,20 @@
 Compile and run from repository root:
 
 ```shell
-mvn -Dmaven.test.skip=true clean package && ./generate.sh minetest full ign $HOME/.minetest/worlds/minalac
+mvn -Dmaven.test.skip=true clean package && ./generate.sh minetest full ign $HOME/.minetest/worlds/voxatile
 ```
 
 Run only (from repository root):
 
 ```shell
-./generate.sh minetest full ign $HOME/.minetest/worlds/minalac
+./generate.sh minetest full ign $HOME/.minetest/worlds/voxatile
 ```
 
 ## generate.sh
 
 `generate.sh` scripts creates yaml configuration from configuration fragments and passes it to `Generator.jar`.
 
-It mimics a simple behavior of future `minalac-configurator` and is only intended to be used for testing purpose.
+It mimics a simple behavior of future `voxatile-configurator` and is only intended to be used for testing purpose.
 
 Usage:
 ```bash
@@ -40,8 +40,8 @@ Where:
 
 While many places are available, there are only two formats (`minecraft`, `minetest`) and one process (`full`) for now.
 
-To perform tiled generation, set `MINALAC_MAX_TILE_SIZE` environment variable to the wanted maximum tile size:
+To perform tiled generation, set `VOXATILE_MAX_TILE_SIZE` environment variable to the wanted maximum tile size:
 
 ```shell
-MINALAC_MAX_TILE_SIZE=512 ./generate.sh minetest full ign $HOME/.minetest/worlds/minalac
+VOXATILE_MAX_TILE_SIZE=512 ./generate.sh minetest full ign $HOME/.minetest/worlds/voxatile
 ```

--- a/generate.sh
+++ b/generate.sh
@@ -136,4 +136,4 @@ if [ "$display_only" ]; then
     exit 0
 fi
 
-MINALAC_PARAMS=$params MINALAC_MODULES_PATH=modules $JAVA_CMD -jar $JAR_PATH $generator_opt "$output_dir"
+VOXATILE_PARAMS=$params VOXATILE_MODULES_PATH=modules $JAVA_CMD -jar $JAR_PATH $generator_opt "$output_dir"

--- a/pom.xml
+++ b/pom.xml
@@ -280,7 +280,7 @@
                         <!-- Ensures the JAR comes with a proper MANIFEST.MF file -->
                         <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                             <!-- With at least an entry "Main-Class: ..." to make it executable -->
-                            <mainClass>com.ignfab.minalac.generator.MinalacGenerator</mainClass>
+                            <mainClass>com.ignfab.minalac.generator.Voxatile</mainClass>
                         </transformer>
                         <!-- Properly shades all resources, required for GeoTools HSQL embedded databases and GeoTIFF module -->
                         <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />

--- a/src/main/java/com/ignfab/minalac/generator/Voxatile.java
+++ b/src/main/java/com/ignfab/minalac/generator/Voxatile.java
@@ -60,10 +60,10 @@ import com.ignfab.minalac.generator.utils.world3d.WorldBBox3d;
 import com.ignfab.minalac.generator.world.MapWriteException;
 
 /**
- * Main class of Minalac project.
+ * Main class of Voxatile project.
  */
-public final class MinalacGenerator {
-    private MinalacGenerator() {
+public final class Voxatile {
+    private Voxatile() {
         throw new UnsupportedOperationException();
     }
 
@@ -81,7 +81,7 @@ public final class MinalacGenerator {
         // Deserialization duration start
         Instant initializationStart = Instant.now();
         // Command line arguments parsing & basic processing
-        MinalacGeneratorCLI cli = new MinalacGeneratorCLI();
+        VoxatileCLI cli = new VoxatileCLI();
         cli.parse(args);
 
         File destination;

--- a/src/main/java/com/ignfab/minalac/generator/VoxatileCLI.java
+++ b/src/main/java/com/ignfab/minalac/generator/VoxatileCLI.java
@@ -18,13 +18,13 @@ import com.ignfab.minalac.generator.utils.FileHelpers;
 
 /**
  * A command line parser and basic processor.
- * MinalacGeneratorCLI performs parsing, basic validation and some basic tasks such as retrieving generation parameters.
+ * {@code VoxatileCLI} performs parsing, basic validation and some basic tasks such as retrieving generation parameters.
  */
-public class MinalacGeneratorCLI {
+public class VoxatileCLI {
 
-    private static final String PARAMS_ENVVAR_NAME = "MINALAC_PARAMS";
-    private static final String MAX_TILE_SIZE_ENVVAR_NAME = "MINALAC_MAX_TILE_SIZE";
-    private static final String MODULES_PATH_ENVVAR_NAME = "MINALAC_MODULES_PATH";
+    private static final String PARAMS_ENVVAR_NAME = "VOXATILE_PARAMS";
+    private static final String MAX_TILE_SIZE_ENVVAR_NAME = "VOXATILE_MAX_TILE_SIZE";
+    private static final String MODULES_PATH_ENVVAR_NAME = "VOXATILE_MODULES_PATH";
 
     private Path outputPath;
     private Path parametersPath;
@@ -40,7 +40,7 @@ public class MinalacGeneratorCLI {
     /**
      * Creates a new GeneratorCommandLine.
      */
-    public MinalacGeneratorCLI() {
+    public VoxatileCLI() {
         options = new Options();
         options.addOption(new Option("h", "help", false, "Display command usage"));
         options.addOption(new Option("p", "param-file", true, "Get generation params from file"));

--- a/src/main/java/com/ignfab/minalac/generator/parameters/JsonDelegateDeserialize.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/JsonDelegateDeserialize.java
@@ -44,7 +44,7 @@ public @interface JsonDelegateDeserialize {
 
     /**
      * Jackson handler to wrap deserializer of annotated beans with the requested one.
-     * This is bundled by default with the {@link com.ignfab.minalac.generator.parameters.ParamsParser.MinalacParserModule}.
+     * This is bundled by default with the {@link com.ignfab.minalac.generator.parameters.ParamsParser.VoxatileParserModule}.
      */
     class BeanModifier extends ValueDeserializerModifier {
         @Override

--- a/src/main/java/com/ignfab/minalac/generator/parameters/JsonWrapper.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/JsonWrapper.java
@@ -42,7 +42,7 @@ import tools.jackson.databind.util.AccessPattern;
 public @interface JsonWrapper {
     /**
      * Jackson handler to set deserializer of annotated beans with the appropriate one.
-     * This is bundled by default with the {@link com.ignfab.minalac.generator.parameters.ParamsParser.MinalacParserModule}.
+     * This is bundled by default with the {@link com.ignfab.minalac.generator.parameters.ParamsParser.VoxatileParserModule}.
      */
     class BeanModifier extends ValueDeserializerModifier {
         @Override

--- a/src/main/java/com/ignfab/minalac/generator/parameters/ParamsParser.java
+++ b/src/main/java/com/ignfab/minalac/generator/parameters/ParamsParser.java
@@ -40,8 +40,8 @@ public class ParamsParser {
         GenerationParams params;
 
         // Custom deserializers
-        MinalacParserModule module = new MinalacParserModule();
-        // TODO OutputFormat handling might be relocated to the MinalacParserModule (not sure)
+        VoxatileParserModule module = new VoxatileParserModule();
+        // TODO OutputFormat handling might be relocated to the VoxatileParserModule (not sure)
         module.addDeserializer(OutputFormat.class, formatDeserializer);
         mapperBuilder.addModule(module);
 
@@ -104,12 +104,12 @@ public class ParamsParser {
     /**
      * Jackson module used by this parser.
      */
-    public static class MinalacParserModule extends SimpleModule {
+    public static class VoxatileParserModule extends SimpleModule {
         /**
          * Creates a new instante of this module.
          */
-        public MinalacParserModule() {
-            super("MinalacParserModule");
+        public VoxatileParserModule() {
+            super("VoxatileParserModule");
         }
 
         @Override

--- a/src/test/java/com/ignfab/minalac/generator/parameters/ParamsTester.java
+++ b/src/test/java/com/ignfab/minalac/generator/parameters/ParamsTester.java
@@ -42,7 +42,7 @@ public final class ParamsTester {
         builder.configure(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES, true);
         builder.enable(StreamReadFeature.STRICT_DUPLICATE_DETECTION);
 
-        builder.addModule(new ParamsParser.MinalacParserModule());
+        builder.addModule(new ParamsParser.VoxatileParserModule());
 
         format.registerPlaceableDeserializer(builder);
 


### PR DESCRIPTION
### Issue
Partially solves #204

### Changes

Renaming:
- Class `MinalacGenerator` -> `Voxatile`
- Class `MinalacGeneratorCLI` -> `VoxatileCLI`
- Class `MinalacParserModule` -> `VoxatileParserModule`
- Environment variables `MINALAC_*` -> `VOXATILE_*`
- Update documentation accordingly
- Update `generate.sh` accordingly
- Some sparse documentation updates

No behavior change except name changed.

### Reason

Project renaming from Minalac Generator to Voxatile.

### Self-checks
- ~~The code has unit tests associated~~
- ~~The code has Javadoc Comments associated~~
- ~~Complex / Unexpected code is explained / justified with a small comment~~
- [x] Relevant documentation inside the `/docs` folder has been updated
- [x] All examples in `examples/` work the same (or have been adapted if subject to changes in this PR)
- [x] Git history is clean (each commit accomplish a single task and describe it accordingly)
- ~~The texts have been proofread (documentation, error messages, logs, comments...)~~
